### PR TITLE
Corrected OCR in Homilia 1 of 016.

### DIFF
--- a/data/tlg2042/tlg016/tlg2042.tlg016.opp-grc1.xml
+++ b/data/tlg2042/tlg016/tlg2042.tlg016.opp-grc1.xml
@@ -176,7 +176,7 @@ optime Theophile&lt;</head>
 <lb n="5"/>
 <p>Sicut olim in populo Judaeorum
 multi prophetiam  <milestone unit="altpage" n="86"/>  pollicebantur,
-<lb n="10"/> cebantur, et quidam erant pseudoprophetae
+<lb n="10"/>et quidam erant pseudoprophetae
 — e quibus unus fuit
 Ananias, filius Azor —, alii vero
 prophetae, et erat gratia in populo
@@ -191,8 +191,8 @@ instrumento &gt;multi conati sunt&lt;
 ἄνθρωπον ὄντα θεοῦ διδακαλίαν
 καὶ ῥήματα συγγράφειν, εἰκότως
 ἀπολογεῖται ἐν τῷ προοιμίῳ.</p>
-<p>Ὢσπερ δὲ ἐν τῷ πάλαι λαῷ πολ-
-λοὶ προφητείαν ἐπηγγέλλοντο, ἀλλὰ
+<p>Ὢσπερ δὲ ἐν τῷ πάλαι λαῷ πολλοὶ 
+προφητείαν ἐπηγγέλλοντο, ἀλλὰ
 τούτων τινὲς μέν ἦσαν
 φεδοπροφῆται,</p>
 <p>τινὲς δὲ ἀληθῶς προφῆται, καὶ
@@ -322,7 +322,7 @@ narrationem de his rebus, quae</p>
 θεοῦ ἐκκλησία.</p>
 <p>| Λόγος ἐστὶ παραγραπτέος Ἰωάννην
 ἔτι περιόντα βίῳ ἐπὶ Νέρωνος
-τὰ συγγεγραμμένα εὐαγγέλια συνα-</p>
+τὰ συγγεγραμμένα εὐαγγέλια συναγαγεῖν·</p>
 <note type="footnote">zu 5,21—6,5 vgl. Euseb. Hist. eccl. III 24. 7 (S. 246, 13ff. E. Sehwaitz)</note>
 <note type="footnote">1 haereses De plurimas mr e &gt;E 1/2 quoddam] unum A
 3 iuxta] secundum B 5 ~evang. scribere CK 7 sed + et multi conati 
@@ -373,7 +373,7 @@ non corruet, quia &gt;super
 fundatum est. Nec putemus oculis
 istis carnalibus firmitatem
 fidei dari, quam mens et ratio</p>
-<p>γαγεῖν· καὶ τὰ μὲν μὲν ἐγκρῖναι καὶ ἀποδέξασθαι,
+<p>καὶ τὰ μὲν ἐγκρῖναι καὶ ἀποδέξασθαι,
 ὧν οὐδὲν ἡ τοῦ διαβόλου
 ἐπιβουλὴ καθήψατο, τὰ δὲ ἀπολέξασθαι
 καὶ καταργῆσαι, ὅσα μὴ τῆς
@@ -426,7 +426,7 @@ quid verum quidve falsum sit.</p>
 <p>&gt;Sicut tradiderunt nobis, qui
 ab initio ipsi viderunt et ministri
 fuerunt sermonis&lt; In
-<lb n="10"/> scriptum est populus videbat
+<lb n="10"/>Exodo scriptum est populus videbat
 vocem Dei&lt; . Et certe vox auditur
 potius quam videtur, sed
 propterea ita scriptum est, ut
@@ -485,7 +485,7 @@ m + ὁ am, + κύριος Ἰησ.] κατὰ Ε 3 9 ~ αὐτοῦ ἔνσα�
 viderunt et iniuistri fuerunt sermonis&lt; .
 Igitur apostoli ipsi viderunt
 sermonem, non quia adspexerant
-eorpus Domini Salvatoris,
+corpus Domini Salvatoris,
 <lb n="5"/> sed quia Verbum viderant.
 Si enim juxta corpus vidisse Jesum
 hoc est: Dei vidisse sermonem,
@@ -515,9 +515,9 @@ doctrinae finis sit ipsa doctrina,</p>
 Εἰ γὰρ τὸ ἑωρακέναι τὸν Ἰησοῦν κατὰ
 σῶμα &gt;αὐτόπτην τοῦ λόγου&lt; γίνεσθαι
 ἦν, καὶ Πιλᾶτος &gt;αὐτόπτης&lt; ἦν
-&gt;τοῦ λόγου&lt; καταδικάξων αὐτὸν γαὶ
+&gt;τοῦ λόγου&lt; καταδικάξων αὐτὸν καὶ
 Ἰούδας ὁ προδότης καὶ πάντες οἱ
-λέγοντες· &gt;σταύρου, σταύρου αύτόν&lt;.
+λέγοντες· &gt;σταύρου, σταύρου αὐτόν&lt;.
 Ἀλλ' ἀπείη λέγειν, ὄτι ἐκεῖνοι
 ἦσαν &gt;αὐτόπται τοῦ λόγου&lt; Τὸ
 οὖν ἰδεῖν τὸν λόγον ἐκεῖ ἐννοεῖται,

--- a/data/tlg2042/tlg016/tlg2042.tlg016.opp-grc1.xml
+++ b/data/tlg2042/tlg016/tlg2042.tlg016.opp-grc1.xml
@@ -2015,7 +2015,7 @@ K 7 cessabit C ~ Christus esse De 8 Rehnquit C sermo
 est AC, scribitur D (spater eingef.) 9 sicut] secuti AK + simt K
 ut] sicut De custodia Ce, cistodiarum c D, custodiarum ABEK
 10 expugnantvir B 11 concit.] continentur C 12 archanima
-ACDK 13 saliite nostra De nostra2 A nostri causa] in pena
+ACDK 13 salute nostra De nostra2 A nostri causa] in pena
 nostra C 14 et1] ut C maiore B qvios] nos BE simus +
 cumB K 15 sunt] sint et] si A dignum adoptione] ad
 optime dignum B, dign. ad optionem K clementiae K 16 qui]
@@ -3185,7 +3185,7 @@ suscipitis. Obsecro vos, Ο
 <lb n="20"/> catechumeni : nohte retractare,
 nemo vestrum formidet et paveat,
 sed sequimini praeeuntem
-Jesum. Ille vos traliit ad salutem,
+Jesum. Ille vos trahit ad salutem,
 tem, congregat in ecclesiam nunc
 <lb n="25"/> quidem super terram, si autem</p>
 <p>τούτου ὁ κατ' αὐτὴν μείζων πιστευθῇ
@@ -3214,7 +3214,7 @@ tem, congregat in ecclesiam nunc
 <note type="footnote">1/2 referuntur De fi ο &gt; ABE 7 cathecumini ABDE,
 C ecclesia CDe 9 himc] hoc E 10 enim &gt;
 domos A 11 sigillatim AB, singulatim C circuivimus Clmn
-15 retractores A 17 vehit BE 19 Ο &gt; ABE 23 traliit &gt;
+15 retractores A 17 vehit BE 19 Ο &gt; ABE 23 trahit &gt;
 23/24 sakitem + qui A 24 congregati E</note>
 <note type="footnote">50, 3 καλῶς — 7 καρποί + 53, –25 Y</note>
 <note type="footnote">1/2 ὁ . . μείζων . . . τοκετός] τὸ μεῖζον dCS κατ' αὐτὴν &gt; λ
@@ -4105,7 +4105,7 @@ populo suo, et suscitavit cornu
 <lb n="15"/> salutis nobis in domo David&lt;
 &gt;de semine David secundum
 natus est Christus.</p>
-<p>Et vere fuit cornu saliitis in
+<p>Et vere fuit cornu salutis in
 domo , quia prophetia ista
 <lb n="20"/> concinitur : &gt; Vinea enim facta</p>
 <p>καἰ προφητευσαι τα ἀναγεγραμμένας.
@@ -8260,7 +8260,7 @@ regionem circa Jordanem A 9 circumire E 10 vicinia e Jordanis
 CDe 12 essent AD lavacr. aquae] lavandum aqua AB 15 largo]
 arguto B 16 Domin. &gt; C est et Dominus B noster + et E
 17 quem] quo ADE 17/18 aquam veram, aquam salutarem C, quam veram
-aquam saliitarem De, aqua veram aquam salvatorem E vera — salutari
+aquam salutarem De, aqua veram aquam salvatorem E vera — salutari
 &gt; B 18 remissione A 19 peccat. + in De baptisma &gt;
 20 praedicat e Venite C cathecumini BA, catecumini CD
 21 ut] et E 21/22 u. 23 remissione C 24 accepit B</note>
@@ -12293,7 +12293,7 @@ te judici ab adversario praeparatum,
 postea frustra conaberis.
 &gt;Da &gt;ergo &lt;operam, ergo libereris &lt; ut
 <lb n="10"/> adversario tuo sive a principe, ad
-quem te traliit adversarius. &gt;Da
+quem te trahit adversarius. &gt;Da
 operam &lt;, ut habeas
 justitiam, fortitudinem, temperantiam,
 et tunc complebitur:
@@ -12348,16 +12348,16 @@ Quomodo E 20/21 ad princ. &gt; A 22 quid] quod Imn 24 et1 &gt;
 13 δικαιοσ. — 14 σοφ] καὶ τὰς λοιπὰς ἀρετάς C ἀνδρίαν Κ1 σου &gt;</note>
 
 <pb n="v.9.p.212"/>
-<p>ut ab adversario &gt;libereris &lt;, quae te sequantur, ausculta. &gt;Traliit
+<p>ut ab adversario &gt;libereris &lt;, quae te sequantur, ausculta. &gt;Trahit
 ad judicem &lt; adversarius sive princeps, cum te susceperit ab
-&gt;traliit te ad
-Quam elegans sermo &gt;traliit &lt;,
+&gt;trahit te ad
+Quam elegans sermo &gt;trahit &lt;,
 <lb n="5"/> ostendat quodammodo retractantes
 et nolentes ad condemnationem
-tralii et ire compelli! Quis
+trahi et ire compelli! Quis
 enim homicida concito gradu pergit
 ad judicem ? Quis gaudens ad condemnationem suam ire festinat,
-<lb n="10"/> et non invitus traliitur ac repugnans ? Scit enim se ad hoc ire,
+<lb n="10"/> et non invitus trahitur ac repugnans ? Scit enim se ad hoc ire,
 ut sententiam mortis accipiat. &gt;Ne forte trahat te ad judicem &lt;.  <milestone unit="altpage" n="222"/> 
 Quis, putas, iste &gt;judex &lt; est ? Ego nescio aUum judicem nisi
 nostrum Jesum Christum, de quo et ahbi dicitur: &gt;statuet
@@ -12382,7 +12382,7 @@ plura persequi? Unusquisque pro quahtate et quantitate peccati
 <note type="footnote">13f. Matth. 25, 33 14ff. Matth. 10, 32. 33 22ff. vgl. Luk. 7, 41. 42
 25 Matth. 18, 24
 1 quae — sequantur] qviis sit iste et quantus ABE 2 advers. — 3 judicem &gt;
-4 sermo] verbum Ir traliit + inquit B 5 ostendit B pertractantes D
+4 sermo] verbum Ir trahit + inquit B 5 ostendit B pertractantes D
 6 contempnationem E 7 trahere E et &gt; ire &gt; 9 suam] sui Aln
 10 et] ut BE trahatur B ~ ad hoc se A ~ ire adhocBE 11 &gt; E
 excipiatAB tradat ACDE 12 &gt; ABE 13 nostrum] meum DEe
@@ -12418,7 +12418,7 @@ creditum sit et quid lucri quidve detrimenti fecerimus, quis nostrum
 acceperit mnam, quis unum talentum, quis duo, quis quinque.
 <lb n="20"/> Quid necesse est plura rephcare, cum hoc in commune dixisse sufficiat
 reddituros nos esse rationem et, si debitores inventi
-fuerimus, tralii ad judicem et a judice exactori tradi ? Singuh
+fuerimus, trahi ad judicem et a judice exactori tradi ? Singuh
 exactores proprios habemus, omnis vero multitudo pluribus traditur,
 secundum id, quod in Isaia scriptum est: &gt;populus
 <lb n="25"/> meus, exactores vestri spohant vos et, qui potentes sunt, dominantur
@@ -12439,7 +12439,7 @@ C 11 condemn.] damnatur De, contempnatur AB 12 mna] mina BE
 reddere C Supp.] Sed putanda C Supp. — 16 est2 &gt; E, — 16 rationis
 B 16 ~ nobis omnibus A ratio] gratia De 18 ~ sit cred. C
 sit] est De quis] qui e 19 minam BE 20 Quid &gt; De] Nec
-Necesse + non De repHcare] indicare De 21 nos] non r 22 tralii]
+Necesse + non De repHcare] indicare De 21 nos] non r 22 trahi]
 tradi BDE 23 exauctores A propr.] singulos C 24 id &gt; C 25 exauctores
 A (23 u. 26 ist exauct. corr. A!) vos] nos B 26 vestri] nostri B
 27 dixer.] vixerimus De Servavi] servabo De

--- a/data/tlg2042/tlg016/tlg2042.tlg016.opp-grc1.xml
+++ b/data/tlg2042/tlg016/tlg2042.tlg016.opp-grc1.xml
@@ -95,7 +95,7 @@ petistis, ut contemptis istiusmodi nugis saltem triginta et novem
 Adamantii nostri in Lucam omelias, sicut in graeco
 interpreter — molestam rem et tormento similem alieno, ut ait
 <lb n="10"/> TulUus, stomacho et non suo scribere; quam tamen idcirco nunc
-faciam, quia subhmiora non poscitis. Siquidem ilhid quod ohm
+faciam, quia subhmiora non poscitis. Siquidem illud quod ohm
 Romae sancta Blaesilla efflagitaverat, ut viginti sex tomos ilhus in
 Matthaeum et quinque ahos in Lucam et triginta duos in Johannem
 nostrae hnguae traderem, nec virium mearum nec otii nec laboris
@@ -565,7 +565,7 @@ etiam in notitia ministerioque sermonis est. Unde scribitur:
 <lb n="15"/> fuerunt sermonis&gt;, ut ex eo, quod
 dixit: &lt;ipsi viderunt&gt;, doctrinam
 et scientiam significari, ex eo
-vero, quod ait: &gt; fuerunt
+vero, quod ait: &gt;ministri fuerunt
 sermonis&lt;, demonstrari opera
 <lb n="20"/> cognoscamus.
 &lt;Visum est et mihi subsecuto
@@ -1152,7 +1152,7 @@ sorde respergimur, ut placeamus
 non placet Deo, boni
 operis causa praecedit, quamvis
 faciamus praeceptum Dei, tamen
-<lb n="15"/> et injuste id, quocl justum est,
+<lb n="15"/> et injuste id, quod justum est,
 sequimur. Difficile ergo est, am-
 bulare x &gt;in omnibus mandatis et
 justificationibus Domini sine
@@ -1209,16 +1209,16 @@ est gloria et imperium in saecula saeculorum. Amen.</p>
 </div>
 <div type="textpart" subtype="homilia" n="3">
 <lb n="5"/><p>HOMILIA III.</p>
-<p> <milestone unit="altpage" n="95"/>  De eo, quod scriptum est: x &gt;apparuit ei angelus Domini, stans
-a dextris altaris x &lt;</p>
+<p> <milestone unit="altpage" n="95"/>  De eo, quod scriptum est: &gt;apparuit ei angelus Domini, stans
+a dextris altaris incensi&lt;</p>
 <p>Quae corporalia sunt et sensu
 carent, ut videantur ab alio, ipsa
-lu nLhil efficiunt, sed tantummodo
+lu nihil efficiunt, sed tantummodo
 oculus alterius intentus in ea,
 sive vohierint illa sive noluerint,
-videt, quo aciem contemplatio-
-nemque direxit. Quid enim potest
-<lb n="15"/> est homo aut aUa res, quae
+videt, quo aciem contemplationemque 
+direxit. Quid enim potest
+<lb n="15"/> est homo aut alia res, quae
 crasso circumdatur corpore, cum
 in praesenti fuerit, facere, ne cernatur?
 E contrario ea, quae superna
@@ -1236,7 +1236,7 @@ Abrahae vel ceteris prophetis,
 Οὑ τοιαῦτα δὲ τὰ θεῖα, οὐδ’ ἐν
 τῷ παρόντι, ὁρώμενα χωρὶς τῆς ἐαυτῶν
 ἐνεργείας.
-Καὶ γοῦν χάριτι θεὸς x &gt;
+Καὶ γοῦν χάριτι θεὸς &gt;ὢφθη&lt; τῷ
 Ἀβραὰμ ἤ τινι τῶν ἁγίων, οὐ τοῦ
 ὀφθαλμοῦ τῆς ψυχῆς τοῦ Ἀβραὰμ
 <note type="footnote">2f. Röm.
@@ -1255,7 +1255,7 @@ CDe 19 etiam] ea De 20 in x &gt; B 23 gratiae AC (richtig ?)
 20, 8 –21, 25 δεῖνι ξ</note>
 
 <pb n="v.9.p.21"/>
-Abraliam in causa fuerit, ut cerneret
+Abraham in causa fuerit, ut cerneret
 Deum, sed quod gratia Dei
 ultro se adspiciendam praebuerit
 viro justo. Hoc autem non solum
@@ -1273,15 +1273,15 @@ sive animae nostrae se ad contemplandum
 apparuerit angelus et se videndum
 praebuerit, ille, qui videre
 desiderat, non videbit. Itaque
-ubicunque scriptum f uerit : x &gt;apparuit
-<lb n="20"/> x &lt; ilh vel illi, et ut nunc :
-x &gt;apparuit ei angelus Domini,
-stans a dextris altaris x &lt; ita
+ubicunque scriptum fuerit: &gt;apparuit
+<lb n="20"/> Deus&lt; illi vel illi, et ut nunc:
+&gt;apparuit ei angelus Domini,
+stans a dextris altaris incensi&lt; ita
 ut dixi intellege. Sive Deus sive
 angelus Abrahae vel Zachariae,
 <lb n="25"/> cum noluerit vel voluerit, aut non
 videbitur aut videbitur. Et hoc
-non tantum in x &lt;praesenti x &gt;
+non tantum in &gt;praesenti saeculo&lt;
 dicimus, sed etiam in  <milestone unit="altpage" n="96"/>  futuro,
 cum migraverimus e mundo, quod
 <lb n="30"/> non omnibus vel Deus vel angeli</p>
@@ -1289,18 +1289,18 @@ cum migraverimus e mundo, quod
 αὐτῷ τὸν θεόν, ἀλλὰ τοῦ θεοῦ
 παρασχόντος ἑαυτὸν εἰς ἐμφανιςτὸν
 τῷ δικαίῳ, ἀξίῳ γενομένῳ τῆς
-ὀπτασίας
+ὀπτασίας αὐτοῦ.
 Ἀλλὰ γὰρ καὶ ἄγγελος, ὅσον οὐ
 βούλεται βλέπεσθαί τινι ἡμῶν, παρὼν
 οὐ βλέπεται.
 Καὶ μὴ θαυμάσῃς ἐπὶ τοῦ παρόντος,
-εἰ ὁ θεὸς θέλων x &lt; τῷ
-Ἀβραάμ, μὴ θέλων δὲ οὐκ x &lt;
-τῷ δεῖνι, καὶ &gt;ἄγγελος x &lt; τῷ
+εἰ ὁ θεὸς θέλων &gt;ὤφθη&lt; τῷ
+Ἀβραάμ, μὴ θέλων δὲ οὐκ &gt;ὤφθη&lt;
+τῷ δεῖνι, καὶ &gt;ἄγγελος ὤφθη&lt; τῷ
 Ζαχαρίᾳ, καὶ μὴ θέλων οὐκ ἂν
-x &lt; αὐτῷ.</p>
-<p>Ἀλλὰ καὶ μετὰ τὸν x &lt;
-x &lt; ἐὰν ἐξέλθωμεν, ἴσθι, ὅτι οὐ
+&gt;ὤφθη&lt; αὐτῷ.</p>
+<p>Ἀλλὰ καὶ μετὰ τὸν &gt;ἐνεστῶτα&lt;
+&gt;αἰῶνα&lt;, ἐὰν ἐξέλθωμεν, ἴσθι, ὅτι οὐ
 παντὶ φαίνεται ὁ θεὸς ἢ οἱ ἄγγελοι,
 <note type="footnote">27 lat., 28 f. gr. Gal. I, 4</note>
 <note type="footnote">1 causam CD fuit B 2 quo EK 3/4 viro sancto praebiierit B
@@ -1318,43 +1318,43 @@ nol. e 26 ~ vid. aut non vid. CK 29 e mundo x &gt;BE
 
 <pb n="v.9.p.22"/>
 appareant, quo scilicet et angelos
-et Spiritum sanctum et Domi-
-niinum Salvatorem et ipsum
-Deum Patrem is, qui cle corpore
+et Spiritum sanctum et Dominimum
+Salvatorem et ipsum
+Deum Patrem is, qui de corpore
 <lb n="5"/>exierit, statim mereatur videre;
-sed ille tantum videbit, qui mun-
-dum liabuerit cor et talem se
-praebuerit, ut Dei sit dignus ad-
-spectu. Et quamvis in eodeni
+sed ille tantum videbit, qui mundum 
+habuerit cor et talem se
+praebuerit, ut Dei sit dignus adspectu.
+Et quamvis in eodem
 <lb n="10"/>loco sint, qui mundo corde est,
 et is, qui adhuc aliqua sorde
-respergitur, unus locus nec no-
-cere quem poterit nec juvare,
+respergitur, unus locus nec nocere
+quem poterit nec juvare,
 quia, qui mundum cor habuerit,
 <lb n="15"/>Deum videbit, qui autem non
-taUs fuerit, id quod alii cernitur
-non videbit. Tale quid mihi in-
-tehegendum et de Christo, quando
-m corpore videbatur, quod non,
-<lb n="20"/>quicunque eum videbant, pote-
-rant videre. Videbant quippe
+talis fuerit, id quod alii cernitur
+non videbit. Tale quid mihi intellegendum 
+et de Christo, quando
+in corpore videbatur, quod non,
+<lb n="20"/>quicunque eum videbant, poterant
+videre. Videbant quippe
 tantum corpus illius, secundum
-vero quocl Christus erat, eum
-videre non poterant. Porro dis-
-<lb n="25"/>cipuh eum videbant et magnitu-
-dinem divinitatis iUius contem-</p>
+vero quod Christus erat, eum
+videre non poterant. Porro discipuli
+<lb n="25"/>eum videbant et magnitudinem
+divinitatis illius contem-</p>
 <p>ἀλλὰ ἔκαστος τῶν βλεπόντων τῷ
 καθαρὰν ἔχειν καρδίαν καὶ παρεσκευάσθαι
 πρὸς τὸ βλέπειν τὸν θεὸν
-ὅψεται τὸν θεόν. καὶ ἐν τῷ αὐτῷ
-τόπῳ δύο, ὁ μὲν καθαρὰν ἔχων καρ-
-δίαν, ὁ δὲ ἐβελυγμένην.</p>
-<p>ὁ μεν οψεται, επει ουκ εν τοπῳ
+ὅψεται τὸν θεόν. Kαὶ ἐν τῷ αὐτῷ
+τόπῳ δύο, ὁ μὲν καθαρὰν ἔχων καρδίαν,
+ὁ δὲ ἐβδελυγμένην·</p>
+<p>ὁ μὲν ὄψεται, ἐπεὶ οὐκ ἐν τόπῳ
 βλέπεται ὁ θεός, ἀλλὰ καθαρᾷ καρδίᾳ,
 ὁ δὲ οὐκ ὄψεται αὐτόν. Οὕτω
 νοητέον καὶ ἐπὶ τοῦ Χριστοῦ.</p>
-<p>Μὴ γὰρ οἴου, ὅτι πάντες οἱ βλέ-
-ποντες χριστὸν ἔβλεπον.</p>
+<p>Μὴ γὰρ οἴου, ὅτι πάντες οἱ βλέποντες 
+χριστὸν ἔβλεπον.</p>
 <p>Ἔβλεπον Χριστοῦ σῶμα, Χρι-
 στὸν δέ, καθ’ ὅ Χριστός ἐστιν, οὐκ
 ἔβλεπον. Ἐβλέπετο δὲ ὑπὸ μόνων
@@ -1384,31 +1384,31 @@ non &gt; r
 
 <pb n="v.9.p.23"/>
 <p>plabantur. Propter quod puto et ad Philippum, deprecantem atque
-dicentem: x &gt;ostende nobis Patrem, et sufficit x &gt; respondisse Salvatorem:
-x &gt;tanto tempore vobiscum sum, et non cognovistis me ?
-Philippe, qui videt me, videt et &lt; Neque enim Pilatus, qui
+dicentem: &gt;ostende nobis Patrem, et sufficit nobis&lt;, respondisse Salvatorem:
+&gt;tanto tempore vobiscum sum, et non cognovistis me?
+Philippe, qui videt me, videt et Patrem&lt;. Neque enim Pilatus, qui
 <lb n="5"/> videbat Jesum, intuebatur Patrem nec proditor Judas, quia
 nec ipse Pilatus nec Judas Christum, secundum hoc quod
 erat Christus, videbant, nec multitudo, quae coartabat eum. Illi
 tantum videbant Jesum, quos adspectu suo dignos arbitrabatur.
 Laboremus ergo et nos, ut et impraesentiarum nobis Deus appareat
 <lb n="10"/> — sanctus quippe scripturarum
-sermo promisit: x &gt;quoniam in-
-venietur ab his, qui non tentant
+sermo promisit: &gt;quoniam invenietur 
+ab his, qui non tentant
 eum, apparet autem his, qui non
-sunt increduh in x &lt; — et in
+sunt increduli in eum&lt; — et in
 <lb n="15"/> futuro saeculo non abscondatur a
-nobis, sed videamus eum x &gt;facie ad
-&lt; et habeamus fiduciam
- <milestone unit="altpage" n="97"/>  bonae vitae fruamurque
+nobis, sed videamus eum &gt;facie ad
+faciem&lt; et habeamus fiduciam
+<milestone unit="altpage" n="97"/>bonae vitae fruamurque
 conspectu omnipotentis Dei in
-<lb n="20"/> Christo Jesu et Spiritu sancto :
+<lb n="20"/> Christo Jesu et Spiritu sancto:
 cui est gloria et imperium in
 saecula saeculorum. Amen.</p>
 <p>Ἐπηγγείλατο δέ καὶ ἡ γραφή·
-ὅτι εὑρίσκεται τοῖς μὴ πειράξουσιν
+&gt;ὅτι εὑρίσκεται τοῖς μὴ πειράξουσιν
 αὐτόν, ἐμφανίξεται δέ τοῖς μὴ
-απιστουσιν x &lt;.</p>
+απιστουσιν αὐτῷ&lt;.</p>
 <note type="footnote">2ff. Joh. 14, 8. 9 4ff. vgl. Hom. I (p. 8, 6ff.)
 5,24,31 11 ff. Weish. Sal. 1, 2 16f. 1 Kor. 1312
 7 vgl. Mark.</note>
@@ -1803,8 +1803,7 @@ nur X 11 γὰρ &gt; UVY τὸν Ἡλίαν] αὐτὸν X 12 εἴτ' — 1
 προδρ. U</note>
 
 <pb n="v.9.p.30"/>
-<p>Origenes
-venit et &gt;praeparat Domino
+<p>venit et &gt;praeparat Domino
 perfectum &lt; et in
 asperitatibus planas facit vias et
 dirigit semitas. Non illo tantum
@@ -1836,22 +1835,22 @@ cui est gloria et irnperium in
 </div>
 
 <div type="textpart" subtype="homilia" n="5">
-<p>HOMILIA V.</p>
+<head>HOMILIA V.</head>
+<head>De eo, quod Zacharias obmutuit.</head>
 <p>Zacharias sacerdos, cum in
 templo offert incensum, silentio
-20 conclemnatur et reticet,
+<lb n="20"/>conclemnatur et reticet,
 immo tantum nutibus loquitur,
 et mutus usque ad ortum Joannis
 fihi perseverat. Quo haec tendit
-historia ? Silentium Zachariae</p>
-<p>De eo, quod Zacharias obmutuit.
-Καταδικάζεται σιωπᾶν Ζαχαρίας
+historia? Silentium Zachariae</p>
+<p>Καταδικάζεται σιωπᾶν Ζαχαρίας
 ὁ ἱερεύς, ὁ λειτουργὸς τοῦ θεοῦ ὁ τὰς
 θυσίας προσφέρων, καὶ σιωπᾷκαῖσιωπῶν
 μόνον διένευεν, καὶ διέμεινε κωφὸς
 μέχρι τῆς γεννήσεως Ἰωάννου.
-Τι οὖν ταῦτα; Ἡ τοῦ Ζαχαρίου
-σιωπὴ σιωπὴ &lt;σιωπὴ &gt;</p>
+Τί οὖν ταῦτα; Ἡ τοῦ Ζαχαρίου
+σιωπὴ &lt;σιωπὴ &gt; τῶν προφητῶν</p>
 <note type="footnote">If. lat. vgl. Luk. 1, 17 3f. lat. vgl. Luk. 3. 4 lOf. vgl. Joh. 1, 51
 17 Luk. 1, 20. 22 23ff. vgL Ambros. in Lucam I, 40 (35, loff. Schenkl)</note>
 <note type="footnote">I venit] ibit c B, &gt; De 1/2 pop. perf.] plebem perfectam
@@ -1874,23 +1873,23 @@ omeha K 17 Incipit quintade. . . .AC De — K
 <p>silentium  <milestone unit="altpage" n="101"/>  prophetarum est
 in populo Israhel. Nequaquam loquitur
 eis Deus, et &lt;sermo, qui
-principio erat apud Patrem Deus &lt;,
+principio erat apud Patrem Deus&lt;,
 <lb n="5"/> ad nos transiit, nobisque non
 tacet Christus, apud illos usque
-hodie silet : quamobrem et Zacharias
+hodie silet: quamobrem et Zacharias
 propheta tacuit. Manifestissime
 etenim ex sermonibus ipsius
 <lb n="10"/> comprobatur, quod et propheta
 fuerit et sacerdos. Quid sibi vult
 autem hoc, quod sequitur: &gt;annuebat
-eis &lt; et damnum
-nutibus compensabat ? Ego puto
-lo taha esse opera, quae absque sermone
+eis&lt; et damnum
+nutibus compensabat? Ego puto
+<lb n="15"/>talia esse opera, quae absque sermone
 atque ratione nihil nutibus
 differunt. Ubi vero ratio et sermo
 praecesserit et ita opus fuerit subsecutum,
 non debent existimari
-<lb n="20"/> simpHces nutus, qui ornantur
+<lb n="20"/> simplices nutus, qui ornantur
 sermone atque ratione. Si igitur
 videris conversationem Judaeorum
 sine ratione atque sermone,</p>
@@ -1898,18 +1897,18 @@ sine ratione atque sermone,</p>
 Οὐκέτι γὰρ θεὸς λαλεῖ αὐτοῖς,
 ἀλλὰ μεταβέβηκεν &lt;ὁ ἐν
 λόγος — ὁ λόγος, ὁ πρὸς τὸν θεόν,
-ὁ θεὸς — πρὸς ἡμᾶς καὶ
+ὁ θεὸς λόγος&lt; — πρὸς ἡμᾶς καὶ
 παρ’ ἡμῖν οὐ σιωπᾷ, παρ' ἐγείνοις
 δὲ σεσιώπηκεν. Διὰ τοῦτο σιωπᾷ
 ὁ προφήτης Ζαχαρίας· καὶ γὰρ προφήτης
 γεγονέναι λέγεται.</p>
-<p>Τί δέ· &gt;καὶ
-Τὸ &gt;διανεύειν &lt; διαμένοντα κωφὸν
+<p>Τί δέ· &gt;καὶ διένεθεν αὐτοις&lt;;
+Τὸ &gt;διανεύειν &lt; διαμένοντα κωφὸν τοιοῦτόν
 ἐστιν· αἱ χωρὶς λόγου πράξεις
 οὐδέν διαφέρουσι νεύσεων, αἱ δέ
 μετὰ λόγου πράξεις οὐκ εἰσὶ νεύσεις·
-κοσμοῦν·ται γὰρ ὑπὸ τοῦ λόγου.</p>
-<p>’Εὰν οὖν ἴδῃς Ἰουδαίων τὴν
+κοσμοῦνται γὰρ ὑπὸ τοῦ λόγου.</p>
+<p>Ἐὰν οὖν ἴδῃς Ἰουδαίων τὴν
 πολιτείαν ἄλογον, ὡς μὴ δύνασθαι
 αὐτοὺς διδόναι λόγον, περὶ ὧν πράτ</p>
 <note type="footnote">3ff. Joh. 1, 1</note>
@@ -1933,7 +1932,7 @@ UV] προφ. γὰρ Χ 11 Τί—αὐτοῖς &gt; λ 12 Τὸ + δὲ
 εἴδῃς Χ 22 ὡς — 23 αὐτοὺς] νῦν οὐκ ἔτι γὰρ δύνανται C</note>
 
 <pb n="v.9.p.32"/>
-<p>ita iit noii queant eorum, quae
+<p>ita ut non queant eorum, quae
 agunt, rationem reddere, intellege
 id, quod tunc in Zacharia processit,
 in imagine in illis hucusque
@@ -1941,19 +1940,19 @@ in imagine in illis hucusque
 nutibus similis est. Nisi enim
 circumcisionis ratio reddatur, nutus
 est circumcisio et opus mutum.
-Pascha et ahae sollemnitates
+Pascha et aliae sollemnitates
 <lb n="10"/> nutus magis sunt, quam veritas.
 Usque hodie populus Israhel
-surdus et &lt;mutus &gt; est ; neque
+surdus et &lt;mutus&gt; est ; neque
 poterat fieri, ut non surdus esset
-et &lt;mutus &gt; qui a se sermonem
-<lb n="15"/> jecerat. Et ohm quidem Moyses
-loquebatur: &gt;ego &lt;ego autem ἄλογος &gt; sum &lt; —
-expresserit, tamen proprie transferri potest: &gt;absque sermone
-ratione &lt; — , et postquam hoc ait, accepit rationem sive
+et &lt;mutus&gt; qui a se sermonem
+<lb n="15"/> abjecerat. Et olim quidem Moyses
+loquebatur: &gt;ego autem ἄλογος sum&lt; — quod licet aliter latinus
+expresserit, tamen proprie transferri potest: &gt;absque sermone sive
+ratione &lt; —, et postquam hoc ait, accepit rationem sive sermonum
 quem confessus fuerat se antea non habere. Populus autem Israhel
 <lb n="20"/> in Aegypto, priusquam legem acciperet, absque sermone atque ratione
- <milestone unit="altpage" n="102"/>  quodammodo &lt; erat ; deinde accepit sermonem, cujus
+ <milestone unit="altpage" n="102"/>  quodammodo &lt; erat; deinde accepit sermonem, cujus imago
 fuit Moyses. Iste igitur non confitetur modo, quod tunc confessus</p>
 <p>τουσι, βλέπε τὸν τύπον τὸν γεγενημένον
 ἐπὶ Ζαχαρίου διαμένοντος
@@ -1992,18 +1991,18 @@ tibi videtur confessio esse stulti
 ἀποδοῦναι νομικοῦ ἢ προφητικοῦ
 λόγου;
 tiae, quando nullus eorum potest
-<lb n="5"/> legahum praeceptoruni et propheticid
-vaticmii rationem reddere
-? Cessavit esse Christus in</p>
-<p>eis, rehquit eos sermo, completum est ihud, quod in Isaia scribitur:
-relinquetur fiha Sion sicut tabernaculum in vinea, et ut custodia
-<lb n="10"/> in cucumerario, ut civitas, quae . Quibus rehctis salus
-translata est ad nationes, ut ihi concitentur ad zehim. Intuentes
+<lb n="5"/> legalium praeceptorum et prophetici
+vaticinii rationem reddere?
+Cessavit esse Christus in</p>
+<p>eis, reliquit eos sermo, completum est iliud, quod in Isaia scribitur:
+&gt;relinquetur filia Sion sicut tabernaculum in vinea, et ut custodia
+<lb n="10"/> in cucumerario, ut civitas, quae expugnatur&lt;. Quibus relictis salus
+translata est ad nationes, ut ilii concitentur ad zelum. Intuentes
 ergo dispensationem et arcanum Dei, quomodo Israhel abjectus sit
-in salutem nostram, cavere debemus, ne forte et ihi nostri causa
-ejecti sint, et nos majori supphcio digni simus, propter quos et alii
-<lb n="15"/> derehcti sunt, et nos nihil dignum adoptione Dei et ejus clementia
-fecerimus, qui adoptavit nos et in suos fihos reputavit in Christo
+in salutem nostram, cavere debemus, ne forte et ilii nostri causa
+ejecti sint, et nos majori supplicio digni simus, propter quos et alii
+<lb n="15"/> derelicti sunt, et nos nihil dignum adoptione Dei et ejus clementia
+fecerimus, qui adoptavit nos et in suos filios reputavit in Christo
 Jesu: cui est gloria et imperium in saecula saeculorum. Amen.</p>
 <note type="footnote">9f. Jes. 1, 8
 10 f. vgl. Rom. 11, 11</note>
@@ -2680,26 +2679,26 @@ nächste Schol. [Anfang v. Hom. 7] ist Orig.: τοῦ αὐτοῦ) 44, 15 κα�
 <lb n="5"/> <p>Meliores ad deteriores veniunt,
 ut eis ex adventu suo aliquid tribuant
 emolumenti. Sic et Salvator
-venit ad Joaimem, ut sanctificaret
+venit ad Joannem, ut sanctificaret
 baptisma illius ; et Maria
 <lb n="10"/> statim ut audivit angelum nuntiantem,
 quod conceperit Salvatorem
  <milestone unit="altpage" n="108"/>  et quod cognata illius
-Elisabeth haberet in utero, consurgens
+Elisabeth haberet in utero, &gt;consurgens
 cum festinatione venit
 <lb n="15"/> in montana, et ingressa est domum
-Elisabeth&lt; Jesus enim,
+Elisabeth&lt;. Jesus enim,
 in utero illius erat, festinabat
 adhuc in ventre matris Joannem
 positum sanctificare. Denique
 <lb n="20"/> antequam veniret Maria et salutaret
-Elisabeth, non exsultavit
+Elisabeth, non &gt;exsultavit
 infans in utero&lt;; sed statim
 Maria locuta est verbum, quod
 Filius Dei in ventre matris suggesserat,
-<lb n="25"/> exsultavit infans in gaudio&lt;,
+<lb n="25"/> &gt;exsultavit infans in gaudio&lt;,
 et tunc primum praecursorem
-suum prophetam fecit Jesus,</p>
+suum prophetam fecit Jesus.</p>
 <p>Οἱ κρείττονες πρὸς τοὺς ἐλάττονας
 ἔρχονται, ἵνα αὐτοὺς εὐεργετήσωσιν.
 Οὕτω καὶ ὁ σωτὴρ
@@ -2748,7 +2747,7 @@ matris ventre C
 
 <pb n="v.9.p.46"/>
 <p>Oportebat quoque Mariam Dei
-prole digiiissimam post alloquium
+prole dignissimam post alloquium
 angeli ad montana conscendere
 et in sublimioribus commorari.
 <lb n="5"/> Unde scriptum est: &gt;Consurgens
@@ -2759,10 +2758,10 @@ properare sollicite et Spiritu
 <lb n="10"/> sancto plena ad sublimiora perduci
 et virtute Dei protegi, a qua
 jam fuerat obumbrata. Venit ergo
-in civitatem Juda et in domum
+&gt;in civitatem Juda et in domum
 Zachariae, et salutavit Elisabeth.
 <lb n="15"/> Et factum est, cum audisset
-salutationem Mariae EUsabeth,
+salutationem Mariae Elisabeth,
 exultavit infans in utero ejus, et
 repleta est Spiritu sancto&lt;.</p>
 <p>Μαρίας καὶ &gt;ἐσκίρτησεν ἐν
@@ -2782,7 +2781,7 @@ repleta est Spiritu sancto&lt;.</p>
 ἀγομένη ὑπὸ τοῦ ἁγίου πνεύματος
 τοῦ ἐπελθόντος αὐτῇ καὶ ὑπὸ
 τῆς δυνάμεως τοῦ ὑψίστου τῆς ἐπισκιασάσης
-αὐτῇ. &gt;Πόλιν&lt; δὲ</p>
+αὐτῇ. &gt;Πόλιν&lt; δὲ &gt;Ἰούδα&lt;</p>
 <note type="footnote">15ff. gr. vgl. Luk. 1, 35</note>
 <note type="footnote">1 quoque &gt; A Maria B Mariam + cum De 2 dignissima
 3 angeli ABE] Dei De &gt; C 4 et &gt; AB 5 Unde + et De
@@ -2811,9 +2810,9 @@ Et — 16 Elisabeth
 ὑπὸ &gt; e 18 αὐτῇ] αὐτὴν</note>
 
 <pb n="v.9.p.47"/>
-<p>δα&lt; &lt;ἐκάλεσε&gt; τὴν ἱερουσαλήμ, ἐν ὁ Ζαχαρίας xar κατῴκει διὰ τὸ πλησιάζειν
-τῷ ἱερῷ. &gt;Εἰσῆλθεν δὲ εἰς τὸν οἶκον Ζαχαρίου&lt;&lt;, rd κατὰ
-’ Ελισάβετ μαθεῖν ἐπειγομένη τὴν &lt;τῶν&gt; πρὸς αὐτὴν εὐαγγελίων βεβαιωθῆναι
+<p>&lt;ἐκάλεσε&gt; τὴν Ἱερουσαλήμ, ἐν ὁ Ζαχαρίας κατῴκει διὰ τὸ πλησιάζειν
+τῷ ἱερῷ. &gt;Εἰσῆλθεν δὲ εἰς τὸν οἶκον Ζαχαρίου&lt;, τὰ κατὰ τὴν
+Ἐλισάβετ μαθεῖν ἐπειγομένη τὴν &lt;τῶν&gt; πρὸς αὐτὴν εὐαγγελίων βεβαιωθῆναι
 πίστωσιν. Τί δὲ τό· &gt;ἠσπάσατο τὴν Ἐλισάβετ&lt; Ἰστέον, ὅτι οὐ
 <lb n="5"/> φιλήματι, ἀλλὰ φωνῇ· δῆλον, ὅτι τῇ συνήθει τοῖς φίλοις προσεφθέγξατο
 τὴν εἰρήνην ἐπιφωνήσασα τῇ συγγενίδι, ὅπερ ἔθος Ἑβραίοις ἀνέκαθεν,
@@ -2823,14 +2822,14 @@ Et — 16 Elisabeth
 <lb n="10"/> tunc &gt;repleta est Spiritu
 propter filium sit &gt;repleta&lt;! Neque
 enim mater primum Spiritum
-sanctum meruit, sed cum Joan-
-nes adhuc clausus in utero Spiritum
+sanctum meruit, sed cum Joannes
+adhuc clausus in utero Spiritum
 <lb n="15"/> sanctum recepisset, tunc
 et illa post sanctificationem filii
-&gt;repletaestSpiritu sancto&lt;
+&gt;repleta est Spiritu sancto&lt;. Poteris
 hoc credere, si simile quid etiam
 de Salvatore cognoveris. Invenitur
-<lb n="20"/> nitur beata Maria, sicut in aliquantis
+<lb n="20"/> beata Maria, sicut in aliquantis
 exemplaribus repperimus,</p>
 <p>Οὐκοῦν ἐν τῷ ἀσπασμῷ &gt;ἐπλήσθη&lt;
 διὰ τὸν υἱὸν &gt;πνεύματος ἁγίου ἡ Ἐλισάβετ&lt;·
@@ -2843,8 +2842,8 @@ exemplaribus repperimus,</p>
 τῶν προφητῶν, διὰ τὸ πλησιάζειν
 αὐτὸν τῇ Χριστοῦ παρουσίᾳ καὶ
 προτρέχειν αὐτῆς· οὐ γὰρ πρότερον
-τοῦ&gt; ἁγίου πνεύματος ἐπλήσθη&lt; , πρὶν
-ἐπιστῆναι τὴν κυοφοροῦσαν τὸν Χρι-</p>
+τοῦ&gt; ἁγίου πνεύματος ἐπλήσθη&lt;, πρὶν
+ἐπιστῆναι τὴν κυοφοροῦσαν τὸν Χριστόν.</p>
 <note type="footnote">19 — 48, 3 lat. ist wohl Zusatz des Ηιερον.; vgl. dazuTh. Zahn, D. Evang.
 d. Lukas ausgelegt (Komm. z. NTIII) 1913, Exkurs III (745—751)</note>
 <note type="footnote">9 ~ dubium itaque B 14/15 ~ sanct. Spir. ADmn 15 recep.]
@@ -2874,10 +2873,10 @@ Spiritu itaque sancto  <milestone unit="altpage" n="109"/>  tunc
 in utero habere Salvatorem. Statim
 enim ut Spiritum sanctum
 accepit Dominici corporis conditorem,
-et FiUus Dei esse coepit
+et Filius Dei esse coepit
 <lb n="10"/> in utero, etiam ipsa completa est
 Spiritu sancto.</p>
-<p>στόν. Ι Πρῶτον δὲ τὸ βρέφος ἐπλήροῦτο
+<p>|Πρῶτον δὲ τὸ βρέφος ἐπλήροῦτο
 πνεύματος καὶ ἐσκίρτα καὶ
 οὕτως τῇ μητρὶ μετεδίδου, καὶ
 ἀνεβόα προφητικὰ ἡ Ἐλισόβετ διὰ
@@ -2892,10 +2891,10 @@ Spiritu sancto.</p>
 γυνὴ τὸν Χριστὸν ἐπεκνογόνησεν — καὶ ἔλεγε τῇ παρθένῳ· εὐλογημένη
 σὺ ἐν · οὐδεμία γὰρ τῆς τοιαύτης χάριτος κοινωνὸς οὔτε γέγονεν
 <lb n="15"/> οὔτε γενέσθαι δύναται. Ἒν γὰρ τὸ θεῖον κύημα, εἷς ὁ θεῖος τοκετός, καὶ
-μία ἡ γεννήσασα τὸν θεάνθρωπον. Τι μοι τοίνυν πρώτη προσαγορεύεις ;
+μία ἡ γεννήσασα τὸν θεάνθρωπον. Τί μοι τοίνυν πρώτη προσαγορεύεις ;
 Μὴ γὰρ ἐγώ εἰμι ἡ τὸν σωτῆρα τίκτουσα; Ἐμὲ ἐχρῆν ἐλθεῖν πρὸς σέ·
 σὺ γὰρ ὑπὲρ πάσας τὰς γυναῖκας εὐλογημένη· σὺ μήτηρ τοῦ κυρίου
-μου, σὺ ἐμὴ κυρία ἡ τῆς κατάρας τὴν λύσιν βαστάζουσα. |</p>
+μου, σὺ ἐμὴ κυρία ἡ τῆς κατάρας τὴν λύσιν βαστάζουσα.|</p>
 <note type="footnote">11 f . 1 Tim. 2, 15</note>
 <note type="footnote">4 Et Spiritu C ~ sancto itaqvie BE 6 ~ habere in utero ACE 7 Spiritu
 sanoto D 9 ~ cepit esse B
@@ -2924,12 +2923,12 @@ dlcCLS] ἐχρῆν ἐμὲ πρὸς σὲ παραγενέσθαι mX + ε�
 ὁ καρπὸς καρπὸς τῆς κοιλίας &lt; dC 18 οὺ — 19 βαστ. &gt; dCS ὑπὲρ]</note>
 
 <pb n="v.9.p.49"/>
-<p>&gt;Exsultavit&lt;ergo&gt;infans in
+<p>&gt;Exsultavit&lt; ergo &gt;infans in
 utero Elisabeth, et repleta est
 Spiritu sancto et clamavit voce
 magna et dixit: Benedicta tu
-<lb n="5"/> inter mulieres
-loco, ne simpUces quique decipiantur,
+<lb n="5"/> inter mulieres&lt;. Debemus in hoc
+loco, ne simplices quique decipiantur,
 ea, quae solent haeretici
 opponere, confutare. In tantum
 quippe nescio quis prorupit insaniae,
@@ -2937,14 +2936,15 @@ quippe nescio quis prorupit insaniae,
 fuisse Mariam a Salvatore, eo
 quod post nativitatem illius
 juncta fuerit Joseph, et locutus
-est, quae, quah mente dixerit, ipse
-lo noverit, qui locutus est. Si
+est, quae, quali mente dixerit, ipse
+<lb n="15"/>noverit, qui locutus est. Si
 quando igitur haeretici vobis tale
 quid objecerint, respondete eis
-et dicite: Certe &gt;Spiritu sanctobenedictad
-<lb n="20"/> tu inter mulieres
+et dicite: Certe &gt;Spiritu sancto&lt;
+plena Elisabeth ait: &gt;benedicta
+<lb n="20"/> tu inter mulieres&lt;. Si a Spiritu
 sancto benedicta canitur Maria,
-quomodo eam Salvator negavit ?
+quomodo eam Salvator negavit?
 Porro quod asserunt eam nupsisse
 post partum, unde approbent,
 <lb n="25"/> non habent; hi enim filii,
@@ -2957,19 +2957,19 @@ scriptura, quae ista commemoret.</p>
 ὅτι ἐτόλμησέ τις εἰπεῖν κατὰ τῆς
 Μαρίας, ὡς ἄρα ὁ σωτὴρ αὐτὴν
 ἠρνήσατο, ἐπεί, φησίν, συνήφθη μετὰ
-τὴν ἀπότεξιν τὴν τοῦ σωτῆρος τῷ
+τὴν τὴν ἀπότεξιν τοῦ σωτῆρος τῷ
 Ἰωσήφ.</p>
 <p>Εἴ ποτε οὖν τοιοῦτοι λόγοι ὑπὸ
 αἱρετικῶν προαχθῶσιν, οὕτως ἀποκριτέον,
 ὅτι &gt;πνεύματος ἀγίου  πλησθεῖσα
-ἡ ’ Ελισάβετ φησίν· &gt;εὐλογημένη
-σὺ ἐν γυναιξίν
+ἡ Ἐλισάβετ φησίν· &gt;εὐλογημένη
+σὺ ἐν γυναιξίν&lt;. Εἰ δὲ εὐλόγηται
 ὑπὸ τοῦ πνεύματος τοῦ
 ἁγίου, πῶς ἠρνήσατο αὐτὴν ὁ σωτήρ;
-’ Αλλ' οὐδὲ ἔχουσιν αὐτὴν ἀποδεῖξαι,
+Ἀλλ' οὐδὲ ἔχουσιν αὐτὴν ἀποδεῖξαι,
 ὅτι συνουσίᾳ ἐχρήσατο μετὰ τὴν
 ἀπότεξιν τοῦ σωτῆρος· οἱ γὰρ υἱοὶ
-’ Ιωσὴφ οὐκ ἦσαν ἄπὸ τῆς Μαρίας.
+Ἰωσὴφ οὐκ ἦσαν ἄπὸ τῆς Μαρίας.
 οὐδὲ ἔχει τις τοῦτο παραστῆσαι
 ἀπὸ τῆς γραφῆς.</p>
 <note type="footnote">zu 5ff. vgl. Th. Zahn, Briider u. Vettern Jesu (Forschimgen z. Gesch. d.
@@ -2986,35 +2986,35 @@ qui BE 9/10 insaniam] infamiam mn 16 ~ haeretici igitur D
 Origenes IX.</note>
 
 <pb n="v.9.p.50"/>
-<p>&gt; δὲ &lt; εἶπεν κατὰ τὴν παρὰ τοῦ θεοῦ πρὸς
-ἐπαγγελιάν τὴν λέγουσαν· ἐκ καρποῦ τῆς κοιλίας σου θήσομαι ἐπὶ
-τὸν θρόνον σου&lt; καλῶς δὲ &gt;καρπὸν κοιλίας( τῆς
+<p>&gt;Καρπὸν&lt; δὲ &gt;κοιλίας&lt; εἶπεν κατὰ τὴν παρὰ τοῦ θεοῦ πρὸς τὸν Δαβὶδ
+ἐπαγγελιάν τὴν λέγουσαν· &gt;ἐκ καρποῦ τῆς κοιλίας σου θήσομαι ἐπὶ
+τὸν θρόνον σου&lt;· καλῶς δὲ &gt;καρπὸν κοιλίας&lt; τῆς παωαγίας παρθένου
 ἡ Ἐλισάβετ ὠνόμασε διὰ τὸ μὴ ἐξ ἀνδρὸς εἶναι τὸ κυοφορούμενον, ἀλλ'
 <lb n="5"/> ἐκ μόνης τῆς Μαρίας πνεύματος ἁγίου ἐνοικήσαντος ἐν αὐτῇ καὶ
 τῆς τοῦ ὑψίστου δυνάμεως ἐπισκιασάσης αὐτῇ· οἱ γὰρ ἐκ τῶν πατέρων
 τὴν σπορὰν ἔχοντες ἐκείνων εἰσὶ καρποί, καθὼς καὶ τῷ Δαβὶδ ἐρρήθη·
-ἐκ καρποῦ τῆς κοιλίας σου&lt;, τοῦτ’ ἔστιν οἱ πρόγονοι τῆς
+ἐκ καρποῦ τῆς κοιλίας σου&lt;, τοῦτ’ ἔστιν οἱ πρόγονοι τῆς παναγίας
 θεοτόκου καὶ αὐτοὶ ἐκ σπορᾶς ἀνδρῶν γεννηθέντες.</p>
-<lb n="10"/><p>Benedicta tu inter mulieres,
+<lb n="10"/><p>&gt;Benedicta tu inter mulieres,
 et benedictus fructus ventris tui.
 Et unde mihi hoc, ut veniat mater
-Domini mei ad me &lt; Hoc,
-ait: &gt;unde mihi hoc ?&lt;
+Domini mei ad me?&lt; Hoc,
+ait: &gt;unde mihi hoc?&lt; non ignorans
 <lb n="15"/> dicit, et maxime Spiritu
 sancto plena, quasi nesciat, quod
 juxta Dei voluntatem mater Domini
-venerit ad eam ; sed isto sensu
-loquitur : quid boni feci ? quae
+venerit ad eam; sed isto sensu
+loquitur: quid boni feci? quae
 <lb n="20"/> opera mea tanta sunt, ut mater
-Domini ad me veniat ? per quam</p>
-<p>Τὸ δέ· &gt;πόθεν μοι
+Domini ad me veniat? per quam</p>
+<p>Τὸ δέ· &gt;πόθεν μοι τοῦτο;&lt; οὐκ
 ἀγνοοῦσα λέγει ἡ Ἐλισάβετ ἡ πνεύματος
 πλησθεῖσα ἁγίου, ὅτι· οὐκ
 οἶδα, ὅτι ἀπὸ θεοῦ γεγένηται τὸ
-ἐλθεῖν τὴν μητέρα &gt;τοῦ κυρίου
-πρός , ἀλλὰ τό · &gt;πόθεν μοι
+ἐλθεῖν τὴν μητέρα &gt;τοῦ κυρίου μου
+πρός με&lt;, ἀλλὰ τό· &gt;πόθεν μοι τοῦτο&lt;
 τοιοῦτόν ἐστιν· τί γάρ μοι, φησίν,
-τηλικοῦτον πέπρακται ἀγαθόν, ἵνα</p>
+τηλικοῦτον πέπρακται ἀγαθόν, &gt;ἵνα</p>
 <note type="footnote">2f. 8 Ps. 131 (132), 11 5f. vgl. Luk. 1, 35.
 &gt; C ut — ABCE 13
 50, 1 — 7 καρποί (neues Schol. nach 49, 27) ξ1 50, 3 καλῶς — 7 καρποί
@@ -3041,44 +3041,44 @@ U)</note>
 <pb n="v.9.p.51"/>
 <p>justitiam, ex quibus bonis, de qua
 fidelitate mentis hoc merui, ut
-mater Domini mei veniat ad me ?
+mater Domini mei veniat ad me?
 &gt;Ecce enim ut facta est
 <lb n="5"/> tua in aures meas, exsultavit in
-exsultatione infans in utero &lt;.
+exsultatione infans in utero&lt;.
 Sancta erat anima beati Joannis,
-et adhuc  <milestone unit="altpage" n="110"/>  in matris utero clausa
+et adhuc <milestone unit="altpage" n="110"/> in matris utero clausa
 venturaque in mundum sciebat,
-<lb n="10"/> quem Israhel ignorabat ; unde &gt;exsilivit&lt;,
-et non simphciter &gt;exsilivit&lt;
-sed &gt;in gaudio&lt;
+<lb n="10"/> quem Israhel ignorabat; unde &gt;exsilivit&lt;,
+et non simpliciter &gt;exsilivit&lt;
+sed &gt;in gaudio&lt;. Senserat
 enim venisse Dominum suum, ut
 sanctificaret servum, antequam
 <lb n="15"/> de matris ventre procederet. Utinam mihi eveniat, ut ab infidelibus
-stultus dicar, qui tahbus credidi. Ipsum opus ostendit et
+stultus dicar, qui talibus credidi. Ipsum opus ostendit et
 veritas non me stultitiae, sed sapientiae credidisse, quia hoc,
 quod stultum apud illos putatur, mihi salutis occasio fit. Nisi enim
 fuisset caelestis et beata nativitas Salvatoris, nisi habuisset
-<lb n="20"/> divini ahquid et humanitatem hominum supergredientis, nunquam
-in toto orbe iUius doctrina
+<lb n="20"/> divini aliquid et humanitatem hominum supergredientis, nunquam
+in toto orbe illius doctrina
 penetrasset. Si tantum homo
 fuisset in Mariae utero et non
-Dei Fihus, quomodo poterat fieri,</p>
-<p>ἡ μήτηρ τοῦ γυρίου μου ἔλθῃ πρός
-; πόθεν, ἀπὸ ποίας δικαιοσύνης
+Dei Filius, quomodo poterat fieri,</p>
+<p>ἡ μήτηρ τοῦ κυρίου μου ἔλθῃ πρός
+με&lt;; πόθεν, ἀπὸ ποίας δικαιοσύνης
 ἢ πράξεων ἀγαθῶν ἐπέτυχον τούτου;
 ἰδοὺ γὰρ ἐσκίρτησε τὸ βρέφος
-ἐν τῇ κοιλίᾳ μου&lt;
+ἐν τῇ κοιλίᾳ μου&lt;. Τεράστιος
 ἦν ἡ ψυχὴ τοῦ Ἰωάννου, καὶ
 ἔτι ἐν τῇ μήτρᾳ τῆς μητρὸς ὑπάρχουσα
 καὶ μέλλουσα εἰς γένεσιν
-ἥκειν ἔγνω, ὅν οὐκ ἔγνω ’ Ισραήλ.
+ἥκειν ἔγνω, ὅν οὐκ ἔγνω Ἰσραήλ.
 Οὐχ απλῶς δὲ &gt;ἐσκίρτησεν&lt;,
 ἐν ἀγαλλιάσει&lt;· ἤσθετο γάρ,
 κύριος ἦλθεν ἐν τῇ μητρί, ἵνα αὐτὸν
 παραλαβὼν ἁγιάσῃ.</p>
 <p>| Σύμφωνα δὲ φθέγγεται τῷ υἱῷ
 ἡ Ἐλισάβετ· κἀκεῖνος γὰρ ἀντάξιον
-ἑαυτὸν τῆς πρὸς τὸν Χριστὸν παρα  </p>
+ἑαυτὸν τῆς πρὸς τὸν Χριστὸν παραστάσεως </p>
 <note type="footnote">3 mei &gt; BC ~ ad me veniat C 5 auribus meis BE 8 in &gt;
 9 venturaque] venturum AE, venturumque C mimdvim + quasi per
 experientiae sensum D (spat. Einfvigixng) e 10 quem ACE] quae BDe
@@ -3102,34 +3102,34 @@ p. 52, 1 ἔλεγεν nach 3 παρθ. dC 24 τῆς — παραστ.] τῆς
 <pb n="v.9.p.52"/>
 <p>ut et illo tempore et nunc non
 solum corporum, sed etiam animarum
-morbi multiplices curarentur
-rentur? Quis nostrum non
+morbi multiplices curarentur? 
+Quis nostrum non insipiens
 <lb n="5"/> fuit, qui nunc propter misericordiam
 Dei habemus intellegentiam
-et scimus Deum ? Quis
+et scimus Deum? Quis
 non incredulus justitiae, qui nunc
 propter Christum justitiam habemus
-<lb n="10"/> sequimurque justitiam ?
+<lb n="10"/> sequimurque justitiam?
 Quis nostrum non errabundus et
 vagus, qui nunc propter adventum
 Salvatoris non fluctuamus
 atque turbamur, sed sumus in
-<lb n="15"/> via, in illo videUcet, qui ait : Ego
-sum &lt; ? Possumus et
+<lb n="15"/> via, in illo videlicet, qui ait: Ego
+sum via&lt;? Possumus et
 congregantes videre, quoniam
 omnia, quae scripta sunt de eo,</p>
-<p>στάσεως ἔλεγεν, οὕτο,ς καὶ αὐτὴ
+<p>ἔλεγεν, οὕτως καὶ αὐτὴ
 ἀναξίαν ἑαυτὴν τῆς παρουσία τῆς
 πάρθένου.</p>
-<p>&gt;Μμητέρα&lt; δὲ καλεῖ τὴν ἔτι
-φθάνουσα προφητικῶ̣ λόγῳ
+<p>&gt;Μμητέρα&lt; δὲ καλεῖ τὴν ἔτι παρθένον,
+φθάνουσα προφητικῷ λόγῳ
 τὴν ἔκβασιν.</p>
 <p>Θεία μὲν οὖν οἰκονομία τὴν Μαρίαν
 ἤγαγε πρὸς τὴν Ἐλισάβετ,
-ἶνα ἡ μαρτυρία ’ Ιωάννου ἐκ μήτρας
+ἶνα ἡ μαρτυρία Ἰωάννου ἐκ μήτρας
 εἰς τὸν κύριον πληρωθῇ διὰ τῆς
 ἰδίας μητρός. |</p>
-<p>Ι Εἶχε δὲ καὶ ἡ πορεία τῆς παρθένου
+<p>| Εἶχε δὲ καὶ ἡ πορεία τῆς παρθένου
 τὴν οἰκείαν αὐτῆς σπουδήν·
 ἦλθε γὰρ ὀψομένη τὴν Ἐλισάβετ
 καὶ τὸ ἐν ἀυτῇ παράδοδον κύημα
@@ -3163,26 +3163,26 @@ d, πληρωθῇ, μᾶλλον Se πληροφορηθῇ 8 διὰ — μη�
 λ 18 — p. 53, 1 διὰ x &gt; VX] διὰ τοῦτο SU, + καὶ λ</note>
 
 <pb n="v.9.p.53"/>
-<p>diviiia admiratione digna referantur,
+<p>divina admiratione digna referantur,
 quod et nativitas illius
 et nutrimenta et virtus et passio
 et resurrectio non solum illo tempore,
-<lb n="​5"/>d sed etiam nunc operentur
+<lb n="​5"/>sed etiam nunc operentur
 in nobis. Quis vos, Ο catechumeni,
-in ecclesiam congregavit ?
+in ecclesiam congregavit?
 quis stimulus impulit, ut relictis
-domibus in hunc coetum coeatis ?
+domibus in hunc coetum coeatis?
 <lb n="10"/> Neque enim nos domus vestras
 singillatim circuimus, sed omnipotens
 Pater virtute invisibili
 subjicit cordibus vestris, quos scit
-esse dignos, hunc ardorem,ut  <milestone unit="altpage" n="111"/> 
+esse dignos, hunc ardorem, ut  <milestone unit="altpage" n="111"/> 
 <lb n="15"/> quasi inviti et retractantes veniatis
 ad fidem, maxime in exordio
 religionis, cum veluti trepidi et
 paventes salutis fidem cum timore
 suscipitis. Obsecro vos, Ο
-<lb n="20"/> catechumeni : nohte retractare,
+<lb n="20"/> catechumeni: nolite retractare,
 nemo vestrum formidet et paveat,
 sed sequimini praeeuntem
 Jesum. Ille vos trahit ad salutem,
@@ -3192,16 +3192,16 @@ tem, congregat in ecclesiam nunc
 τοκετός, ὁ ἐξ αὐτῆς, φημί, τῆς παρθένου·
 καὶ συντρέχει πρὸς τὴν πίστιν
 ταύτην ὁ λόγος τῆς Ἐλισάβετ λεγούσης·
-καὶ μαδαρία ἡ πιστεύσασα,
+&gt;καὶ μακαρία ἡ πιστεύσασα,
 ὅτι ἔσται τελείωσις τοῖς λελαλημένοις
-αὐτῇ παρὰ κυρίου&lt;</p>
-<p>Ι Βεβαιοτέρα γὰρ Πρὸς τὴν πίστιν
+αὐτῇ παρὰ κυρίου&lt;.|</p>
+<p>Ι Βεβαιοτέρα γὰρ πρὸς τὴν πίστιν
 ταύτην ἐκ τούτων ἐγίνετο τῶν ῥημάτων
 ἡ παρθένος μακαριζομένη,
 ὅτι ἐπίστευσεν ἀγγέλου τε προσημαίνοντος
 καὶ τῆς συγγενίδος τὰ
 παραπλήσια προφητευούσας.
-[&gt;Μακαρία ἡ πιστεύσασα κτλ &lt;</p>
+[&gt;Μακαρία ἡ πιστεύσασα κτλ..&lt;]</p>
 <p>Ὁ λόγος οὗτος τὴν τοῦ Ζαχαρίου
 αἰνίττεται σιωπήν, ὅτι ἀπιστήσας
 τοῖς λελαλημένοις ἔλαβε Ποινὴν
@@ -3209,7 +3209,7 @@ tem, congregat in ecclesiam nunc
 ἐξέφυγες πόθους· καὶ ἄλλως·
 ἐπειδὴ &gt;τοῖς λελαλημένοις&lt;
 μακαρία εἶ. Διὰ τι; Ἔσται
-γὰρ τελείωσις , καὶ οὐ μάτην
+γὰρ τελείωσις, καὶ οὐ μάτην
 παρὰ τοῦ ἀγγέλου λελάληται. |</p>
 <note type="footnote">1/2 referuntur De fi ο &gt; ABE 7 cathecumini ABDE,
 C ecclesia CDe 9 himc] hoc E 10 enim &gt;
@@ -3232,14 +3232,14 @@ S 4 ταύτην + καὶ dC λόγος + ὁ dCUV 5 καὶ &gt;
 
 <pb n="v.9.p.54"/>
 <p>dignos fructus feceritis, in &gt;ecclesiam
-priniitivorum, qui scripti
-sunt in caelestibus&lt; &gt;Beata
-credidit&lt;, et beatus qui
-<lb n="5"/> quia eritperfectiohis,&gt;quae dicta
-sunt&lt; ei &gt;a Domino&lt;
-Dominum Jesum.
+primitivorum, qui scripti
+sunt in caelestibus&lt;. &gt;Beata
+credidit&lt;, et beatus qui credidit,
+<lb n="5"/> quia erit perfectio his, &gt;quae dicta
+sunt&lt; ei &gt;a Domino&lt;. Super quibus
+et Maria &gt;magnificat&lt; Dominum Jesum.
 &gt;Magnificat&lt; autem
-Dominum, spiritus Deum&lt;.
+Dominum, spiritus Deum&lt;. Quae
 <lb n="10"/> quam habeant interpretationem,
 si concesserit Dominus, ut rursus
 in ecclesiam congregemur, ut
@@ -3253,8 +3253,8 @@ saeculorum. Amen.</p>
 τοῖς λεχθῶσιν αὐτῇ διὰ τοῦ·&gt;μακαρία
 ἡ πιστεύσασα, ὅτι ἔσται τελείωσις
 τοῖς λαληθεῖσιν αὐτῇ παρὰ
-κυρίου&lt;, φάσκουσα· &gt;μεγαλύνει
-φυχή μου τὸν κύριον(. Ἐπειδὴ γὰρ
+κυρίου&lt;, φάσκουσα· &gt;μεγαλύνει ἡ
+ψυχή μου τὸν κύριον&lt;. Ἐπειδὴ γὰρ
 παρθένος οὖσα ἐν γαστρὶ σωματικῶς
 παρὰ τὴν κοινὴν συνελάμβανε
 φύσιν, σωματικῶς μὲν ὡς ἐν σώματι,
@@ -4653,7 +4653,7 @@ k Βηθλ. &gt; α μὴ ὀλιγοστὸς β ὀλιγ. — 9 Ἰσραή�
 <p> <milestone unit="altpage" n="123"/>  horas atque momenta spiritu
 erementa capiebat. Et non solum
 augmenta spiritus sequebantur.
-Illud quocl praecipit Deus: crescite
+Illud quod praecipit Deus: crescite
 <lb n="5"/> et multiplicamini&lt;,
 simpliciter et juxta litteram accipiunt,
 quomodo possint exponere
@@ -6872,7 +6872,7 @@ vorum D monstravit] ostendit De ~ in man. suis monstr. E</note>
 8</note>
 
 <pb n="v.9.p.116"/>
-<p>aliis e regione tractantibus : si ideni corpus habuit, quomodo
+<p>aliis e regione tractantibus : si idem corpus habuit, quomodo
 clausis ingressus est ostiis et stetit &lt; ? ? Vides igitur, quemadmodum
 argumentis variis etiam resurrectionis ejus quaestio concitetur,
 et sit &gt;signum, cui contradicitur &lt; . Ego et hoc, quod
@@ -7199,7 +7199,7 @@ dignitatibus non solum fornicatio, sed et secundae nuptiae repellunt
 immaculatorumquec, x &gt;, &gt;ecclesia, quae non habet maculam neque
 rugam &lt; , ejicietur digamus; non quo in aeternum mittatur incendium,
 sed quo partem non habeat in regno Dei. Memini, cum interpretarer
-ilhid, quod ad Corinthios scribitur : x &gt;ecclesiae Dei, quae est
+illud, quod ad Corinthios scribitur : x &gt;ecclesiae Dei, quae est
 <lb n="10"/> Corinthi, cum omnibus, qui invocant x &gt;, dixisse me diversetatem
 esse x &lt; et eorum, x &gt;qui invocant &lt; nomen Domini.
 enim monogamum et virginem et eum, qui in castimonia perseverte,
@@ -7393,7 +7393,7 @@ De interrogatio + JesusB 26 Non] Nec C 27 eum] enim e
 mei oportet me esse x &lt; Ubi simt haeretioi, ubi impii atque ve-
 sani, qui asserunt non esse patris Jesu Christi legem et prophetas ?
 Certe Jesus x &gt;in templo &lt; erat, quod a Salomone constructum est,
-confitetur temphim ilhid patris sui esse, quem nobis revelavit, cujus
+confitetur temphim illud patris sui esse, quem nobis revelavit, cujus
 <lb n="5"/>  <milestone unit="altpage" n="155"/>  filium esse se dixit. Respondeant, quomodo alter bonus et
 alter sit justus Deus. Quia igitur Salvator Creatoris est fihus, in
 commune Patrem Fihumque laudemus, cujus lex, cujus et templum
@@ -12871,7 +12871,7 @@ omelia XXXVII. A
 <pb n="v.9.p.222"/>
 <div type="textpart" subtype="homilia" n="38">
 <head>HOMILIA XXXVIII.</head>
-<head>De eo, quocl scriptum est : &gt;Cum autem appropinquasset, vidit
+<head>De eo, quod scriptum est : &gt;Cum autem appropinquasset, vidit
 et flevit super eam &lt;, usque ad eum locum, ubi
 &gt;ejecit omnes vendentes columbas&gt;.</head>
 <lb n="5"/> <p>Cum appropinquasset Hierusalem Dominus noster atque Salvator,

--- a/data/tlg2042/tlg016/tlg2042.tlg016.opp-grc1.xml
+++ b/data/tlg2042/tlg016/tlg2042.tlg016.opp-grc1.xml
@@ -76,6 +76,7 @@ License</p>
 </profileDesc>
 <revisionDesc>
 <change who="Jack Duff" when="2016-07-06">Corrected metadata, expanded pb, added ref. Need to tackle structure seperately.</change>
+<change who="Jack Duff" when="2016-07-13">Corrected OCR in Homilia 1 by hand.</change>
 </revisionDesc>
 </teiHeader>
   <text>
@@ -115,7 +116,7 @@ evang. + cjuas de graeco vertit in latinum (hctae dominicis diebus A,
 Hieronymus E Eustochiae(!) F 4 Matthaeo De et + in De
 Luca De 6 verbis1 &gt; R 7 ~ istiusmodi contemptis nugis R
 istiusmodi] huiusmodi A tiiginta — novem &gt; De et novem &gt; K
-9 Molestam R 10 quam] quod B, quam (ahi quod) R 12 flagitaverat
+9 Molestam R 10 quam] quod B, quam (alii quod) R 12 flagitaverat
 CDKe ut] et E XXXVI De 13 quinque] duos B
 duos] novem Dmnr Joannem e 14 otii + et D nec &gt; K laboris]
 temporis B 15 esse perspicitis] est. Perspicitis De En CE] In ABK,
@@ -171,24 +172,24 @@ Lucam A</note>
 <div type="textpart" subtype="homilia" n="1">
  <head>HOMILIA I.</head>
 <head>In exordium Lucae usque acl eum locum, ubi ait: &gt;scribere tibi,
-optime Theophile</head>
+optime Theophile&lt;</head>
 <lb n="5"/>
-<p>Sicut olim in populo Judae-
-orum multi prophetiam  <milestone unit="altpage" n="86"/>  pollicebantur,
+<p>Sicut olim in populo Judaeorum
+multi prophetiam  <milestone unit="altpage" n="86"/>  pollicebantur,
 <lb n="10"/> cebantur, et quidam erant pseudoprophetae
 — e quibus unus fuit
-Ananias, filius Azor —, ahi vero
+Ananias, filius Azor —, alii vero
 prophetae, et erat gratia in populo
 discernendorum spirituum,
-<lb n="15"/> per quam ahi inter prophetas
-recipiebantur, nonnulH quasi ab
-&gt;exercitaissimis trapezitis reprobabantur, 
+<lb n="15"/> per quam alii inter prophetas
+recipiebantur, nonnulli quasi ab
+&gt;exercitaissimis trapezitis&lt; reprobabantur, 
 ita et nunc in novo
-instrumento multi conati sunt
+instrumento &gt;multi conati sunt&lt;
 <lb n="20"/>scribere evangelia, sed non omnes</p>
 <p>Ἐπειδὴ ὑπέρογκον ἦν τὸ ἐπιχείρημα
 ἄνθρωπον ὄντα θεοῦ διδακαλίαν
-Λ·αὶ ῥήματα συγγράφειν, εἰκότως
+καὶ ῥήματα συγγράφειν, εἰκότως
 ἀπολογεῖται ἐν τῷ προοιμίῳ.</p>
 <p>Ὢσπερ δὲ ἐν τῷ πάλαι λαῷ πολ-
 λοὶ προφητείαν ἐπηγγέλλοντο, ἀλλὰ
@@ -196,11 +197,11 @@ instrumento multi conati sunt
 φεδοπροφῆται,</p>
 <p>τινὲς δὲ ἀληθῶς προφῆται, καὶ
 ἦν χάρισμα τῷ λαῷ διάκρισις πνευμάτων,
-ἀφ'αὖ ἐκορίντο ὅ τε ἀληθὴς
+ἀφ' οὖ ἐκρίνετο ὅ τε ἀληθὴς
 προφήτης καὶ ὁ ψευδώνυμος·</p>
 <p>οὕτω καὶ νῦν ἐν τῇ καινῇ διαθήκῃ
-τὰ εὐαγγέλια &gt; πολλοἰκ ἠθέλησαν
-γράψαι, ἀλλ᾿&gt;οἱ δόκιμοι τραπε-</p>
+τὰ εὐαγγέλια &gt;πολλοἰ&lt; ἠθέλησαν
+γράψαι, ἀλλ᾿ &gt;οἱ δόκιμοι τραπεζῖται&lt;</p>
 <note type="footnote">2—3 Luk. 1, 1—4 8ff. vgl. 2 Petr. 2, 1; vgl. Ambros. in Lucaml, 1. 2
 (S. 10, 6ff. Schenkl); Hieron. Praef. comm. super Matth.; A. Harnack, Geschichte
 der altchristl. Literatur bis Eusebius 1. Teil (Leipzig 1893), 4f. u.
@@ -226,14 +227,14 @@ non A omnes + sunt K</note>
 </note>
 
 <pb n="v.9.p.4"/>
-<p>recepti. Et ut seiatis non solum
-quatuor evangelia. sed plurima
+<p>recepti. Et ut sciatis non solum
+quatuor evangelia, sed plurima
 esse conscripta, e quibus haec,
 quae habemus, electa sunt et <milestone unit="altpage" n="87"/> 
-<lb n="5"/>tiadita ecclesiis, ex ipso proocemio
+<lb n="5"/>tradita ecclesiis, ex ipso prooemio
 Lucae, quod ita contexitur, cognoscamus:
 &gt; Quoniam quidem
-multi conati sunt ordinare narrationem&lt;
+multi conati sunt ordinare narrationem&lt;.
 Hoc quod ait: &gt;conati
 <lb n="10"/> sunt&lt;, latentem habet accusationem
 eorum, qui absque gratia
@@ -242,12 +243,12 @@ prosiluerunt. Matthaeus
 quippe et Marcus et Joannes et
 <lb n="15"/> Lucas non sunt &gt;conati&lt; scribere,
 sed Spiritu sancto pleni scripserunt
-evangelia. &gt; Multi&lt; igitur
-&gt; conati sunt ordinare narrationem
+evangelia. &gt;Multi&lt; igitur
+&gt;conati sunt ordinare narrationem
 de his rebus, quae manifestissime
-<lb n="20"/> festissime cognitae sunt in nobis &lt;
+<lb n="20"/>cognitae sunt in nobis&lt;.
 Ecclesia quatuor habet evangelia,
-ζῖται &lt; οὐ πάντα ἐνέκριναν, ἀλλα τινα
+οὐ πάντα ἐνέκριναν, ἀλλα τινα
 αὐτῶν ἐξελέξαντο.</p>
 <p>Τάχα δὲ καὶ τὸ &gt;ἐπεχείρησαν &lt;
 λεληθυῖαν ἔχει κατηγορίαν τῶν προπετῶς
@@ -283,40 +284,40 @@ V 13 Ματθ. — 17 Λουκ.] Ματθ. καὶ Μᾶρκ. καὶ Ἰωάν
 Πέτοου ST</note>
 
 <pb n="v.9.p.5"/>
-<p>haeresis plurima, e qiiibus quocldain 
-soribitur secundum Aegyptios, 
+<p>haeresis plurima, e quibus quoddam
+scribitur secundum Aegyptios, 
 aliud juxta Duodecim Apostolos. 
 Ausus fuit et Basilides
 <lb n="5"/> scribere evangelium et suo illud
-nomine titulare. Multi conati
-suntr scribere, sed quatuor tantum 
+nomine titulare. &gt;Multi conati
+sunt&lt; scribere, sed quatuor tantum 
 evangelia sunt probata, e
 quibus super persona Domini et
 <lb n="10"/> Salvatoris nostri proferenda sunt
 dogmata. Scio quoddam evangelium, 
 quod appellatur secundum 
-Thomani, et juxta Mathiam; 
-et alia phira legimus, ne quid
+Thomam, et juxta Mathiam; 
+et alia plura legimus, ne quid
 <lb n="15"/> ignorare videremur propter eos,
-qui se putant ahquid scire, si ista
+qui se putant aliquid scire, si ista
 cognoverint. Sed in his omnibus
-nihil aUud ])robamus, nisi quod
+nihil aliud probamus, nisi quod
 ecclesia, id est quatuor tantum
--̓0 evangeha recipienda. Haec idcirco, 
+<lb n="20"/> evangelia recipienda. Haec idcirco, 
 quia in principio lectum
-est: multi conati sunt ordinare
+est: &gt;multi conati sunt ordinare
 narrationem de his rebus, quae</p>
 <p>Τὸ μέντοι ἐπιγεγραμμένον κατὰ
 Αἰγυπτίους εὐαγγέλιον καὶ τὸ ἐπιγεγραμμένον 
 τῶν Δώδεκα εὐαγγέλιον 
-οἱ συγγράψαντες 〉ἐπεχείρησαν〈.
+οἱ συγγράψαντες &gt;ἐπεχείρησαν&lt;.
 Ἤδη δὲ ἐτόλμησε καὶ Βασιλείδης
 γράψαι κατὰ Βασιλείδην εὐαγγέλιον.
-〉Πολλοὶ μὲν οὖν ἐπεχείγησαν〈.</p>
+&gt;Πολλοὶ μὲν οὖν ἐπεχείγησαν&lt;.</p>
 <p>φέρεται γὰρ καὶ τὸ κατὰ Θωμῶν
 εὐαγγέλιον καὶ τὸ κατὰ Ματθίαν
 καὶ ἄλλα πλείονα.</p>
-<p>Ταῦτό ἐοτι τῶν ἐπιχειρησάντων.
+<p>Ταῦτά ἐστι τῶν ἐπιχειρησάντων·
 τὰ δὲ τέσσαρα μόνα προκρίνει ἡ τοῦ
 θεοῦ ἐκκλησία.</p>
 <p>| Λόγος ἐστὶ παραγραπτέος Ἰωάννην
@@ -502,28 +503,29 @@ Patrem, qui misit me&lt; .</p>
 <p>&gt; Sicut tradiderunt nobis, qui a
 <lb n="20"/> principio ipsi viderunt et ministri
 fuerunt sermonis &lt; Clam Lucae
-sermonibus edocemur, quod cujus-</p>
+sermonibus edocemur, quod cujusdam
+doctrinae finis sit ipsa doctrina,</p>
 <p>τῆς φωνῆς λόγος. Διὰ τοῦτο· Καθὼς
 παρέδοσαν ἡμῖν οἱ ἁπ' ἀρχῆς
 αὐτόπται καὶ ὑπηρέται γενόμενοι
-τοῦ x &gt; Οὐκοῦν οἱ ἀπόστολοι
-αὐτόπται τοῦ x &gt; ἦσαν οὐ
+τοῦ λόγου&lt; Οὐκοῦν οἱ ἀπόστολοι
+&gt;αὐτόπται τοῦ λόγου&lt; ἦσαν οὐ
 μόνον ἑωρακότες τὸν Ἰησοῦν κατὰ
 σῶμα, ἀλλὰ καὶ τὸν θεοῦ λόγον.
-Εἰ γὰρ τὸ ἑωρακέναι τὸν Ἰησοῦν γατὰ
-σῶμα &gt; αὐτόπτην τοῦ x &gt; γίνεσθαι
-ἦν, Λ·αὶ Πιλᾶτος x &gt; ἦν
-&gt; τοῦ x &gt; καταδικάξων αὐτὸν γαὶ
+Εἰ γὰρ τὸ ἑωρακέναι τὸν Ἰησοῦν κατὰ
+σῶμα &gt;αὐτόπτην τοῦ λόγου&lt; γίνεσθαι
+ἦν, καὶ Πιλᾶτος &gt;αὐτόπτης&lt; ἦν
+&gt;τοῦ λόγου&lt; καταδικάξων αὐτὸν γαὶ
 Ἰούδας ὁ προδότης καὶ πάντες οἱ
-λέγοντες· σταύρου, σταύρου x &gt;.
+λέγοντες· &gt;σταύρου, σταύρου αύτόν&lt;.
 Ἀλλ' ἀπείη λέγειν, ὄτι ἐκεῖνοι
-ἦσαν &gt; αὐτόπται τοῦ x &gt; Τὸ
+ἦσαν &gt;αὐτόπται τοῦ λόγου&lt; Τὸ
 οὖν ἰδεῖν τὸν λόγον ἐκεῖ ἐννοεῖται,
-ὅπου ἔλεγεν ὁ σωτήρ· &gt; Ὁ ἑωρακὼς
+ὅπου ἔλεγεν ὁ σωτήρ· &gt;Ὁ ἑωρακὼς
 ἐμέ ἑώρακε τὸν πατέρα τὸν
-πέμψαντά x &gt;.</p>
+πέμψαντά με&lt;.</p>
 <p>Καὶ λεληθότως δέ τι καλὸν μάθημα
-dam doctrinae finis sit ipsa doctri- | διδάσκει ἡμᾶς ὁ Δουκᾶς ἐνταῦθα,</p>
+διδάσκει ἡμᾶς ὁ Λουκᾶς ἐνταῦθα,</p>
 <note type="footnote">11 f. Joh. 19. 15 s. A. Resch. AuBercanou. Paralleltexte (zu Luk. 23. 18 a)
 (TuU Χ, 3, 710) [auch Akt. 22, 22 ?, vgl. E. Hautsch, D. Evv. zitate d. Orig.
 (TuU 3. R. IV, 2a, 116)] 16 f. Joh. 14.  9</note>
@@ -546,9 +548,9 @@ eCUy] λεληθὸς Χ, λεληθῶς V τι CUVX &gt; e 23 ἠμᾶς &gt; 
 ὁ Δουκᾶς &gt; Cγ ~ ἐνταῦθα ὁ Δουκᾶς</note>
 
 <pb n="v.9.p.9"/>
-<p>na, alterius vero doctrinae finis in | 
-opere computetur. Verbi gratia: ἡ 
-scientia geometriae finem habet | των 
+<p>alterius vero doctrinae finis in
+opere computetur. Verbi gratia: 
+scientia geometriae finem habet 
 ipsam tantum scientiam atque
 <lb n="5"/> doctrinam. Alia vero scientia est, cujus finis opus exigit, velut medicina.
 Oportet me rationem et dogmata scire medicinae, non ut
@@ -560,31 +562,31 @@ Quae si quis tantum scierit et non opere fuerit subsecutus,
 cassa erit eius scientia. Simile quid scientiae medicinae et operi
 etiam in notitia ministerioque sermonis est. Unde scribitur:
 &lt;sicut tradiderunt nobis, qui a principio ipsi viderunt et ministri
-<lb n="15"/> fuerunt &gt;, ut ex eo, quod
-dixit: x &lt;ipsi &gt;, doctrinam
+<lb n="15"/> fuerunt sermonis&gt;, ut ex eo, quod
+dixit: &lt;ipsi viderunt&gt;, doctrinam
 et scientiam significari, ex eo
-vero, quod ait: &gt; fuerunt| &gt; τὸ πρακτικὸν αὐτῶν πα
-&gt;, demonstrari
-opera
+vero, quod ait: &gt; fuerunt
+sermonis&lt;, demonstrari opera
 <lb n="20"/> cognoscamus.
 &lt;Visum est et mihi subsecuto
-ab &gt;. Inculcat ac replicat,
+ab initio&gt;. Inculcat ac replicat,
 quoniam ea, quae scripturus
 est, non rumore cognoverit,
 <lb n="25"/> sed ab initio ipse fuerit
 consecutus.</p>
 <p>ὅτι τινῶν μὲν θεωρημάτων τὸ τέλος
-θεωρία ἐστίν, τινῶν δέ θεωρημά-
+ἡ θεωρία ἐστίν, τινῶν δέ θεωρημάτων
 τὸ τέλος ἡ πρᾶξις.
-Ἵνα μὲν οὖν διὰ τοῦ x &gt;
+Ἵνα μὲν οὖν διὰ τοῦ αὐτόπται&gt;
 δηλώσῃ τὸ θεωρητικόν, διὰ δέ τοῦ
-ραστήσῃ, &gt; αὐτόπται καὶ x &gt;
-εἶπεν διὰ τὸ βέβαιον καὶ ἀδιάστατον.
-διὰ γὰρ τοῦ x &gt; τὸ
+&gt;ὑπηρέται&lt; τὸ πρακτικὸν αὐτῶν παραστήσῃ, 
+&gt; αὐτόπται καὶ ὑπηρέται&gt;
+εἶπεν |διὰ τὸ βέβαιον καὶ ἀδιάστατον.
+διὰ γὰρ τοῦ αὐτόπται&gt; τὸ
 θεωρητικὸν τῆς τοῦ σαρκωθέντος
-λόγου θεότητος, ἥν ἑώρακεν &gt; ὁ x &gt;
-τὸν χριστὸν τῇ πίστει καὶ δι’
-αὐτοῦ 〉τὸν πατέρα〈, διὰ δέ τοῦ x &gt;
+λόγου θεότητος, ἥν ἑώρακεν &gt; ὁ ἑωρακὸς&gt;
+τὸν Χριστὸν τῇ πίστει καὶ δι’
+αὐτοῦ &gt;τὸν πατέρα&lt;, διὰ δέ τοῦ ὑπηρέται&gt;
 τὸ πρακτικόν· πρᾶξις γὰρ</p>
 <note type="footnote">2 computatur A 4 irsa E 4/5 scientia atque doctrina E 5 velut
 AB + in CDe 5/6 medicina. Oportet ABEK] medicina oportet
@@ -605,28 +607,28 @@ von 8. 1 — 9, 3?)
 
 <pb n="v.9.p.10"/>
 <p>θεωρίας ἀνάβασις. Δύνασαι δὲ καὶ ἑτέρως ἐκλαβεῖν τό· ὑπνρέται γενόμενοι
-τοῦ x &gt; ἥτοι τοῦ διδασκαλικοῦ λόγου, ὅν παρεδίδου ὁ
-σωτήρ, ἢ καὶ αὐτοῦ τοῦ θεοῦ λόγου, ᾧ καὶ ἐξυπηρέτησαν
-οἱ μαθηταί. | Τὸ δέ· &gt;ἔδοξε κἁμοὶ παρηκολουθηκότι x &gt; δηλοῖ
+τοῦ λόγου&lt; ἥτοι τοῦ διδασκαλικοῦ λόγου, ὅν παρεδίδου ὁ
+σωτήρ, ἢ καὶ αὐτοῦ τοῦ θεοῦ λόγου, ᾧ καὶ ἐξυπηρέτησαν παρόντες
+οἱ μαθηταί. | Τὸ δέ· &gt;ἔδοξε κἁμοὶ παρηκολουθηκότι ἄνωθεν&gt; δηλοῖ
 <lb n="5"/> ὡσανεὶ ὅτι λέγει, ὅτι· τάχα ἂν καὶ κινδυνεύσαιμι, εἰ παρηκολουθηκὼς
 πᾶσιν ἀκριβῶς ἤμελλον σιωπῇ παραδιδόναι τηλικαῦτα πράγματα. γράφω
 δὲ οὐ ψιλὴν ἀκοήν, φησίν, παραλαβών, ἀλλ' ἀκριβῶς παρηκολουθηκὼς
 ἄνωθεν πᾶσιν. Ἐπαινεῖ
-δὲ τὸν μακάριον Δουκᾶν καὶ ὁ
+δὲ τὸν μακάριον Λουκᾶν καὶ ὁ
 ἀπόστολος λέγων· οὖ ὁ ἔπαινος
-ἐν τῷ x &gt;. Ι Ἔδοξε κἀμοὶ
-ἄνωθεν x &gt; διαβεβαιοῦται,
-x &gt;,
+ἐν τῷ εὐαγγελίῳ&gt;. | Ἔδοξε κἀμοὶ
+ἄνωθεν παρηχολουθηκότι&gt; διαβεβαιοῦται,
+ὅτι &gt;ἄνωθεν παρηκολούθησεν&lt;,
 οὕ τισι τῶν εἰρημένων,</p>
 <p>Unde et ab apostolo Paulo merito
 <lb n="10"/> collaudatur dicente : &lt;cujus laus
 in evangelio per omnes &gt;
 Hoc enim de nullo alio dicitur, nisi
 de  <milestone unit="altpage" n="90"/>  Luca dictum traditur.</p>
-<lb n="15"/><p>ἀλλὰ x &gt; τοῖς αὐτόπταις καὶ ὑπηρέταις, ἵνα μὴ τῇδε κἀκεῖσε
+<lb n="15"/><p>ἀλλὰ &gt;πᾶσιν&lt; τοῖς αὐτόπταις καὶ ὑπηρέταις, ἵνα μὴ τῇδε κἀκεῖσε περιφερόμενος
 ἀποτραπῇς τῆς εὐθείας ὁδοῦ· οὐ γὰρ ἔτερα κατηχηθείς, ἔτερα
 νῦν παρὰ τῆσδε τῆς γραφῆς ἐνηχηθήσῃ, ἀλλὰ περὶ ὧν τὴν γνῶσιν εἴληφας
-τελεωτέραν δόξῃ 〉τὴν x &gt;. Ι</p>
+τελεωτέραν δόξῃ &gt;τὴν ἀσφάλειαν&gt;. |</p>
 <note type="footnote">10 f. 2Kor. 8, 18</note>
 <note type="footnote">9 Paulo &gt; CDe 10 laus + est B 11 evangelio + est De 12 alio
 &gt; K, alio dicitur &gt; AB dicitur + et mr, + nec In 13 ~traditur
@@ -658,37 +660,36 @@ UVY + δὲ dCy, + γὰρ λ 13 ἄνωθεν &gt; Y οὔ τισι τῶν ε�
 <p>&lt;Visum est et mihi assecuto
 a principio omnia diligenter ex
 ordine tibi scribere, optime
-&gt;. Putet aUquis, quod
+Theophile&gt;. Putet aliquis, quod
 <lb n="5"/> ad Theophilum quempiam evangelium
 scripserit.</p>
 <p>Omnes qui nos auditis loquentes,
-si tales fueritis, ut diH-
-gamini a Deo, et vos &gt;
-<lb n="10"/> estis et ad vos evangeHum scri-
-bitur. Si quis &gt; est,
+si tales fueritis, ut diligamini
+a Deo, et vos &gt;theophili&lt;
+<lb n="10"/> estis et ad vos evangelium scribitur.
+Si quis &gt;theophilus&lt; est,
 iste et optimus et fortissimus est,
 hoc quippe significantius graeco
-sermone dicitur: &gt; Nemo
-<lb n="15"/> &gt; infirmus est. Et
+sermone dicitur: &gt;κράτιστος&lt;. Nemo
+<lb n="15"/> &gt;theophilus&lt; infirmus est. Et
 quomodo scriptum est de populo
 Israhel, quando egrediebatur ex
 Aegypto, quod &lt;non fuerit in tri-</p>
 <p>Εἰκὸς δέ ὑπολαμβάνειν τινός, ὅτι
-Θεοφίλῳ τινὶ ἔγραψε τὸ
-εὐαγγέλιον,
-ος εις ην των πιστευσαντων
-Λ·αὶ ζέων τῷ πνεύματι καὶ ἀπλήστως
+Θεοφίλῳ τινὶ ἔγραψε τὸ εὐαγγέλιον,
+ὃς εἶς ἦν τῶν πιστευσάντων
+καὶ ζέων τῷ πνεύματι καὶ ἀπλήστως
 ἔχων περὶ τὰς τοῦ κυρίου
 πράξεις τε καὶ λόγους, ὅνπερ ἐποίει
 ἀσφαλέστερον καὶ τὰ νῦν γραφόμενα.
 Ἀλλὰ καὶ πάντες, ἐὰν τοιοῦτοι
 ὦμεν ὡς ἀγαπᾶσθαι ὑπὸ τοῦ θεοῦ καὶ
-φιλεῖσθαι, x &gt; ἐσμεν. Εἰ δέ
-x &gt;.
-οὐδεὶς γὰρ x &gt; ἀσθενής. Καὶ
+φιλεῖσθαι, &gt;θεόφιλοί&lt; ἐσμεν. Εἰ δέ
+τις &gt;θεόφιλος&lt;, οὗτος καὶ &gt;κράτιστος&lt;·
+οὐδεὶς γὰρ &gt;θεόφιλος&lt; ἀσθενής. Καὶ
 ὥσπερ γέγραπται ἐπὶ τοῦ λαοῦ
 ἐξερχομένου ἐκ τῆς Αἰγύπτου.
-ὅτι 〉οὐκ ἦν ἐν ταῖς φυλαῖς αὐτῶν</p>
+ὅτι &gt;οὐκ ἦν ἐν ταῖς φυλαῖς αὐτῶν</p>
 <note type="footnote">7 gr. vgl. Akt. 18,25 7ff. vgl. Ambros. in Lucam I, 12 (S. 18, 9ff.
 Schenkl) 18 f. Ps. 104 (105), 37</note>
 <note type="footnote">2 omnibus CD 4 putat ADe + et EK 7 audistis E
@@ -715,23 +716,23 @@ x &gt; ε λόγους+ ἔγγραφον ᾔτησεν ἔχειν τὸ εὐ�
 ἐκ γῆς Ε 2 18 ὅτι x &gt; eUV</note>
 
 <pb n="v.9.p.12"/>
-<p>bubus eorum x &lt; : sic audacter
-loquar, quod omnis, qui &lt;
+<p>bubus eorum infirmus&lt; : sic audacter
+loquar, quod omnis, qui &gt;theophilus&lt;
 est, sit robustus, habens
-fortitudineni et robur tam a Deo
+fortitudinem et robur tam a Deo
 <lb n="5"/> quam a sermone ejus, ut cognoscere
 possit eorum verborum,
 quibus eruditus est, veritatem,
-intellegens sermonem evangehi in
+intellegens sermonem evangelii in
 Christo: cui est gloria et imperium
 <lb n="10"/> in saecula saeculorum.
 Amen.</p>
-<p>&lt; , οὕτως εἴποιμι ἄν, ὅτιπᾶς
-x &gt; κράτιστός ἐστιν ἔχων
-τὸ κρότος καὶ τὴν δύναμιν τὴν ἀπὸ
+<p>ὁ ἀσθενῶον&lt;, οὕτως εἴποιμι ἄν, ὅτι πᾶς
+&gt;θεόφιλος&lt; κράτιστός ἐστιν ἔχων
+τὸ κράτος καὶ τὴν δύναμιν τὴν ἀπὸ
 τοῦ θεοῦ καὶ τοῦ λόγου αὐτοῦ·
-καὶ οὕτως ἐπιγνώσεταί τις, 〉περὶ
-ὧν κατηχήθη λόγων τὴν
+καὶ οὕτως ἐπιγνώσεταί τις, &gt;περὶ
+ὧν κατηχήθη λόγων τὴν ἀσφάλειαν&lt;,
 συνεὶς τὸν λόγον τοῦ εὐαγγελίου·
 ἐπαγγέλλεται τοίνυν τῆς
 γνώσεως τὸ βέβαιον, ἵνα, ἅπερ
@@ -1331,7 +1332,7 @@ respergitur, unus locus nec no-
 cere quem poterit nec juvare,
 quia, qui mundum cor habuerit,
 <lb n="15"/>Deum videbit, qui autem non
-taUs fuerit, id quod ahi cernitur
+taUs fuerit, id quod alii cernitur
 non videbit. Tale quid mihi in-
 tehegendum et de Christo, quando
 m corpore videbatur, quod non,
@@ -1365,7 +1366,7 @@ dinem divinitatis iUius contem-</p>
 sit D 9 Et DEe &gt; ABCDK 10 sint] sit De sint + is AB,
 + his K 11 his K 13 quempiam De potuerit E
 mundum A 15 ~ videbit Deum BEK Deum &gt; A
-16 ahi CDEKe] ahis A, ab aho B cernitur ABCE] cermmt DKe
+16 alii CDEKe] aliis A, ab aho B cernitur ABCE] cermmt DKe
 - et E 17/18 inteUege ABEK 18 &gt;Ar Christo
 quando] quondam CDe 19 ~ videb. in eorp. K non] nunc K
 + hoc CDe, hoc vero K
@@ -2000,7 +2001,7 @@ relinquetur fiha Sion sicut tabernaculum in vinea, et ut custodia
 translata est ad nationes, ut ihi concitentur ad zehim. Intuentes
 ergo dispensationem et arcanum Dei, quomodo Israhel abjectus sit
 in salutem nostram, cavere debemus, ne forte et ihi nostri causa
-ejecti sint, et nos majori supphcio digni simus, propter quos et ahi
+ejecti sint, et nos majori supphcio digni simus, propter quos et alii
 <lb n="15"/> derehcti sunt, et nos nihil dignum adoptione Dei et ejus clementia
 fecerimus, qui adoptavit nos et in suos fihos reputavit in Christo
 Jesu: cui est gloria et imperium in saecula saeculorum. Amen.</p>
@@ -2014,7 +2015,7 @@ K 7 cessabit C ~ Christus esse De 8 Rehnquit C sermo
 est AC, scribitur D (spater eingef.) 9 sicut] secuti AK + simt K
 ut] sicut De custodia Ce, cistodiarum c D, custodiarum ABEK
 10 expugnantvir B 11 concit.] continentur C 12 archanima
-ACDK 13 sahite nostra De nostra2 A nostri causa] in pena
+ACDK 13 saliite nostra De nostra2 A nostri causa] in pena
 nostra C 14 et1] ut C maiore B qvios] nos BE simus +
 cumB K 15 sunt] sint et] si A dignum adoptione] ad
 optime dignum B, dign. ad optionem K clementiae K 16 qui]
@@ -2116,7 +2117,7 @@ gelicus cermo describit. Et dif-
 προεφήτευσεν ἡ Ἐλισάβετ καὶ ἐκ
 &gt;πνεύματος ἁγίου ἐλάλησε τὰ ἀναγεγραμμενα.</p>
 <p>Καὶ &gt;ἐλαλήθη ἐν τῇ ὀρεινῇ πάντα
-τὰ ῥήματα ταῦτα〈. Λαληθέντων
+τὰ ῥήματα ταῦτα&lt;. Λαληθέντων
 οὖν αὐτῶν ὡς περὶ θείας συλλή</p>
 <note type="footnote">14ff. Luk. 1, 44
 19 ff. Luk. 1
@@ -2243,13 +2244,13 @@ Salvator dispensationem suam τὴν οἰκονομίαν λανθάνειν 
 λέγω, τὸν μετὰ τὸν μακάριον Πέτρον
 τῆς Ἀντιοχείας δεύτερον ἐπίσκοπον,
 τὸν ἐν τῷ διωγμῷ ἐν Ῥώμῃ
-θηρίοις μαχησάμενον — · 〉καὶ ἔλαθε
+θηρίοις μαχησάμενον — · &gt;καὶ ἔλαθε
 τὸν ἄρχοντα τοῦ αἰῶνος τούτου ἡ
 παρθενία Μαρίας&lt;.</p>
 <p>Ὡς, εἰ μὴ
 ἐγεγόνει ὁ δοκῶν γάμος, οὐκ ἄν αὐτὸν
 ἔλαθεν, ἀλλ' ἔγνω ὁ ἄρχων τοῦ
-αἰῶνος τούτου〈, ὅτι μηδέποτε μετὰ
+αἰῶνος τούτου&lt;, ὅτι μηδέποτε μετὰ
 ἀνδρὸς κοιμηθεῖσα ἡ Μαρία συνέλαβεν
 καὶ ὀφείλει τὸ σύλλημα τοῦτο
 θεῖον εἶναι.</p>
@@ -3184,7 +3185,7 @@ suscipitis. Obsecro vos, Ο
 <lb n="20"/> catechumeni : nohte retractare,
 nemo vestrum formidet et paveat,
 sed sequimini praeeuntem
-Jesum. Ille vos trahit ad salutem,
+Jesum. Ille vos traliit ad salutem,
 tem, congregat in ecclesiam nunc
 <lb n="25"/> quidem super terram, si autem</p>
 <p>τούτου ὁ κατ' αὐτὴν μείζων πιστευθῇ
@@ -3213,7 +3214,7 @@ tem, congregat in ecclesiam nunc
 <note type="footnote">1/2 referuntur De fi ο &gt; ABE 7 cathecumini ABDE,
 C ecclesia CDe 9 himc] hoc E 10 enim &gt;
 domos A 11 sigillatim AB, singulatim C circuivimus Clmn
-15 retractores A 17 vehit BE 19 Ο &gt; ABE 23 trahit &gt;
+15 retractores A 17 vehit BE 19 Ο &gt; ABE 23 traliit &gt;
 23/24 sakitem + qui A 24 congregati E</note>
 <note type="footnote">50, 3 καλῶς — 7 καρποί + 53, –25 Y</note>
 <note type="footnote">1/2 ὁ . . μείζων . . . τοκετός] τὸ μεῖζον dCS κατ' αὐτὴν &gt; λ
@@ -3985,7 +3986,7 @@ omeHa IX. AC</note>
 
 <pb n="v.9.p.67"/>
 <p>Ἐγὼ νομίζω, ὅτι κατὰ τὸν εὐαγγελιστὴν πληρωθέντος τοῦ χρόνου
-τοῦ τεκεῖν〈 τὴν Ἐλισάβετ ἡ Μαρία εἰς τὸν οἶκον  ἀνεχώρησεν·
+τοῦ τεκεῖν&lt; τὴν Ἐλισάβετ ἡ Μαρία εἰς τὸν οἶκον  ἀνεχώρησεν·
 εἰ γὰρ τῷ ἕκτῳ  τῆς Ἐλισάβετ ἀπεστάλη ὁ Γαβριὴλ πρὸς τὴν
 παρθένον εἰς  εὐαγγελιζόμενος αὐτῇ, ἔδραμε δὲ εἰς τὴν
 <lb n="5"/>  πρὸς τὴν ἑαυτῆς συγγενίδα ἡ παρθένος καὶ  ἐκεῖ
@@ -4104,7 +4105,7 @@ populo suo, et suscitavit cornu
 <lb n="15"/> salutis nobis in domo David&lt;
 &gt;de semine David secundum
 natus est Christus.</p>
-<p>Et vere fuit cornu sahitis in
+<p>Et vere fuit cornu saliitis in
 domo , quia prophetia ista
 <lb n="20"/> concinitur : &gt; Vinea enim facta</p>
 <p>καἰ προφητευσαι τα ἀναγεγραμμένας.
@@ -4336,7 +4337,7 @@ C 17 Crebro] Credo 1 18 manibus C 20 et &gt; r 21 praecesserit Ar
 πάντα τὰ ἔθνη k (2. Teil eines Viktor-Schol,, dessen Anfang aber Orig. ist).
 3 μνησθῆναι — 6 ἔθνη nur W 7 Κἄν — τοῦτο] τοῦτο δὲ εἰ καὶ νῦν dCS
 δὲ &gt; S) dUd S 8 τοῦτο— 9 διαθήκης &gt; dCS 13 ὅτι — 14 ῥύονται
-&gt;Χ κaὶ—14ῥύονται〉S 15/16 &gt; epCSUVY 15/16 nach 18
+&gt;Χ κaὶ—14ῥύονται&gt;S 15/16 &gt; epCSUVY 15/16 nach 18
 δὲ akmLW: διὰ τοῦτό φησιν· τοῦ δοῦναι ἡμῖν ἀφόβως (+ καὶ τὰ ἑξῆς W) +
 ἐκ χειρὸς τῶν ἐχθρῶν ἡμῶν ῥυσθῆναι a τοῦ κτλ. &gt; km) 17 Πολλάκις]
 ἐπειδὴ πολλάκις kmW, καὶ ἐπειδὴ (+ δὲ α) πολλ. aS πολλάκις +
@@ -5080,11 +5081,11 @@ dC (wahrsch. Kyrill</note>
 <p>Αὐτοὺς γὰρ ἔδει τὸ &lt; Ἐπὶ γῆς &lt; κατὰ τὴν πρώτην
 οἵτινες ἤμελλον τὴν εἰρήνην ἐπιφωνεῖν παντὶ τῷ τῆς ἐκκλησίας
 <lb n="5"/> πληρώματι. Τὸ δὲ τῶν ποιμένων πρόσωπον καὶ ἡ δι’ ἀποκαλύψεως
-αὐτοῖς γενομένη χαρὰ σημαίνει σαφῶς, ὡς ἐπὶ 〉τὸ πλανεύμενον πρόβατον〈
+αὐτοῖς γενομένη χαρὰ σημαίνει σαφῶς, ὡς ἐπὶ &gt;τὸ πλανεύμενον πρόβατον&lt;
 ἦλθεν ὁ ποιμὴν ὁ .</p>
 <p>Ποιμένας γὰρ οὐδὲν οὕτο,ς εὐφραίνει, ὅς ἡ τοῦ ἀπολωλότος βοσκή-
 ματος εὕρεσις, ὅπερ οὐκ ἦν ἑτέρου τινὸς εὑρεῖν ἢ τοῦ ἀρχιποίμενος
-<lb n="10"/> Χριστοῦ〈 .</p>
+<lb n="10"/> Χριστοῦ&lt; .</p>
 <p>Et haec quidem sint
 dicta simplicius. Ceterum si ad
 secretiorem oportet adscendere
@@ -5124,7 +5125,7 @@ quia B 23/24 ~ pastor esset B 25 Machedoniae D 26 Machedo D
 ὑμνούμενον (+ μυστήριον W), οἵτινες οἵτ.] ἐΠειδὴ S) dCSW ἐΠεῖχον dSW
 τῆς ἐκκλησίας C 2 αὐτοῖς — ποιμέσιν &gt; dCSW Καὶ — εἰκότως &gt;
 μάλα &gt; S 3 Αὐτοὺς — ἔδει] εἰς γὰρ αὐτὸ ἥρμοττε S τὸ — 4
-καὶ πρώτους ἀκούειν τὸ 〉ἐπὶ γῆς εἰρήνη〈, διότι καὶ οἱ πνευματικοὶ ποιμένες W
+καὶ πρώτους ἀκούειν τὸ &gt;ἐπὶ γῆς εἰρήνη&lt;, διότι καὶ οἱ πνευματικοὶ ποιμένες W
 τὴν &gt; dCS 3/4 ἀκούειν &gt; S 4 ἔμελλον VX 5 Τὸ δὲ] ἔτι δὲ
 διὰ + τῆς ~ γενομένη δι’ αὐτοῖς dCSW 6 ὡς] ὅτι S 6/7 ~ ἦλθεν
 προβ. SW 8 εὐφραίνειν οἶδεν dCW, εὐφραίνειν εἴωθεν S</note>
@@ -5160,7 +5161,7 @@ loquitur nobis angelus diaboli.
 Quomodo igitur per sigulos
 homines bini sunt angeh,
 <lb n="30"/> sic opinor et in singuhs dispares</p>
-<p>λέγων· 〉Μὴ φοβεῖσθε· εὐαγγελίζομαι
+<p>λέγων· &gt;Μὴ φοβεῖσθε· εὐαγγελίζομαι
 γὰρ ὑμῖν . Ἀληθῶς
 γὰρ χαρὰ μεγάλη τοῖς οἰκονομοῦσι
 τοὺς ἀνθρώπους γέγονεν, ὅτι Χρι-
@@ -5471,7 +5472,7 @@ pauca, quae non polluerunt vel</p>
 <p>ἀνθρώποις εὐδοξίας εἰρήνηνἐπὶ γῆς
 οὐκ ἔστιν &gt;εὐδοκίας εἰρήνη
 ἀρνεῖται διδόναι τὴν εἰρήνην, ἀλλ
-ἁπλῶς λέγει· 〉οὐκ ἦλθον βαλεῖν εἰρήνην
+ἁπλῶς λέγει· &gt;οὐκ ἦλθον βαλεῖν εἰρήνην
 ἐπὶ τὴν γῆν</p>
 <p>οὐκ εἶπε δέ &gt;εὐδοκίας εἰρήνην
 ἀλλὰ ταῦτό γε εἶπον παρὰ τοῖς ποι-
@@ -5612,7 +5613,7 @@ Domini sui &lt; . Non popuhis</p>
 ζῶν ὁ ἐκ τοῦ οὐρανοῦ καταβὰς καὶ
 δοθεὶς ὑπέρ τῆς τοῦ κόσμου ζωῆς —
 οἷς ἔργον ἐστὶ τὸν οὐράνιον ἄρτον ἐπιζητεῖν τὸν ἀμνὸν τοῦ θεοῦ, τὸν
-αἴροντα τὴν ἁμαρτίαν τοῦ κόσμου〈 καὶ] μυστικῶς καθ’ ἑκάστην ἱερουργού-
+αἴροντα τὴν ἁμαρτίαν τοῦ κόσμου&lt; καὶ] μυστικῶς καθ’ ἑκάστην ἱερουργού-
 μενον κατὰ τὸ μέγα ἔλεος αὐτοῦ];|
 Σπεύοαντες δέ ἦλθον καὶ οὐ βάδην
 οὐδέ ἐκλελυμένως· διὰ τοῦτο εὗρον
@@ -5676,7 +5677,7 @@ sicut igitur &gt;commortui sumus&lt;</p>
 ἁμαρτίᾳ ἀπέθανεν &gt;, οὐχ ὅτι
 τεν — οὐδὲ γὰρ ἁμαρτίαν ἐποίησεν
 οὐδὲ εὑρέθη δόλος ἐν τῷ στόματι
-αὐτοῦ〈 — ἀλλ’ ὅτι] ἀπέθενεν, ἶνα
+αὐτοῦ&lt; — ἀλλ’ ὅτι] ἀπέθενεν, ἶνα
 ἡμεῖς οἱ συναποθανόντες αὐτῷ, αὐτοῦ
 ἀποθανόντος τῇ , μη-
 κέτι ζῶμεν τῇ . Δι’ ὃ λέγεται·
@@ -6474,10 +6475,10 @@ recipiimt — : Si propterea cruentus et tantum judex et cru-</p>
 Ἰωάννην τό· εἰς κρίμα ἐγὼ εἰς τὸν
 κόσμον τοῦτον ἦλθον, ἵνα οἱ μὴ
 βλέποντες βλέπωσι καὶ οἱ βλέπον-
-τες τυφλοὶ γένωνται(· ὥσπερ οὖν &gt;οἱ
-μὴ βλέποντες〈 ἀπὸ τῶν Μνῶν &gt;βλέπουσι &lt; ,
+τες τυφλοὶ γένωνται&lt;· ὥσπερ οὖν &gt;οἱ
+μὴ βλέποντες&lt; ἀπὸ τῶν Μνῶν &gt;βλέπουσι &lt; ,
 καὶ οἱ ἀπὸ τοῦ Ἰσραὴλ
-〉τυφλοὶ γίνονται &lt; , οὕτως ἦλθεν εἰς
+&gt;τυφλοὶ γίνονται &lt; , οὕτως ἦλθεν εἰς
 πτῶσιν καὶ άνάστασιν &lt; ἡμῶν. Οἱ
 ἑστηκότες πεπτώκασι καὶ οἱ πεπτω-
 κότες ἀνέστησαν Χριστοῦ ἐπιδημήσαντος.
@@ -6716,7 +6717,7 @@ interpres est, dicit nequaquam eum cadere, qui ante non
 Salvator advenerit, nec non et eum, qui consurgat. Nam
 utique ille consurgit, qui ante
 corruerat. Videndum est itaque,
-ne forte Salvator non ahis atque
+ne forte Salvator non aliis atque
 <lb n="15"/> aliis in ruinam &lt; venerit et in
 sed eisdem et in
 ruinam et in resurrectionem &lt;
@@ -6836,13 +6837,13 @@ mater est, signum est, cui contradicitur : Marcionitae contradicunt
 huic signo et aiunt penitus eum de muhere non esse
 <lb n="15"/> generatum ; Hebionitae contradicunt signo, dicentes ex viro et
 muhere ita natum esse, ut nos quoque nascimur. Habuit corpus
-humanum, et hoc signum est, cui contradicitur : ahi enim dicunt
-eum venisse de caehs, ahi tale, quale nos, corpus habuisse, ut
+humanum, et hoc signum est, cui contradicitur : alii enim dicunt
+eum venisse de caehs, alii tale, quale nos, corpus habuisse, ut
 per simihtudinem corporis etiam nostra corpora redimeret a peccatis
 <lb n="20"/> et daret nobis spem resurrectionis. Resurrexit a mortuis,
 et hoc signum est, cui contradicitur : quomodo resurrexerit,
 utrum ipse et tahs, quahs mortuus est, an certe in mehoris substantiae
-corpus resurrexerit ; et est infinita contentio, ahis dicentibus:
+corpus resurrexerit ; et est infinita contentio, aliis dicentibus:
 fixuram clavorum Thomae monstrayit in manibus suis,</p>
 <p>μη πέσῃ η πορνεια, η σωφροσυνη
 οὐκ ἀνίπταται, ἐὰν μὴ ἡ ἀλογία
@@ -6883,7 +6884,7 @@ cui contradicitur,  <milestone unit="altpage" n="149"/>  non quo contradicant hi
 <lb n="10"/> eum — nos quippe omnia scimus vera esse, quae scripta sunt —
 sed quia apud incredulos universa, quae de eo scripta sunt, signum
 sit, cui contradicitur.</p>
-<p>Deinde Simeon ait : et tuam ip- | 〉καὶ 
+<p>Deinde Simeon ait : et tuam ip- | &gt;καὶ 
 <lb n="15"/> Quis est iste gladius, qui non aliorum
 tantum, sed etiam Mariae
 cor pertransiit ? Aperte scribitur,
@@ -7176,7 +7177,7 @@ Praetermisit hoc loco Lucas, quae a Matthaeo satis exposita noverat Dominum
 a parentibus esse delatum defunctoque Herode sic demum GaUlaeam reversuxn
 Nazareth civitatem suam inhabitare coepisse. Solent enim evange-
 Hstae singuH sic omittere quaedam, quae vel ab aliis commemorata viderint,
-vel ab ahis commemoranda in spiritu praeviderint, ut continuata
+vel ab aliis commemoranda in spiritu praeviderint, ut continuata
 <lb n="35"/> suae narrationis serie quasi nuHa praetermisisse videantvir, quae tamen
 alterius evangeHstae considerata scriptura quo loco transiHta fuerint, dihgens
 lector inveniat. x &gt;Puer autem crescebat et confortabatur plenus sapientia,
@@ -8259,7 +8260,7 @@ regionem circa Jordanem A 9 circumire E 10 vicinia e Jordanis
 CDe 12 essent AD lavacr. aquae] lavandum aqua AB 15 largo]
 arguto B 16 Domin. &gt; C est et Dominus B noster + et E
 17 quem] quo ADE 17/18 aquam veram, aquam salutarem C, quam veram
-aquam sahitarem De, aqua veram aquam salvatorem E vera — salutari
+aquam saliitarem De, aqua veram aquam salvatorem E vera — salutari
 &gt; B 18 remissione A 19 peccat. + in De baptisma &gt;
 20 praedicat e Venite C cathecumini BA, catecumini CD
 21 ut] et E 21/22 u. 23 remissione C 24 accepit B</note>
@@ -9301,7 +9302,7 @@ ad preces sancti viri angelos, quos Giezi privis non videbat,
 <lb n="15"/> intuitus est. Haec idcirco diximus, ut ostenderemus publicanos
 doceri a Joanne, non solum eos, qui rei publicae vectigalibus
 serviunt, sed etiam illos, qui veniebant ad paenitentiam et
-alii erant a corporahbus pubhcani, sicut et ahi milites, qui egrediebantur
+alii erant a corporahbus pubhcani, sicut et alii milites, qui egrediebantur
 ad baptismum paenitentiae. Venit enim non Joannes
 <lb n="20"/> et prophetae tantum, sed etiam ipse Salvator et hominibus et
 angehs et virtutibus ceteris salutarem paenitentiam praedicare,
@@ -9513,7 +9514,7 @@ Gahlaeo. Denique in tantam quidam dilectionis audaciam proruperunt,
 <lb n="5"/> ut nova quaedam et inaudita super Paulo monstra confingerent.
 Ahi enim aiunt hoc, quodscriptum  <milestone unit="altpage" n="182"/>  est &gt; sedere a dextris Salvatoris
 et sinistris &lt;, de Paulo et de Marcione dici, quod Paulus sedeat sedeat &gt;a dextris &lt;,
-Marcion sedeat &gt; a sinistris &lt; Porro ahi, legentes : &gt; mittam vobis
+Marcion sedeat &gt; a sinistris &lt; Porro alii, legentes : &gt; mittam vobis
 advocatum, Spiritum veritatis &lt;, nolunt intellegere tertiam personam
 <lb n="10"/> a Patre et Fiho &lt;diversam &gt; et divinam subhmemque naturam, sed
 apostolum Paulum. Nonne tibi hi omnes videntur plus amasse, quam
@@ -9524,7 +9525,7 @@ enim, dum plus nos dihgunt, quam meremur, haec jactitant et loquuntur
 nostra non recipit. Ahi vero tractatus nostros calumniantes ea
 sentire nos criminantur, quae nunquam sensisse nos novimus.
 Sed neque hi, qui plus dihgunt, neque illi, qui oderunt, veritatis
-regulam tenent, et ahi per dilectionem, ahi per odium mentiuntur.
+regulam tenent, et alii per dilectionem, alii per odium mentiuntur.
 <lb n="20"/> Unde oportet caritati quoque frena imponere et tantum ei va-
 gandi permittere hbertatem, quantum in praerupta non corruat.
 Scriptum est in Ecclesiaste: &gt; ne sis justus multum neque amphora
@@ -9537,7 +9538,7 @@ Antiqu. 18, 1, 1 —6; Bell. jud. 2, 8, 1 6 ff vgl. Matth. 20, 21 8 f Joh.
 14,16.17 22 f. Pred. Sal. 7, 17 (16)
 2 quia] ne forte C etiam &gt; C etiam — 3 Samar.]
 etiam de eo B 3 Dositheo] eo ABE, Dositeo C Samaritarum De
-heresiarche ABE. heresiarcho D, heresiarce C 3 ahi] illi E etiam &gt;
+heresiarche ABE. heresiarcho D, heresiarce C 3 alii] illi E etiam &gt;
 4 quidem D audaciam + usque C 5 uti BE monstrata D, mostra C
 6 aiimt] dicuntB SalvatoremA, SalvatoriB. SalvatoreE, -fdiciB 7 et 1
 + aBC &gt; DE de2 &gt;ACE MartioneC dictumB sedeat &gt;ABE] sedet r
@@ -10777,7 +10778,7 @@ rex justis Christus. Sciensque diabolus ad hoc venisse Christum,
 sub eo erant, inciperent esse sub
 Christo, &gt;ostendit  <milestone unit="altpage" n="199"/>  ei
 regna mundi &lt; et hominum
-saecuh, quomodo ahi regnentur a
+saecuh, quomodo alii regnentur a
 <lb n="10"/> fornicatione, alii ab avaritia, illi
 populari rapiantur aura, hi formae
 capiantur illecebris. Neque
@@ -11827,7 +11828,7 @@ est, propter perditas oves &lt;
 qui &gt;de Hierusalem descendit
 Hiericho &lt;, quia voluit ipse
 propterea &gt;in latrones
-Latrones autem nulli sunt ahi,
+Latrones autem nulli sunt alii,
 <lb n="25"/> nisi de quibus Salvator ait : &gt;omnes,
 qui ante me  <milestone unit="altpage" n="214"/>  venerunt,
 fures fuerunt et latrones &lt;.
@@ -12151,7 +12152,7 @@ virtutis, si oves gregis sibi crediti fuerint custoditae, ita intellege et
 de angehs. Ignominia angelo est, si homo sibi creditus fuerit, si
 peccaverit, ut e contrario gloria est angelo, si creditus sibi saltem
 minimus in ecclesia fuerit, si profecerit. Videbunt enim non ahquando,
-<lb n="25"/> sed &gt;semper faciem Patris, qui in caelis est &lt;,  <milestone unit="altpage" n="219"/>  cum ahi
+<lb n="25"/> sed &gt;semper faciem Patris, qui in caelis est &lt;,  <milestone unit="altpage" n="219"/>  cum alii
 non videant. Secundum meritum enim eorum, quorum angeh sunt,
 aut semper aut nunquam, vel parum vel plus, faciem Dei angeh
 contemplabuntur. Cujus rei notitiam ad hquidum Deus noverit,
@@ -12292,7 +12293,7 @@ te judici ab adversario praeparatum,
 postea frustra conaberis.
 &gt;Da &gt;ergo &lt;operam, ergo libereris &lt; ut
 <lb n="10"/> adversario tuo sive a principe, ad
-quem te trahit adversarius. &gt;Da
+quem te traliit adversarius. &gt;Da
 operam &lt;, ut habeas
 justitiam, fortitudinem, temperantiam,
 et tunc complebitur:
@@ -12317,7 +12318,7 @@ sum via &lt;, stetisse non sufficit, sed
 τοῦ ἀντιδίκου σου ἐπ᾿ ἄρχοντα &lt;
 ἀπελθεῖν &gt;πρὸς τὸν κριτήν(,
 ἄξιον γενέσθαι τῆς φυλακῆς, ἕως
-ἔτι ὁδεύεις, 〉δὸς ἐργασίαν ἀπηλλάχθαι &lt;
+ἔτι ὁδεύεις, &gt;δὸς ἐργασίαν ἀπηλλάχθαι &lt;
 &gt; ἀπὸ τοῦ ἀντιδίκου ἢ ἀπὸ
 τοῦ χριτοῦ &lt;, πρὸς ὃν σύρει σε
 ἀντίδικος·</p>
@@ -12347,16 +12348,16 @@ Quomodo E 20/21 ad princ. &gt; A 22 quid] quod Imn 24 et1 &gt;
 13 δικαιοσ. — 14 σοφ] καὶ τὰς λοιπὰς ἀρετάς C ἀνδρίαν Κ1 σου &gt;</note>
 
 <pb n="v.9.p.212"/>
-<p>ut ab adversario &gt;libereris &lt;, quae te sequantur, ausculta. &gt;Trahit
+<p>ut ab adversario &gt;libereris &lt;, quae te sequantur, ausculta. &gt;Traliit
 ad judicem &lt; adversarius sive princeps, cum te susceperit ab
-&gt;trahit te ad
-Quam elegans sermo &gt;trahit &lt;,
+&gt;traliit te ad
+Quam elegans sermo &gt;traliit &lt;,
 <lb n="5"/> ostendat quodammodo retractantes
 et nolentes ad condemnationem
-trahi et ire compelli! Quis
+tralii et ire compelli! Quis
 enim homicida concito gradu pergit
 ad judicem ? Quis gaudens ad condemnationem suam ire festinat,
-<lb n="10"/> et non invitus trahitur ac repugnans ? Scit enim se ad hoc ire,
+<lb n="10"/> et non invitus traliitur ac repugnans ? Scit enim se ad hoc ire,
 ut sententiam mortis accipiat. &gt;Ne forte trahat te ad judicem &lt;.  <milestone unit="altpage" n="222"/> 
 Quis, putas, iste &gt;judex &lt; est ? Ego nescio aUum judicem nisi
 nostrum Jesum Christum, de quo et ahbi dicitur: &gt;statuet
@@ -12381,7 +12382,7 @@ plura persequi? Unusquisque pro quahtate et quantitate peccati
 <note type="footnote">13f. Matth. 25, 33 14ff. Matth. 10, 32. 33 22ff. vgl. Luk. 7, 41. 42
 25 Matth. 18, 24
 1 quae — sequantur] qviis sit iste et quantus ABE 2 advers. — 3 judicem &gt;
-4 sermo] verbum Ir trahit + inquit B 5 ostendit B pertractantes D
+4 sermo] verbum Ir traliit + inquit B 5 ostendit B pertractantes D
 6 contempnationem E 7 trahere E et &gt; ire &gt; 9 suam] sui Aln
 10 et] ut BE trahatur B ~ ad hoc se A ~ ire adhocBE 11 &gt; E
 excipiatAB tradat ACDE 12 &gt; ABE 13 nostrum] meum DEe
@@ -12417,7 +12418,7 @@ creditum sit et quid lucri quidve detrimenti fecerimus, quis nostrum
 acceperit mnam, quis unum talentum, quis duo, quis quinque.
 <lb n="20"/> Quid necesse est plura rephcare, cum hoc in commune dixisse sufficiat
 reddituros nos esse rationem et, si debitores inventi
-fuerimus, trahi ad judicem et a judice exactori tradi ? Singuh
+fuerimus, tralii ad judicem et a judice exactori tradi ? Singuh
 exactores proprios habemus, omnis vero multitudo pluribus traditur,
 secundum id, quod in Isaia scriptum est: &gt;populus
 <lb n="25"/> meus, exactores vestri spohant vos et, qui potentes sunt, dominantur
@@ -12438,7 +12439,7 @@ C 11 condemn.] damnatur De, contempnatur AB 12 mna] mina BE
 reddere C Supp.] Sed putanda C Supp. — 16 est2 &gt; E, — 16 rationis
 B 16 ~ nobis omnibus A ratio] gratia De 18 ~ sit cred. C
 sit] est De quis] qui e 19 minam BE 20 Quid &gt; De] Nec
-Necesse + non De repHcare] indicare De 21 nos] non r 22 trahi]
+Necesse + non De repHcare] indicare De 21 nos] non r 22 tralii]
 tradi BDE 23 exauctores A propr.] singulos C 24 id &gt; C 25 exauctores
 A (23 u. 26 ist exauct. corr. A!) vos] nos B 26 vestri] nostri B
 27 dixer.] vixerimus De Servavi] servabo De


### PR DESCRIPTION
Found a handful of incorrectly OCR'd sections in 016, and figured it would be a good idea if it was as clean as possible for the purposes of the automatic alignment we'll be trying. I've corrected (by hand) all the errors in the first homily, but there exist a large number more throughout the document, which is worth noting. It seems the bilingual text was a bit of a problem, as well as significant use of &lt; and &gt; as editorial marks.