### PR TITLE
issue 168 second correction on language tags

### DIFF
--- a/data/tlg0555/tlg001/tlg0555.tlg001.opp-grc1.xml
+++ b/data/tlg0555/tlg001/tlg0555.tlg001.opp-grc1.xml
@@ -34,7 +34,7 @@
     <profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc>
   </teiHeader>

--- a/data/tlg0555/tlg002/tlg0555.tlg002.opp-grc1.xml
+++ b/data/tlg0555/tlg002/tlg0555.tlg002.opp-grc1.xml
@@ -35,7 +35,7 @@
     <profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc>
   </teiHeader>

--- a/data/tlg0555/tlg004b/tlg0555.tlg004b.opp-grc1.xml
+++ b/data/tlg0555/tlg004b/tlg0555.tlg004b.opp-grc1.xml
@@ -28,7 +28,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg0555/tlg005/tlg0555.tlg005.opp-grc1.xml
+++ b/data/tlg0555/tlg005/tlg0555.tlg005.opp-grc1.xml
@@ -34,7 +34,7 @@
     <profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc>
   </teiHeader>

--- a/data/tlg0555/tlg006/tlg0555.tlg006.opp-grc1.xml
+++ b/data/tlg0555/tlg006/tlg0555.tlg006.opp-grc1.xml
@@ -31,7 +31,7 @@
     <profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc>
   </teiHeader>

--- a/data/tlg0555/tlg007/tlg0555.tlg007.opp-grc1.xml
+++ b/data/tlg0555/tlg007/tlg0555.tlg007.opp-grc1.xml
@@ -34,7 +34,7 @@
     <profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc>
   </teiHeader>

--- a/data/tlg0610/tlg001/tlg0610.tlg001.opp-grc1.xml
+++ b/data/tlg0610/tlg001/tlg0610.tlg001.opp-grc1.xml
@@ -34,7 +34,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg0645/tlg001/tlg0645.tlg001.perseus-grc2.xml
+++ b/data/tlg0645/tlg001/tlg0645.tlg001.perseus-grc2.xml
@@ -34,7 +34,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg0645/tlg002/tlg0645.tlg002.perseus-grc2.xml
+++ b/data/tlg0645/tlg002/tlg0645.tlg002.perseus-grc2.xml
@@ -34,7 +34,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg0645/tlg003/tlg0645.tlg003.perseus-grc2.xml
+++ b/data/tlg0645/tlg003/tlg0645.tlg003.perseus-grc2.xml
@@ -30,7 +30,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg1205/tlg001/tlg1205.tlg001.perseus-grc1.xml
+++ b/data/tlg1205/tlg001/tlg1205.tlg001.perseus-grc1.xml
@@ -34,7 +34,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg1205/tlg001/tlg1205.tlg001.perseus-grc2.xml
+++ b/data/tlg1205/tlg001/tlg1205.tlg001.perseus-grc2.xml
@@ -34,7 +34,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg1205/tlg002/tlg1205.tlg002.perseus-grc1.xml
+++ b/data/tlg1205/tlg002/tlg1205.tlg002.perseus-grc1.xml
@@ -34,7 +34,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg1205/tlg002/tlg1205.tlg002.perseus-grc2.xml
+++ b/data/tlg1205/tlg002/tlg1205.tlg002.perseus-grc2.xml
@@ -30,7 +30,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg1725/tlg001/tlg1725.tlg001.perseus-grc1.xml
+++ b/data/tlg1725/tlg001/tlg1725.tlg001.perseus-grc1.xml
@@ -30,7 +30,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg1725/tlg001/tlg1725.tlg001.perseus-grc2.xml
+++ b/data/tlg1725/tlg001/tlg1725.tlg001.perseus-grc2.xml
@@ -30,7 +30,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg1766/tlg001/tlg1766.tlg001.perseus-grc1.xml
+++ b/data/tlg1766/tlg001/tlg1766.tlg001.perseus-grc1.xml
@@ -30,7 +30,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg2042/tlg001/tlg2042.tlg001.perseus-grc1.xml
+++ b/data/tlg2042/tlg001/tlg2042.tlg001.perseus-grc1.xml
@@ -30,7 +30,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg2042/tlg007/tlg2042.tlg007.perseus-grc1.xml
+++ b/data/tlg2042/tlg007/tlg2042.tlg007.perseus-grc1.xml
@@ -30,7 +30,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg2042/tlg008/tlg2042.tlg008.perseus-grc1.xml
+++ b/data/tlg2042/tlg008/tlg2042.tlg008.perseus-grc1.xml
@@ -41,7 +41,7 @@
     <profileDesc>
       <langUsage>
         <language ident="la">Latin</language>
-        <language ident="greek">Greek</language>
+        <language ident="grc">Greek</language>
       </langUsage>
     </profileDesc>
     <revisionDesc>

--- a/data/tlg2115/tlg060/tlg2115.tlg060.perseus-grc1.xml
+++ b/data/tlg2115/tlg060/tlg2115.tlg060.perseus-grc1.xml
@@ -30,7 +30,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg2255/perseus002/tlg2255.perseus002.perseus-grc1.xml
+++ b/data/tlg2255/perseus002/tlg2255.perseus002.perseus-grc1.xml
@@ -30,7 +30,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 

--- a/data/tlg2313/perseus002/tlg2313.perseus002.perseus-grc1.xml
+++ b/data/tlg2313/perseus002/tlg2313.perseus002.perseus-grc1.xml
@@ -30,7 +30,7 @@
     </encodingDesc><profileDesc>
       <langUsage>
 	<language ident="la">Latin</language>
-	<language ident="greek">Greek</language>
+	<language ident="grc">Greek</language>
       </langUsage>
     </profileDesc></teiHeader>
 


### PR DESCRIPTION
corrected
`<language ident="greek">Greek</language>`
into correct Epidoc
`<language ident="grc">Greek</language>`