### PR TITLE
Issue #266, removing extra cRefPattern in March/Owen editions of tlg1205

### DIFF
--- a/data/tlg1205/tlg001/tlg1205.tlg001.perseus-grc2.xml
+++ b/data/tlg1205/tlg001/tlg1205.tlg001.perseus-grc2.xml
@@ -36,6 +36,7 @@
     </profileDesc>
   <revisionDesc>
     <change who="Jack Duff" when="2016-06-13">Revised reference structure to include both levels, deleted milestones, moved paragraphs inside sections.</change>
+    <change who="Jack Duff" when="2016-06-16">Removed second level of reference to match Otto edition's structure.</change>
   </revisionDesc>
   </teiHeader>
 

--- a/data/tlg1205/tlg001/tlg1205.tlg001.perseus-grc2.xml
+++ b/data/tlg1205/tlg001/tlg1205.tlg001.perseus-grc2.xml
@@ -26,7 +26,6 @@
         </sourceDesc>
     </fileDesc><encodingDesc>
 <refsDecl n="CTS">
-        <cRefPattern n="section" matchPattern="(.+).(.+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']/tei:div[@n='$2'])"/>
         <cRefPattern n="chapter" matchPattern="(.+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"/>
       </refsDecl>
 

--- a/data/tlg1205/tlg002/tlg1205.tlg002.perseus-grc2.xml
+++ b/data/tlg1205/tlg002/tlg1205.tlg002.perseus-grc2.xml
@@ -33,6 +33,7 @@
     </profileDesc>
   <revisionDesc>
     <change who="Jack Duff" when="2016-06-13">Restructured to two ref levels, put p inside sections, removed milestones, replaced pb xml:id with n.</change>
+    <change who="Jack Duff" when="2016-06-16">Removed second level of reference to match Otto edition's structure.</change>
   </revisionDesc>
 </teiHeader>
 

--- a/data/tlg1205/tlg002/tlg1205.tlg002.perseus-grc2.xml
+++ b/data/tlg1205/tlg002/tlg1205.tlg002.perseus-grc2.xml
@@ -23,7 +23,6 @@
         </sourceDesc>
     </fileDesc><encodingDesc>
 <refsDecl n="CTS">
-  <cRefPattern n="section" matchPattern="(.+).(.+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']/tei:div[@n='$2'])"/>
   <cRefPattern n="chapter" matchPattern="(.+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"/>
       </refsDecl>
 


### PR DESCRIPTION
The second pattern was deemed superfluous, and with only one level of structure (chapters) this edition of these two texts now better matches the Otto editions of same. See also Issue #121.