### PR TITLE
Issue #290, chapter divisions and encoding critical punctuation in tlg2018.tlg010.opp-ger1

### DIFF
--- a/data/tlg2018/tlg010/tlg2018.tlg010.opp-ger1.xml
+++ b/data/tlg2018/tlg010/tlg2018.tlg010.opp-ger1.xml
@@ -75,6 +75,7 @@
 </profileDesc>
 <revisionDesc>
   <change who="Jack Duff" when="2016-06-21">Corrected metadata, expanded pb, removed lat and grc tag and replaced with ger, added ref, corrected book numbering.</change>
+  <change who="Jack Duff" when="2016-07-28">Completed chapter numbering, changed roman num. to arabic, OCR correction, encoding critical punctuation.</change>
 </revisionDesc>
 </teiHeader>
   <text>
@@ -86,20 +87,21 @@
 
 <pb n="v.3.pt.2.p.39"/>
 <head>Das erste Buch des Cäsareensers Eusebius über die Theophanie.</head>
-<note type="marginal">Σ 1</note> <p>Ι. Diejenigen, welche sagen von der Herstllung der ganzen weiten
+<div type="textpart" subtype="chapter" n="1">
+<milestone unit="altnumbering" n="1"/> <p>Diejenigen, welche sagen von der Herstllung der ganzen weiten
 und schönen Welt und non dem manningachen und reich zusammengstetzten
-Bestande Himmels und der Erden, daβ sie keinen Anfang und <lb n="5"/>
-Keinen Verwalter habe, und daβ sie ohne Herr und ohne Voersehung
+Bestande Himmels und der Erden, daß sie keinen Anfang und <lb n="5"/>
+Keinen Verwalter habe, und daß sie ohne Herr und ohne Voersehung
 Planlos und aufs Geratewohl und durch einen unverständigen Zufall, der
 Sich grade ereignete, von selber entstand, sind vollkommen Frevler
 Und gottlose. Die daher aus (unsern) Göttlichen Versammlunge aus
-Gestoβen und von unsern heiligen Tempeln ferngehalten warden sollen, <lb n="10"/>
+Gestoßen und von unsern heiligen Tempeln ferngehalten warden sollen, <lb n="10"/>
 Geziemenderwiese, deswegen weil auch sie weder ein Haus herstellen
 Können ohne Überlegung und Fürsorge, noch ein Schiff schön zusammengepflockt
 Warden kann ohne einen Schiffsmann, noch ein Gewand gewebt 
 Warden kann ohne bie Webkunst, noch eine Satdt gebaut warden kann, wenn
 Die Wisheit des Baumeirsters nicht voerhanden ist. Indem sie dies zugestehen, <lb n="15"/>
-Weiβ ich nicht, in welchem Verstandeswahnsinn sie nicht achten
+Weiß ich nicht, in welchem Verstandeswahnsinn sie nicht achten
 Auf die Bahnen der Sonne, die nach ihrer Art, noch auf die Wechsel des
 Mondes, die nach iherer Ordnung, noch auf die Reigen der Sterne, die
 Nach ihere Regel (geschehen), noch auf das Kreisen der Himmelsgewölbe,
@@ -114,21 +116,23 @@ Noch auf die Formen des leibes, noch auf seine Glieder, die gut *an ihren
 <note type="footnote">11 ff. vgl. Praep. VII 33 17 ff. vgl. Dwm. IV 58 laus 206 27 ff.</note>
 <note type="footnote">1 Die Überschrift rührt kaum von Eusebius her 21 vgl. L 208 26 ἔαρ δὲ....
 ἰσορρόποις ταλαωτεύσας ζυγοῖς 23 <foreign xml:lang="abbr">ABBREV</foreign> 
-<foreign xml:lang="abbr">ABBREV</foreign> 182 5 =εἰς μαχρὸν αἰῶνα 27 ,, noch auf die Glieder des
-Leibes noch auf seine Formen “(oder,, Farben“) Σ hat vermutlich umgestellt, wie
-Oft; oier ungeschickt | ,,und an“ Σ streiche <foreign xml:lang="abbr">ABBREV</foreign></note>
+<foreign xml:lang="abbr">ABBREV</foreign> 182 5 =εἰς μαχρὸν αἰῶνα 27 „noch auf die Glieder des
+Leibes noch auf seine Formen “(oder „Farben“) Σ hat vermutlich umgestellt, wie
+Oft; oier ungeschickt | „und an“ Σ streiche <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.40"/>		
 Platz gestellt sind — mit ihren Augen sehen sie und mit ihren Händen
-tasten sie, was, wie man sagt, selbst den blinden klar ist, so daβ sie <note type="marginal">Σ 2</note>
+tasten sie, was, wie man sagt, selbst den blinden klar ist, so daß sie <milestone unit="altnumbering" n="2"/>
 mit gottlosen Worten und im Frevel länsterlichen Sinnes wähnen, es
 gebe weder ein Werk der Weisheit, wie sie sagen, noch des Wortes
 <lb n="5"/> Gottes und der Vorsehung, sondern (nur) des unverständigen, zufälligen
 *Verhängnisses, das planlos und aufs Geratewohl von irgendwoher sich
 ereigne. Eben diese also sollen als vollkommen Gottlose von dem
 Verkehr mit den Gottesfürchtigen und von dem Hören (des) göttlichen
-(Wortes) weit weggetriebe warden.</p>
-<lb n="10"/> <p>II. Die Menge der Polytheisten aber scheint mir auf der anderen
+(Wortes) weit weggetriebe warden.</p></div>
+	   
+<div type="textpart" subtype="chapter" n="2">
+<lb n="10"/><p>Die Menge der Polytheisten aber scheint mir auf der anderen
 Seite, die sich der ersten gegenü	berreiht, einen anderen Irrtum nach
 Art der Kinder in ihrem Denken begangen zu haben. Diejenigen, welche
 die Verehrung des Weltschöpfers und des Allenkers, des Gottes, der
@@ -140,22 +144,22 @@ Götter genannt haben, (Dinge), die niemals wären, noch geworden wären,
 noch genannt würden, wenn nicht der Weltschöpfer, das Wort Gottes
 <lb n="20"/> (wäre), der ihr Werden wollte —, *sie scheinen mir nicht besser als
 diejenigen, welche den Baumeister der vorzüglichen Arbeiten in den
-Königshäusern auβer acht lassen und (statt dessen) die *Dachbalken und die Wände und die *vielfarbigen und *vielblumigen Bilder, die an
+Königshäusern außer acht lassen und (statt dessen) die *Dachbalken und die Wände und die *vielfarbigen und *vielblumigen Bilder, die an
 ihnen (hängen), und die goldbunten Schnitzwerke und die Steinskulpturen
 <lb n="25"/> anstaunen und eben diesen (Dingen) das Lob der Weisheit ihres Künstlers
 beilegen, während sie nicht diesen sichtbaren (gegenständen), sondern
 nur dem, der ihr Baumeister ist, die Ursache ihres Staunens zuschreiben
-und bekennen sollten, daβ Werke der Weisheit die moisten seien, (daβ)
+und bekennen sollten, daß Werke der Weisheit die moisten seien, (daß)
 <note type="footnote">12—s. 48, 9 = Laus 225 27–232 3</note>
-<note type="footnote">6 <foreign xml:lang="abbr">ABBREV</foreign> wird hier wie Σ 15 51 Αdjektivum sein, also: ,,einen unverständigen
-Gegensatz des zufalls, der planlos‘‘. . . Aber lies <foreign xml:lang="abbr">ABBREV</foreign> SchulthebB. Ber-
+<note type="footnote">6 <foreign xml:lang="abbr">ABBREV</foreign> wird hier wie Σ 15 51 Αdjektivum sein, also: „einen unverständigen
+Gegensatz des zufalls, der planlos“. . . Aber lies <foreign xml:lang="abbr">ABBREV</foreign> SchulthebB. Ber-
 mutlich ἀλόγιστος φορὰ τυχῆς. Praep. VII 106: μὴ γὰρ εἰκῆ ὡς ἔτυχε μηδ’
 αὐτομάτῳ καὶ ἀλόγῳ φορᾷ συνεστάωαι τὸν . . . . . διάκοσμον 19 εἰ μὴ τῷ
-κοσμοποιῷ τοῦ θεοῦ λόγῳ παρέστη L 20 ,,und sie‘‘ str. <foreign xml:lang="abbr">ABBREV</foreign> 22 1. <foreign xml:lang="abbr">ABBREV</foreign>
-Bernstein 23 1. <foreign xml:lang="abbr">ABBREV</foreign> Hoftmann 24 ,,die
-goldbunten Dächer‘‘ Σ vermutlich = χρυςόφοφά τε ποικίλματα, aber vgl. xrysqo-
-φορά τε δαιδάλματα Ηkl χρυςόροφα L 25 ,,Lob‘‘] εὐηγορίαν Σ ἐπηγορίαν L
-28 ,,daβ viele Werke der Weisheit seien‘‘ Σ aber vgl. Fortsetzung und σοφίας
+κοσμοποιῷ τοῦ θεοῦ λόγῳ παρέστη L 20 „und sie“ str. <foreign xml:lang="abbr">ABBREV</foreign> 22 1. <foreign xml:lang="abbr">ABBREV</foreign>
+Bernstein 23 1. <foreign xml:lang="abbr">ABBREV</foreign> Hoftmann 24 „die
+goldbunten Dächer“ Σ vermutlich = χρυςόφοφά τε ποικίλματα, aber vgl. xrysqo-
+φορά τε δαιδάλματα Ηkl χρυςόροφα L 25 „Lob“] εὐηγορίαν Σ ἐπηγορίαν L
+28 „daß viele Werke der Weisheit seien“ Σ aber vgl. Fortsetzung und σοφίας
 ἔργα τὰ πολλὰ εἶναι L</note>
 
 <pb n="v.3.pt.2.p.41"/>
@@ -164,14 +168,18 @@ Von unmündigen Kindern also sind sie durchaus in nichts verschieden,
 Ebensowenig (wie) diejenigen, welche die siebensaitige Zither, eben das
 Musikinstrument, aber keineswegs den, der dessen Zusammensetzung erfunden
 Hat und dessen kundig ist, und seine Weisheit anstaunen, oder <lb n="5"/>
-(wie) diejenigen, welche den in Kriegen tapferen (Mann) auBer acht
+(wie) diejenigen, welche den in Kriegen tapferen (Mann) außer acht
 Lassen, (wohl) aber seine Lanze und seinen Schild mit Siegeskränzen
 schmücken, oder (wie) diejenigen, welche in gleicher Weise wie den
 GroBkönig, der die Ursache für die groBe und königliche Stadt ist,
 (auch) die Märkte und StraBen, die Gebäude, die seelenlosen Tempel <lb n="10"/>
-<note type="marginal">Σ 3</note> und Gymnasien ehren während sie nicht die Säulen noch die Steine,
+<milestone unit="altnumbering" n="3"/> und Gymnasien ehren während sie nicht die Säulen noch die Steine,
 Sondern den groBen Schöpfer und Gesetzgeber dieser weisheitsreichen
-Dinge anstaunen sollten. III. DemgemäB aber dürfen wir auch als Ursache
+Dinge anstaunen sollten.</p>
+</div>
+	   
+<div type="textpart" subtype="chapter" n="3">
+<p>DemgemäB aber dürfen wir auch als Ursache
 Von eben diesem Ganzen, das man mit leiblichen Augen sieht,
 Weder Sonne noch Mond noch ein anderes (Gestirn) von denen am <lb n="15"/>
 Himmel setzen, sondern wir müssen bekennen, daB sie alle Werke der
@@ -187,13 +195,16 @@ Die äuBere Bedeckung seines. Gewandes *weise nennt, noch <lb n="25"/>
 Die Geräte im Hause weise, noch die GefäBe, die zum Dienst der Philosophen
 (bestimmt sind), sondern jeder, der Verstand hat, bewundert die
 Verborgene, unsichtbare Intelligenz, die in dem Menschen ist.</p>
-<p>IV. So sollen wir den auch vielmehr vor den sichtbaren Schmuckgegenständen
+</div>
+	   
+<div type="textpart" subtype="chapter" n="4">
+<p>So sollen wir den auch vielmehr vor den sichtbaren Schmuckgegenständen
 Der ganzen Welt, die körperlich und au seiner ὕλη gemacht <lb n="30"/>
 sind, das verborgene, unsichtbare Wort, den Schöpfer und
 Schmuckwart der (Ur) bilder des Alls bewundern, (ihn), der der eingeborne
 Logos Gottes ist, den der jenseits von aller und über aller οὐσία
 <note type="footnote">5 ἐπιστήμονα τῆς σοφίας L. Streicht man das <foreign xml:lang="abbr">ABBREV</foreign> „und“ vor <foreign xml:lang="abbr">ABBREV</foreign>, so
-Kann man übersetzen, „wegen seiner Weisheit“ 23 επεὶ καὶ &lt;ἐπὶ&gt; ἀνθρώπου
+Kann man übersetzen, „wegen seiner Weisheit“ 23 επεὶ καὶ <add>ἐπὶ</add> ἀνθρώπου
 σώματι οὐδεὶς πώποτε . . . . ὀφθαλμοὺς ἢ . . . . περιβολὴν σοφὴν ἀνηγόρευσεν L
 (ἐπὶ + Hkl) 25 „Weisheit“ Σ σοφήν L, lies <foreign xml:lang="abbr">ABBREV</foreign> 26 οὐδὲ σοφὰ τῆς
 Οἰκίας τὰ ἔπιπλα οὐδὲ φιλοςόφου τὰ ὑπηρετικὰ σκεύη L, τ. φ. &lt;Wilamowitz.
@@ -201,8 +212,11 @@ Heikel möchte unter σκεύη die „Sklaven“ verstehen</note>
 
 <pb n="v.3.pt.2.p.42"/>
 (Stehende) Schöpfer des Alls aus sich wie einen Lichtstrahl aus seiner
-Gottheit gezeugt und zum Führer und Lenker dieses Alls eingesetzt hat.
-V. Denn weil es unmöglich war, daß die flüssige οὐσία der Körper und
+Gottheit gezeugt und zum Führer und Lenker dieses Alls eingesetzt hat.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="5">
+<p>Denn weil es unmöglich war, daß die flüssige οὐσία der Körper und
 die Natur der vernünftigen Wesen, die jetzt geworden *sind, sich dem
 <lb n="5"/> Allenker Gott nahte wegen der Größe (ihres) Mangels an Gutem —
 den er war ein Sein, das jenseits und oberhalb von allem (ist,), das
@@ -212,7 +226,7 @@ aber existierte nicht und aus dem Nichts brachte er sie hervor, sehr
 <lb n="10"/> verschieden und sehr weit entfernt von der Natur des Seins — so stellate
 daher mit Recht der an allem Guten reiche Gott des Alls zuvor ein Mittleres
 auf: die göttliche kraft seines Eingebornen, die allem genügt, die vor-
-<note type="marginal">Σ4</note>
+<milestone unit="altnumbering" n="4"/>
 züglich genau and nah emit dem Nater redet und innerhalb von ihm
 <lb n="15"/> niedrigt und denen gleich wird an Gestalt, die von der Spitze fern
 bleiben. Denn auf andere Weise war es weder ehrbar noch gerecht,
@@ -221,22 +235,26 @@ gänglicher ὕλη und mit einem Körper vermischte. Deswegen drange der
 göttliche Logos 9unvermerkt) dazwischen in das All ein, band die Zügel
 <lb n="20"/> des Alls zusammen und führt und trägt (es) dahin durch göttliche, un-
 körperliche Kraft, indem er es allweise lenkt, wie es ihm gut zu sein
-scheint. VI. Der Beweis der Rede aber ist klar. Denn wenn für sich
+scheint.</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="6">
+<p>Der Beweis der Rede aber ist klar. Denn wenn für sich
 (existieren) die Teile der Welt, die wir gewohnt sind, die Ur-στοιχεῖα
 des Alls zu nennen: Erde, Wasser, Luft und Feuer, *die (ja) aus ver-
 <lb n="25"/> wirrter Natur bestehen, was wir auch mit unsern Augen sehen, und wenn
 es (ferner) Eine οὐσία des Alls gibt, welche *diejenigen, die hierin er-
-fahren sind, ,,Aufnehmerin des Alls“, ,,Mutter“ und ,,Amme“ zu nennen
-<note type="footnote">1 vgl. Hebr 13 7 vgl. I Tim 616 11 ,,ein Mittleres — 16 fern bleiben“
+fahren sind, „Aufnehmerin des Alls“, „Mutter“ und „Amme“ zu nennen
+<note type="footnote">1 vgl. Hebr 13 7 vgl. I Tim 616 11 „ein Mittleres — 16 fern bleiben“
 = Dem. IV 63 27 vgl. Platon Tim 51. 52</note>
-<note type="footnote">4 ,,die Natur . . . . , die jetzt geworden ist“ Σ, aber τήν τε τῶν ἄσρι γενο-
-μένων λογικῶν φύσιν l. Lies <foreign xml:lang="abbr">ABBREV</foreign> 7 ,,stolzem . . . . desgleichen es nicht
-gibt“] ἀπρόσιτον L 13 ,,und innerhalb von seiner Verborgenheit empfangt“
-(= ἀπολαβοῦσαν) Σ εἴσν τε αὐτοῦ τῶν ἀποσςήτων ἀπολαύουσαν L 20 ,,band
+<note type="footnote">4 „die Natur . . . . , die jetzt geworden ist“ Σ, aber τήν τε τῶν ἄσρι γενο-
+μένων λογικῶν φύσιν l. Lies <foreign xml:lang="abbr">ABBREV</foreign> 7 „stolzem . . . . desgleichen es nicht
+gibt“] ἀπρόσιτον L 13 „und innerhalb von seiner Verborgenheit empfangt“
+(= ἀπολαβοῦσαν) Σ εἴσν τε αὐτοῦ τῶν ἀποσςήτων ἀπολαύουσαν L 20 „band
 die Zügel des Alls zusammen mit göttlicher, unkörperlicher Kraft und führt und
 bringt indem“ . . . Σ ἡνίας τοῦ παντὸς ἐνδηςάμενος ἀσωμάτῳ καὶ θεϊκῇ δυνάμει
 ἄγετ καὶ φέρει L. Also gehört das <foreign xml:lang="abbr">ABBREV</foreign> vor <foreign xml:lang="abbr">ABBREV</foreign> statt vor <foreign xml:lang="abbr">ABBREV</foreign> 24 Statt
-<foreign xml:lang="abbr">ABBREV</foreign> ,,und aus“ lies <foreign xml:lang="abbr">ABBREV</foreign> SchultheB 25 εἰ μία τοῖς περὶ ταῦτα δεινοῖς ὀνομάζειν
+<foreign xml:lang="abbr">ABBREV</foreign> „und aus“ lies <foreign xml:lang="abbr">ABBREV</foreign> SchultheB 25 εἰ μία τοῖς περὶ ταῦτα δεινοῖς ὀνομάζειν
 φίλον L 26 lies <foreign xml:lang="abbr">ABBREV</foreign> statt <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.43"/>
@@ -245,24 +263,56 @@ und Vernunft (ist) — woher, würde jemand sagen, hat sie (den) die
 Ordnung, die in ihr ist? Woher der Unterschied der στοιχεῖα? Woher
 der (Zusammen)lauf der gegensätzlichen (Elemente) zur Einheit? Wer
 hat befohlen, daß das schwere στοιχεῖον der Erde oben auf der feuchten <lb n="5"/>
-οὐσία reite? VII. Wer hat die nach unten fliessende Natur der Wasser
-umgekehrt und sie zurückgebracht zur Höhe durch die Wolken? VIII.
-Wer hat die Kraft des Feuers gefesselt, so daß es ins Holz hineinkriecht,
+οὐσία reite?</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="7">
+<p>Wer hat die nach unten fliessende Natur der Wasser
+umgekehrt und sie zurückgebracht zur Höhe durch die Wolken?</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="8">
+<p>Wer hat die Kraft des Feuers gefesselt, so daß es ins Holz hineinkriecht,
 und hat sie gemischt mit dem, was seiner Natur nach ihr gegensätzlich
-ist? IX. Wer hat die kalte Luft mit warmer Kraft vermengt, sie aus <lb n="10"/>
-dem Kampf miteinander befreit und in Liebe versöhnt? X. Wer hat
+ist?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="9">
+<p>Wer hat die kalte Luft mit warmer Kraft vermengt, sie aus <lb n="10"/>
+dem Kampf miteinander befreit und in Liebe versöhnt?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="10">
+<p>Wer hat
 das sterbliche Geschlecht mit der Art der Fortpflanzung ausgesonnen
-und zur langen Ewigkeit unsterblichen Lebens hinausgeführt? XI. Wer
+und zur langen Ewigkeit unsterblichen Lebens hinausgeführt?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="11">
+<p>Wer
 hat so das Männliche gebildet, die Gestalt des Weiblichen gemacht und
 beide zu Einer Harmonie vereinigt und Einen Anfang der Geburt für <lb n="15"/>
-<note type="marginal">Σ 5</note> alle Lebewesen gefunden? XII. Wer hat den flüssigen Samen der
+<milestone unit="altnumbering" n="5"/> alle Lebewesen gefunden?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="12">
+<p>Wer hat den flüssigen Samen der
 Zeugung aus seinem vergänglichen und törichten Laufe umgeändert
-und Leben zeugend gemacht? XIII. Wer wirkt bis jetzt all dies und
-Unzähliges darüber hinaus, das alles Wundern und Staunen übertrifft?
-XIV. Wer vollbringt an allen Tagen und zu allen Stunden <lb n="20"/>
+und Leben zeugend gemacht?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="13">
+<p>Wer wirkt bis jetzt all dies und
+Unzähliges darüber hinaus, das alles Wundern und Staunen übertrifft?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="14">
+<p>Wer vollbringt an allen Tagen und zu allen Stunden <lb n="20"/>
 ihre Entstehung und ihren Wandel mit verborgener, unsichtbarer
 Kraft?</p>
-<p>XV. Aber als die Ursache aller dieser (Erscheinungen) wird mit
+</div>
+<div type="textpart" subtype="chapter" n="15">
+<p>Aber als die Ursache aller dieser (Erscheinungen) wird mit
 Recht der wundertätige Logos Gottes genannt. Denn der in Wahrheit
 allmächtige Logos Gottes erstreckte sich durch alles, breitete sich nach <lb n="25"/>
 oben zur Höhe und nach unten zur Tiefe unkörperlich aus, faßte die
@@ -271,7 +321,7 @@ und schnürte das All zus Alls zusammen, befestigte sich dies reich zusammengese
 Instrument und schlägt die unvernünftige, gestalt- und formlose
 <note type="footnote">4 ff. vgl. Dem. IV 56 ff.</note>
 <note type="footnote">3 „Welt“ Σ πόθεν ἂν εἴποι τις τὸν ἐν αὐτῇ κόσμον ἐνυπάρχειν αὐτῇ; L
-15 εἰς ἁρμονίαν συναγαγὼν μίαν, &lt;μίαν&gt; γενέσεως ἀρχὴν . . . ἐξεύρατο Σ μίαν &lt; L
+15 εἰς ἁρμονίαν συναγαγὼν μίαν, <add>μίαν</add> γενέσεως ἀρχὴν . . . ἐξεύρατο Σ μίαν &lt; L
 16 τὴν ῥοώδη καὶ σπερματικὴν γένεσιν τῆς φθαρτῆς καὶ ἀλογίστου (HSS ἀναισθήτου
 Valesius Hkl) μεταβαλὼν ῥοῆς ζωογόνον ἀπέδειξεν; L 21 γενέσεις καὶ
 ὥρας L φθορὰς Valesius φορὰς Heikel τροπὰς? Σ 27 „mit der Breite gleichsam
@@ -285,13 +335,24 @@ und gestimmt.“ Σ hat falsch konstruiert und zu etymologisch übersetzt: τὴ
 οὐσία der Körper mit allweiser und vernünftiger Kraft an, indem er
 schön die (Tonleiter der) διάτονοι mit (derjenigen der) διεζευγμένα verbindet,
 und lenkt die Sonne, den Mond und die leuchten am Himmel
-mit unaussprechlichen Worten und führt (sie) zum Nutzen des alls.
-<lb n="5"/> XVI. Eben dieser Logos Gottes ließ sich auch auf die Erdxe zur Tiefe
+mit unaussprechlichen Worten und führt (sie) zum Nutzen des alls.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="16">
+<lb n="5"/><p>Eben dieser Logos Gottes ließ sich auch auf die Erdxe zur Tiefe
 herab und stellte alle verschiedenen Arten der Lebewesen und alle Gestalten
-schöner Pflanzen her. XVII. Eben dieser Logos Gottes tauchte
+schöner Pflanzen her.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="17">
+<p>Eben dieser Logos Gottes tauchte
 auch bis auf die Tiefen des Meeres hinunter und ersann *die schwimmenden
 Naturen und wirkte auch hier wiederum ungezählte Myriaden
-<lb n="10"/> von Gestalten und allerlei verschiedene Tiere. XVIII. Eben dieser
+<lb n="10"/> von Gestalten und allerlei verschiedene Tiere.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="18">
+<p>Eben dieser
 vollendet auch *das, was im Leibe getragen wird, innen in der *Kunstwerkstatt
 der Natur und bildet Leben. Dieser hebt auch leicht die
 flüssige und schwere Natur der feuchten οὐσία nach oben zur Höhe und
@@ -299,19 +360,26 @@ wandelt sie dann in Süssigkeit. Nach (bestimmtem) Maß bringt er sie
 <lb n="15"/> aufs land und vollendet (so) zu bestimmten Zeiten seine Versorgung.
 Nachdem er nach Art eines vorzüglichen Landmannes den Acker gut
 bewässert und mit der Trackenheit die Feuchtigkeit vermengt hat, wandelt
-er (ihn) auf alle Art um, indem er bald durch die schöche Blüten, bald <note type="marginal">Σ 6</note>
+er (ihn) auf alle Art um, indem er bald durch die schöche Blüten, bald <milestone unit="altnumbering" n="6"/>
 durch allerlei Formen, bald durch angenehme Gerüche, bald durch die
 <lb n="20"/> wechselnden Unterschiede der Früchte und bald durch den Geschmack
-allerhand Genüsse gevährt. XIX. Wie darf ich mich erdreisten, über
+allerhand Genüsse gevährt.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="19">
+<p>Wie darf ich mich erdreisten, über
 die Kräfte des göttlichen Logos zu reden und Unmögliches anzugreifen,
-da es lkar ist, daß seine Energie jeden sterblichen Verstand weit übertrifft?
-XX. Die einen also haben diesen Allnatur, die anderen Allseele, noch
+da es lkar ist, daß seine Energie jeden sterblichen Verstand weit übertrifft?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="20">
+<p>Die einen also haben diesen Allnatur, die anderen Allseele, noch
 <lb n="25"/> andere Schicksal genannt. Andere aber haben gesagt, er sei der jenseits
 von allem (weilende) Gott, und haven ich weiß nicht wie unendlich
 weitgetrennte (Dinge) vermischt, indem sie den Alllenker, die höchste
 <note type="footnote">6 παντοδαπῶν γένη ζώων φυτῶν τε πολύμορφα κάλλη L 8 Statt <foreign xml:lang="abbr">ABBREV</foreign>
-lies <foreign xml:lang="abbr">ABBREV</foreign> ebenso Z. 11 11„Kunst“ Σ. Aber statt <foreign xml:lang="abbr">ABBREV</foreign> lies <foreign xml:lang="abbr">ABBREV</foreign>
-<foreign xml:lang="abbr">ABBREV</foreign> Hoffmann: ἔνδον ἐν τῷ τῆς φύσεως ἐργαστηρίῳ L 12„die feuchte
+lies <foreign xml:lang="abbr">ABBREV</foreign> ebenso Z. 11 11 „Kunst“ Σ. Aber statt <foreign xml:lang="abbr">ABBREV</foreign> lies <foreign xml:lang="abbr">ABBREV</foreign>
+<foreign xml:lang="abbr">ABBREV</foreign> Hoffmann: ἔνδον ἐν τῷ τῆς φύσεως ἐργαστηρίῳ L 12 „die feuchte
 οὐσία, die flüssige und schwere Natur“ Σ, aber τῆς ὑγρᾶς οὐσίας τὴς ῥευστὴν καὶ
 βαρεῖαν φύσιν L 16 Σ kann man vielleicht verstehen: „und vollendet … seine
 Versorgung nach art eines …. Landmannes, der den acker gut bewässert und …..
@@ -324,28 +392,37 @@ da er den Schluß übersetzt: „bald dem Geschmacke allerlei Genüsse gewährt�
 
 <pb n="v.3.pt.2.p.45"/>
 Kraft des Seins nach unten auf die Erde und in die Körper warfen
-&lt;und&gt; mit vergänglicher ὕλη verknüpften und vorgaben, er umkreise
+<add>und</add> mit vergänglicher ὕλη verknüpften und vorgaben, er umkreise
 die Mitte der unvernünftigen und vernünftigen, sterblichen und unsdterblichen
 Lebewesen. Aber sie (behaupten) dies.</p>
-<p>XXI. Die göttliche Lehre aber sagt, daβ das höchste  aller Güter, <lb n="5"/>
+</div>
+<div type="textpart" subtype="chapter" n="21">
+<p>Die göttliche Lehre aber sagt, daß das höchste  aller Güter, <lb n="5"/>
 eben er, der die Ursache des Alls ist, jenseits von allem Begreifen sei.
 Deswegen sei er unsagbar, unaussprechlich, unnennber, und nicht nur
 höher als jedes   Wort, sondern auch als alle Vernnuft, weder an einem
 Orte greifbar noch in Körpern existierend, weder im Himmel noch im
 Äther noch in (irgend) einem der Teile  des Alls, sondern zugleich überall <lb n="10"/>
-und auβerbalb von allem, auftbewahrt in her Tiefe des verborgenen
+und außerbalb von allem, auftbewahrt in her Tiefe des verborgenen
 Wissens. Diesen allein als wahren  Gott zu wissen, lehren die göttlichen
 Worte, (ihn,) der von jeder körperlichen οὑσία gesondert und jedem
 Verwaltungsdienst fremd ist. Deswegen ist uns überliefert, daß alles
-von ihm, aber keineswegs  durch ihn sei. XXII. Sondern er  sitzt nach <lb n="15"/>
+von ihm, aber keineswegs  durch ihn sei.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="22">
+<p>Sondern er  sitzt nach <lb n="15"/>
 Art eines Königs drinnen in der Verborgenheit und Verstecktheit und
 Unxugänglichkeit in der Höhe des Blickes und lenkt und ordnet (alles)
 nur durch die  Kraft  seines Willens. Denn wenn er will, so existiert
 das, was da existiert, und wenn er nicht will, so existiert es nicht. Er
-will aber alles Gute, deswegen weil auch er gut ist in seiner οὐσία.</p> <lb n="20"/>
-<note type="marginal">Σ 7</note> <p>XXIII. Er aber, durch den alles (ist), der Logosgott *regnet von
+will aber alles Gute, deswegen weil auch er gut ist in seiner οὐσία.</p>
+</div> <lb n="20"/>
+	   
+<div type="textpart" subtype="chapter" n="23">
+<milestone unit="altnumbering" n="7"/><p>Er aber, durch den alles (ist), der Logosgott *regnet von
 oben aus seinem guten Vater wie aus  einer unendlichen, immer fließenden
-Quelle &lt;und&gt; geht durch unaussprechliche Worte nach Art eines Flusses
+Quelle <add>und</add> geht durch unaussprechliche Worte nach Art eines Flusses
 hervor, indem er ganz und gar (zum Überfließen) voll ist für die gesamte Erlösung des Alls. Wie aber nach dem in unserer Weise (gewählten) 25
 Beispiel der verborgene und unsichtbare Verstand, der in uns
 <note type="footnote">14 vgl. I Kor 8 6 16 vgl. I Tim 7 16 25—S 46, 20 =  1. Bruchstück
@@ -383,7 +460,7 @@ Wort des über alles (herrschenden) Gottes und ist seinem Wesen nach
 die Kraft Gottes und die Weisheit Gottes, und geht aus der Gottheit
 und dem Königreich seines Vaters hervor und ist der gute Sprößling
 <lb n="20"/> eines guten Vaters und der gemeinsame Erlöser aller, und tränkt alles
-&lt;und&gt; läßt allem Leben, Vernunft, Weisheit, Licht und alles Gute aus
+<add>und</add> läßt allem Leben, Vernunft, Weisheit, Licht und alles Gute aus
 seiner eigenen Fülle zufließen. Er tränkt aber keineswegs nur das, was
 vor ihm (liegt) und ihm am nächsten (ist), sondern auch das weit Entfernte
 zu Lande und zu Wasser und wenn es irgend einen anderen Teil
@@ -403,83 +480,99 @@ und mit königlicher Vollmacht, und teilt“. Σ hat schlecht verknüpft: κα�
 Streiche (<foreign xml:lang="abbr">ABBREV</foreign>) vor (<foreign xml:lang="abbr">ABBREV</foreign>)</note>
 
 <pb n="v.3.pt.2.p.47"/>
-anderen, daβ sie den Himmel selber bewohnen, für andere die atherischen
+anderen, daß sie den Himmel selber bewohnen, für andere die atherischen
 Wohnstatten, für  andere die Luft und fur andere die Erde, und dann,
-<note type="marginal">Σ 8</note> indem er sie non hier wieder anderswohin verlegt, unterscheidet er sehr
+<milestone unit="altnumbering" n="8"/> indem er sie non hier wieder anderswohin verlegt, unterscheidet er sehr
 wohl die Lebensfuhrungen aller, pflanzt Gewohnheiten und Sitten unterschiedlich 
 fort und sorgt fur leben *und Nahrung keineswegs der Vernunftigen <lb n="5"/>
 allein, sondern auch der unvernunftigen Tiere zum Gebrauch
-der vernunftigen (Menschen). XXIV. Und den einen gewahrt er den Genuβ
+der vernunftigen (Menschen).</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="24">
+<p>Und den einen gewahrt er den Genuß
 des sterblichen und zeitlichen Lebens, den andern aber das Teilhaben
 an der Unsterblichkeit. Alles aber wirkt er als der Logos Gottes, *indem
 er allem nahe ist und alles mit vernunftiger Kraft durcheilt, nach <lb n="10"/>
-oben seinen Vater anblickt und gemaβ seinen Winken das Untere und
+oben seinen Vater anblickt und gemaß seinen Winken das Untere und
 ihm nachfolgend wie ein Erloser aller lenkt, indem er so in der 
-Mitte befindet, der das Getrennte zusammenfesselt und nicht zuläbt, daβ <lb n="15 "/>
+Mitte befindet, der das Getrennte zusammenfesselt und nicht zuläbt, daß <lb n="15 "/>
 ist und die gewordene οὐσία dem Sein annahert.</p>
-<p>Eine unzerreiβbare Fessel ist der Logos Gottes, der sich in der 
+<p>Eine unzerreißbare Fessel ist der Logos Gottes, der sich in der 
 es weit (auseinander) fallt. Er ist die uber alles (waltende) Vorsehung,
 er ist der Pfleger und Lenker des Alls, er ist die Kraft Gottes und die
 Weisheit Gottes, er ist der Eingeborne, der Sohn Gottes, der Gott aus
-Gott Gezeugte, das Wort. ,,Denn im Anfang war das Wort und das
+Gott Gezeugte, das Wort. „Denn im Anfang war das Wort und das
 Wort war bei Gott und Gott war das Wort. Alles ist durch dasselbe <lb n="20"/>
 geworden und ohne dasselbe ist nichts“, lehren die ruhmlichen Worte
-gottlicher manner. XXV. Er ist der gemeinsame *Pflanzer aller, um
+gottlicher manner.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="25">
+<p>Er ist der gemeinsame *Pflanzer aller, um
 deswillen die οὐσία des Alls wachst und bluht, von seinem Tau zu jeder
 Zeit getrankt, fur immer verjungt in ihrer Blute und einen schonen
 Anblick jederzeit gewahrend. Er aber halt ihre Zugel und fuhrt sie <lb n="25 "/>
-auf richtigem Wege zum Ziel &lt;und&gt; steuert nach den Winken seines
+auf richtigem Wege zum Ziel <add>und</add> steuert nach den Winken seines
 <note type="footnote">17 vgl. I Kor 124 19 = John 1 1. 3.</note>
-<note type="footnote">5 ,,Leben der nahrung“ Σ ζωῆς τε καὶ τροφῆς L 1. <foreign xml:lang="abbr">ABBREV</foreign> 9 ,,und
-indem er nahe ist“ Σ streiche <foreign xml:lang="abbr">ABBREV</foreign>: ἐνεργεῖ, τοῖς πᾶσιν ἐπιπαρὼν L 12 ,,ihm
+<note type="footnote">5 „Leben der nahrung“ Σ ζωῆς τε καὶ τροφῆς L 1. <foreign xml:lang="abbr">ABBREV</foreign> 9 „und
+indem er nahe ist“ Σ streiche <foreign xml:lang="abbr">ABBREV</foreign>: ἐνεργεῖ, τοῖς πᾶσιν ἐπιπαρὼν L 12 „ihm
 nachfolgend“ Σ τὰ κάτω καὶ μετ’ αὐτὸν ἀκολούθως οἶα κοινὸς ἁπάντων σωτὴρ
-διακυβερνᾷ L καὶ μετ’ αὐτὸν &lt; Heikel |  ,,so“ Σ ἁμηγέπη L 17 ,,er ist die
+διακυβερνᾷ L καὶ μετ’ αὐτὸν &lt; Heikel |  „so“ Σ ἁμηγέπη L 17 „er ist die
 pflegende Vorsehung uber alles, er ist der Lenker“ Σ (ΑΒΒREV Mask. trotz
 <foreign xml:lang="abbr">ABBREV</foreign> wie 4122 7825 8311). Aber Miβverstandnis: οὒτος ἡ καθόλου πρόνοια,
 κηδεμὼν οὒτος καὶ διορθωτὴς L 18 oὖτος μονογενής, θεὸς ἐκ θεοῦ γεγεννημένος,
-λόγος L μονογενὴς] + θεοῦ θἱὸς ,,der eingeborne Sohn Gottes“ Σ laβt sich als
+λόγος L μονογενὴς] + θεοῦ θἱὸς „der eingeborne Sohn Gottes“ Σ laβt sich als
 ursprunglich (wie oben) verstehen (gegen Stud. 59) 21 θεολόγων ἀνδρῶν ἱεραὶ
-διδάσκουσι φωναί L 22 ,,Erloser“ Σ 1. ΑΒΒREV = φυτουργός L 26 Man
+διδάσκουσι φωναί L 22 „Erloser“ Σ 1. ΑΒΒREV = φυτουργός L 26 Man
 erwartet <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.48"/>
-Vaters  den groβen Nachen der gesamten Welt. Diesenschönkÿnstlerischen
+Vaters  den großen Nachen der gesamten Welt. Diesenschönkÿnstlerischen
 eihgebornen Sohn zeugte der *jenseits von allem(stehende) Gott,
 wie ein gutter Vater eine gute Frucht, und gab (ihn)dieser Welt als das vorzÿglichste Geschek wie eine Seele für denseelenlosen Leib, und
 <lb n="5"/> warf in die unvernünftige Natur der Körper seine Vernunft and erleuchtete
 und belebte die form- und gestaltlose,seelen- und artlose οὐσία
 mit der Kraft des göttlichen Logos, den auch wir kennen und verehren müssen, während er der ὕλη und den στοιχεῖα der Körper allezeit nahekommt,
-und der (selber) ohne Hyle und ohne Körper ist und weise, <note type="marginal">Σ 9</note>
-<lb n="10"/> nicht als ob er von anderen weise gemacht worden ware, sondern er ist die Weisheit, das Leben und das Licht (selber), ein verständiger Spröβling unsagbaren Lichtes und Einer seiner οὐσία nach, wie er von Einem Vater ist, aber er besitzt viele Kräfte in sich.</p>
+und der (selber) ohne Hyle und ohne Körper ist und weise, <milestone unit="altnumbering" n="9"/>
+<lb n="10"/> nicht als ob er von anderen weise gemacht worden ware, sondern er ist die Weisheit, das Leben und das Licht (selber), ein verständiger Sprößling unsagbaren Lichtes und Einer seiner οὐσία nach, wie er von Einem Vater ist, aber er besitzt viele Kräfte in sich.</p>
 <p>Denn nicht dÿrfen wir, weil es viele Teile der Welt gibt, deswegen 
-<lb n="15"/> (auch) meinen, daβ es viele Kräfte gebe; ebensoweig dürfen wir, weil
-es viele Werke gibt, deswegen auch viele Götter hinstellen. XXVI. Einen
+<lb n="15"/> (auch) meinen, daß es viele Kräfte gebe; ebensoweig dürfen wir, weil
+es viele Werke gibt, deswegen auch viele Götter hinstellen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="26">
+<p>Einen
 gewaltigen Irrtum aber haen, unmündig an ihrer Seele, polytheistische
 Männer begangen, die die Teile des Alls zu Göttern machten und die 
 Eine Welt in viele (Stücke) teilten, gleich wie wenn jemand, der von 
 <lb n="20"/> dem Bestande Eines menschen die Augen besonders nimmt und sagt, sie 
 seien ien Mensch und die Ohren wiederum ein anderer mensch, und 
 (der) ebenso wiederum den Kopf, und den Nachken, die Brust, den Rücken,
-die Hände und die Füβε und die übrigen Glieder einzeln abschneidet und
-die Kräfte der sinne teilt und von dem Einem Menschen sagt, daβ es
+die Hände und die Füßε und die übrigen Glieder einzeln abschneidet und
+die Kräfte der sinne teilt und von dem Einem Menschen sagt, daß es
 <lb n="25"/> uorgeblich sehr viele seien, sich weiter nichts als ein Gelächter über (seine)
-Torheit bei den Weisen erwirkt. Demgemäβ ist auch der, der sich myriadenGötter aus den Teilen der Einen Welt aufstellt und die Körper,
+Torheit bei den Weisen erwirkt. Demgemäß ist auch der, der sich myriadenGötter aus den Teilen der Einen Welt aufstellt und die Körper,
 die durchweg aus flüssiger und zerstiebbarer natur und aus Einer ὕλη gemacht sind, zerschneidet und sie sich wiederum vorgeblich zu Göttern
-<lb n="30"/> macht. XXNII. Viel schlechter als dieser aber ist jeder, der auch diese 
+<lb n="30"/> macht.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="27">
+<p>Viel schlechter als dieser aber ist jeder, der auch diese 
 <note type="footnote">11—27= Laus 2324—19</note>
-<note type="footnote">2 ,,höher als alles” Σ. (??) vermutlich Versehen für (??): ὁ τῶν ὅλων
+<note type="footnote">2 „höher als alles” Σ. (??) vermutlich Versehen für (??): ὁ τῶν ὅλων
 ἐπέκεινα θεός L 8—11 ἐν ὕλῃ μὲν καὶ σωμάτων στοιχείοις διὰ παωτὸς 
 ἐπιχωριάζοντα καὶ τὰ πάωτα ζωογονῦντα, τὸν αὐτὸν δὲ φῶς κτλ. L 17 
-πολυθέων ἀωδρῶν παῖδες L 23 δαταδερματίσας L genauer ,,allmählich
-schneiden” Σ, oder besser ,,einzeln abschneiden” 25 τάς τε τῶν 
+πολυθέων ἀωδρῶν παῖδες L 23 δαταδερματίσας L genauer „allmählich
+schneiden” Σ, oder besser „einzeln abschneiden” 25 τάς τε τῶν 
 αἰσθητηρίων δυνάμεις καταδιελὼν τῷ λόγῳ παμπόλλους λέγοι εἶναι 
-ἀνθρώπους τὸν ἕνα L. Σ verbindet τῷ λόλῳ mit καταδιελὼν: ,,im 
-Gedanken teilt”, dagegen vgl. Z. 29  29 ,,in viele Stücke schneidet” Σ
+ἀνθρώπους τὸν ἕνα L. Σ verbindet τῷ λόλῳ mit καταδιελὼν: „im 
+Gedanken teilt”, dagegen vgl. Z. 29  29 „in viele Stücke schneidet” Σ
 vgl. zu Z. 23</note>
 
 <pb n="v.3.pt.2.p.49"/>
 ganze gewordne Welt, sie ganz und gar zumal, die aus vielen Teilen
-besteht, für Gott halt, ohne zu wissen, daβ eine göttliche Natur niemals
+besteht, für Gott halt, ohne zu wissen, daß eine göttliche Natur niemals
 aus Teilen besteht. Wenn sie aber zusammengesetzt ware, so bedüfte sie
 auch eines anderen, der sie zusammensetzte, noch auch ware sie göttlich,
 wenn sie vielteilig ware. wie denn? Sie sollte aus unähnlichen Unterschieden, <lb n="5"/>
@@ -487,12 +580,12 @@ aus Schlecherm und Besserem bestehen? Denn das Zasammengesetzte
 ist auch auflösbar, und das Vielteilige ist mit Zwang unähnlich.
 einfach und nicht zusammengesetzt. Das Zusammengesetzte aber ist
 aus Unähnlichem zusammengesetzt. Das Unähnliche aber ist an sich <lb n="10"/>
-<lb n="Σ 10"/> etwas Schlechteres gegenüber dem Besseren. Denn wenn es ganz gut
+<milestone unit="altnumbering" n="10"/> etwas Schlechteres gegenüber dem Besseren. Denn wenn es ganz gut
 ware, so ware es gleich und ähnlich, und wenn es so ware, so ware es
 durchweg und in jedem (Teil) sich selbst gleich und ware daher von
 *eindfacher (und) ungeteilter οὐσία. Aber keineswegs zeigt sich diese
 Natur der sichtbaren Welt des Alls. Denn sie ist wahrnehmbar und beseht <lb n="15"/>
-aus Myriaden Teilen und ist zusammengesetzt, sodaβ sie eben in
+aus Myriaden Teilen und ist zusammengesetzt, sodaß sie eben in
 Myriaden Teile sich wandelt, und so nimmt sie, da sie so ist, auch die
 gegensätzliche Natur auf. Deswegen hat diese Welt teil an der sterblichen
 zumal und unsterblichen, nernünftigen und unvernÿnftigen, kalten
@@ -504,7 +597,7 @@ indem er spricht: Der Logos Gottes, der vor allem ist, its allein
 der Erlöser aller Vernünftigen; Gott aber, der jenseits von allem ist, der <lb n="25"/>
 <note type="footnote">1–6 = Laus 23219–24 21 „einfach“ — S. 51, 5 = Laus 23224–23324
 23 vgl. Joh 11?</note>
-<note type="footnote">3 „und nicht ist sie zusammengesetzt, sodaβ sie eines anderen nicht bendarf,
+<note type="footnote">3 „und nicht ist sie zusammengesetzt, sodaß sie eines anderen nicht bendarf,
 der sie zusammensetzt“ Σ aber εἰ δὲ σύνθετος γένοιτο, καὶ ἑτέρου δέοιτο ἂν τοῦ
 συνθήσοντος αὐτήν L (οὑδ ἀσύνθεντος Var.) 5 „Wie aber? Aus anähnlichen
 Unterschieden besteht das Schlechtere und Bessere“Σ, aber? πῶς γάρ; ἐξ ανομοίων
@@ -523,23 +616,34 @@ der vater seines eingebornen Logos genannt, er selbst aber erkennt
 keine ander, höhere Ursache als sich selbst an. Deswegen ist Er (auch)
 allein Gott (selber), der Eingeborne  aber geht aus ihm hernor nach verborgenem,
 <lb n="5"/> unaussprechlichem Ratschluß, der Erlöser aller, Ein Logos
-Gottes, der durch alles (waltet). XXVIII&gt; Die sinnliche Welt also ist
-nach Art einer vielsaitigen Leier,  die aus unähnlichen Saiten besteht,,
+Gottes, der durch alles (waltet).</p>
+</div>
+	   
+<div type="textpart" subtype="chapter" n="28">
+<p>Die sinnliche Welt also ist
+nach Art einer vielsaitigen Leier,  die aus unähnlichen Saiten besteht „
 aus hellen und dumpfen, aus schlaffen, gespannten und mittleren, die
 alle whohl harmonishc sind durch musische Kunst, — demgemäß nun ist
 <lb n="10"/> auch sie,   die vielteilig und reich zusammengesetzt ist aus kalter ͌umal
 und ihr entgegenstehender warmer, aus feuchter und trockener οὐσία, zu
 Einer Harmonie vereinigt und ist ein großes Instrument und ein Werk
-des Gottes des Alls. XXIX. Der göttliche Logos aber besteht keinessondern
+des Gottes des Alls.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="29">
+<p>Der göttliche Logos aber besteht keinessondern
 <lb n="15"/> ist ohne Teil und ohne Zusammensetzung und schlägt schön und
 weise das All an und leistet seinem Vater und dem Könige des Alls den
-ihm schuldigen end gebührenden Lob(estribut). Wie an Einem Leibe <note type="marginal">Σ 11</note>
+ihm schuldigen end gebührenden Lob(estribut). Wie an Einem Leibe <milestone unit="altnumbering" n="11"/>
 (wie) aber eine unsichtbare Seele sich durch alles erstrecht und Ein
 <lb n="20"/> unteilbarer, unkörperlicher Vedrstand, so auch bei diesem (All): Aus
 vielen Teilen besteht Eine Welt und ebenso erstreckt sich Ein Logos Gottes,
 reich an Kräften und mächtig in allem, durch alles und verbreitet sich
 unsichtbar über alles und ist die Ursache von allem, was darin ist.</p>
-<p>XXX. Siehst du nicht mit deinen Augen, daß Ein Himmel die
+</div>
+	   
+<div type="textpart" subtype="chapter" n="30">
+<p>Siehst du nicht mit deinen Augen, daß Ein Himmel die
 <lb n="25"/> ganze Welt umgibt, während Myriaden Reihen von Sternen an ihm
 züglichkeit ihres Lichtes die Strahlen aller (Gestirne) verbirgt? So also,
 da der Vater einer ist, muß auch der Logos dieses (Wesens) Einer
@@ -547,12 +651,12 @@ sein: der gute Sprößling eines guten Vaters. Wenn aber jemand tadelh
 <lb n="30"/> wollte, warum nicht mehr Söhne (da seien), so geziemt es sich für diese,
 auch den Vorwurf zu erheben, warum er nicht mehr Sonnen, Monde,
 <note type="footnote">6 vgl. Eph 46 24 – S. 51,4 „erleuchete” = Dem. IV 514 – 61 κόσμον</note>
-<note type="footnote">1 „und wird “ Σ streiche <foreign xml:lang="abbr">ABBREV</foreign> 10 „und Kälte zumal und Wärme, die ihr
+<note type="footnote">1 „und wird“ Σ streiche <foreign xml:lang="abbr">ABBREV</foreign> 10 „und Kälte zumal und Wärme, die ihr
 entgegen steht, Feuchtigkeit und Trockenheit der οὐσία sind zu Einer Harmonie
 vereinigt“ Σ, aber καὶ ὅδε πολυμερὴς ὢν  καὶ πολυσύνθετος ψυχρᾶς ὁμοῦ καὶ τῆς
 ἐναντίας, εἰς μίαν συνελθὼν ἁρμονίαν L 15 εἶ καὶ σοφῶς τὸ  πᾶν ἀνακρούεται,
 τῷ αὐτολῦ πατρὶ . . .  τὴν ὀφειλομένην . . . ἀποδιδοὺς μελῳδίαν L „ weise in alllem,
-stimmt er sich seinem Vater “Σ 26 „ und durch “ Σ. Str. <foreign xml:lang="abbr">ABBREV</foreign></note>
+stimmt er sich seinem Vater “Σ 26 „und durch“ Σ. Str. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.51"/>
 Welten und Myriaden Anderes herstellte, indem er nach Art eines
@@ -575,11 +679,15 @@ mübten sie werden. Und was gibt es für Unähnliches, das werden
 unvollkommen und seiner Natur nach mangelhaft ist? Aber es gibt
 keinen unvollkommenen Spröbling Gottes. Vollkommen also ist der
 Eingeborne Gottes, und keineswegs gibts es vieles Logoi Gottes, sondern: <lb n="20"/>
-<note type="marginal">Σ 12</note> Gott aus Gott, allem genügend und allmächtig, Ein Bild des Lichtes
+<milestone unit="altnumbering" n="12"/> Gott aus Gott, allem genügend und allmächtig, Ein Bild des Lichtes
 seines Wesens, wie die göttlichen worte überliefern, der zum Nutzen
 der Wiederherstellung und Heilung aller gewordenen (Wesen) notwendig
 geschaffen ist, seinem Wesen nach Einer, aber mannigfach in seinen
-Kräften, der allein zun Schmucke des Alls genügt. XXXI. Denn auch <lb n="25"/>
+Kräften, der allein zun Schmucke des Alls genügt.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="31">
+<p>Denn auch <lb n="25"/>
 im Menschen ist Eine Seele und Eine vernünftige Kraft, und sie ist
 zugleich die Fertigerin der vielen (Künste), wenn eben dieselbe, um das
 Land zu bearbeiten, * Schiffe herzustellen und sie zu lenken und um zu
@@ -592,29 +700,37 @@ niemals jemand geglaubt, dab es vieles Seelen in Einem Leibe gebe,
 8 vgl. De Xenophane, Zen. Gorg. c. 3; Dem. IV 31 ff. 21 vgl. Hebr 1  3
 <note type="footnote">25–S. 53, 14 = Laus 233 24–235 12 Dem. IV 5 9–12</note>
 <note type="footnote">14 „macht unnütz“]  wörtlich „schleppt zum Unnützen “Σ 25 „Denn“]  wörtlicher
-„weil“ Σ, an das Vorige angeschlossen 28 l. <foreign xml:lang="abbr">ABBREV</foreign> mit HS 29„und
+„weil“ Σ, an das Vorige angeschlossen 28 l. <foreign xml:lang="abbr">ABBREV</foreign> mit HS 29 „und
 viele“ str. <foreign xml:lang="abbr">ABBREV</foreign> 30 „und empfängt“ str. <foreign xml:lang="abbr">ABBREV</foreign> 32 l. <foreign xml:lang="abbr">ABBREV</foreign> lee</note>
 
 <pb n="v.3.pt.2.p.52"/>
 noch auch mit Verwunderung erwartet, da? es viele ο?σ?αι im Menschen
 gebe wegen des Empfanges vieler Lehren. Wenn aber jemand eine gestaltlose
 Scholle Lehm findet, sie dann mit seinen Handen *knetet und ihr
-die Gestalt eines Lebewesens gibt, &lt;und&gt; durch die Eine Form einen Kopf,
+die Gestalt eines Lebewesens gibt, <add>und</add> durch die Eine Form einen Kopf,
 <lb n="5"/> durch die andere Hande und Fu?e, durch eine andere ferner die Augen
 und die Wangen *ebenso und die Ohren und den Mund und Nase,
 Brust und Rucken durch die Kunst der Plastik abbildet, *so ist es
-(dennoch) keineswegs richtig, weil viele Formen, &lt;Teile&gt; und Glieder
+(dennoch) keineswegs richtig, weil viele Formen, <add>Teile</add> und Glieder
 an Einem Leibe gschaffen sind, (deshalb) zu meinen, da? ebenso auch
 <lb n="10"/> viele Schopfer seien, sondern Einen allein, den volligen Schopfer des
 Alls zu loben, der durch Eine Uberlegung und Eine Kraft das All hergestellt
-hat. XXXII. So durfen wir auch uber diese ganze Welt, die
+hat.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="32">
+<p>So durfen wir auch uber diese ganze Welt, die
 Eine ist, aber aus vielen Teilen besteht, nicht viele schaffende Krafte
 setzen noch viele Gotter nennen, sondern (nur) die Wine allweise und
 <lb n="15"/> allharmonische, in Wahrheit gottliche Kraft und gottliche Weisheit
 segnen, die mit Einer Kraft und Einer Tuchtigkeit durch alles hindurchgeht,
 durch die ganze Welt wallt, alles einrichtet und lebendig macht
 und zumal allem und jedem Einzelnen, Korpern und Elementen mannigfache
-Unterstutzung verschafft. XXXIII. So ist auch das Licht der <note type="marginal">Σ 13</note>
+Unterstutzung verschafft.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="33">
+<p>So ist auch das Licht der <milestone unit="altnumbering" n="13"/>
 <lb n="20"/> Sonne Eines, und mit einem und demselben Darauffallen zumal durchstrahlt
 sie die Luft, gibt den Augen Licht, erwarmt das Gelenk, befruchtet
 die Erde, mehrt die Pflanzen, richtet die Zeit ein, geht vor den
@@ -622,8 +738,11 @@ Sternen her, umkreist den Himmel, erhellt die Welt, stellt die Kraft
 Gottes allem deutlich hin und vollendet dies alles durch Einen einflu?
 <lb n="25"/> auf die Natur, und eb enso reinigt die Natur des Feuers das Gold,
 schmilzt das Blei, lost das Wachs auf, trocknet den Lehm und verbrennt
-das Dickicht, indem sie all dies mit Einer Brennkraft wirkt.
-XXXIV. So ist auch der Logos Gottes, der Allkonig, der sich durch
+das Dickicht, indem sie all dies mit Einer Brennkraft wirkt.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="34">
+<p>So ist auch der Logos Gottes, der Allkonig, der sich durch
 alles erstreckt, in allem und tritt an alles heran, das im Himmel und
 <lb n="30"/> auf Erden ist, lenkt das Unsichtbare und das Sichtbare, regiert eben die
 Sonne, den Himmel und die ganze Welt mit unaussprechlichen Kraften,
@@ -638,7 +757,7 @@ indem er mit tatiger Kraft allem nahe ist und durch alles waltet, la?t
 
 <pb n="v.3.pt.2.p.53"/>
 Quelle unversiegliches Licht regnen, hat den Himmel als das ähnlichste
-Bild der eigenen Gröβe eingertichtet und halt ihn in Ewigkeit fest, und
+Bild der eigenen Größe eingertichtet und halt ihn in Ewigkeit fest, und
 füllt *die jenseits des Himmels und der Welt (existierenden) Kräfte der
 Engel und der Gutn aus den bei ihm (aufbewahrten) Schätzen, &lt;und&lt; durch Eine und <lb n="5"/>
 dieselbe Kunst der Schöpfertätigkeit *ermangelt er niemals, den Elementen
@@ -647,18 +766,24 @@ Lebewesen und Pflanzen und in den vernünftigen und unvernünftigen <lb n="10"/>
 Seelen bald so bald anders, gewährt allen zumal alles mit Einer Kraft
 und zeigt deutlich keineswegs eine siebensaitighe oder vielasiting Leier,
 sondern Einee ganz harmonische Welt als das Werk Eines weltschaffenden 
-Logos. XXXV. Derart ist also der gemeinsame Erlöser
+Logos.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="35">
+<p>Derart ist also der gemeinsame Erlöser
 aller, der Logos des Gettes des Alls, üder den den ein Theologe mystisch <lb n="15"/>
 so redet: „Er war in der Welt, und die Welt ward duch ihn, aber die 
 Welt kannte ihn nicht“. Denn nicht früher noch lernte sie ihn kennen,
 als bis er sich selbst in den letzten Zeiiten offenbarte dfenen, die in der
-<note type="marginal">Σ 14</note> Finsternis des Bösen gehalten sind. Aber daβ der Schöpfer der ganzen
+<milestone unit="altnumbering" n="14"/> Finsternis des Bösen gehalten sind. Aber daß der Schöpfer der ganzen
 Welt, der der gemeinsame Erlöser aller ist, derart ist und diesem All <lb n="20"/>
-eine so so groβε Unterstützung gewährt, ist von uns mit Recht gezeigt
+eine so so großε Unterstützung gewährt, ist von uns mit Recht gezeigt
 worden. (Jetzt) aber müssen wir in Kürze sagen, welche Natur der οὐσία
 eben die Welt des alls erlangt hat, die von einem κυβερνήτης gelenkt.
 wird (und) die aus Himmel, aus Erde und dem, was darauf ist, besteeht.</p>
-<p>XXXVI. Zwei Naturen also vereinigt sie: die die bessere und dem <lb n="25"/>
+</div>
+<div type="textpart" subtype="chapter" n="36">
+<p>Zwei Naturen also vereinigt sie: die die bessere und dem <lb n="25"/>
 göttlichen Logos verwandte oὐσία, die, selb er verständig und vernünftig,
 mit dem Verstande gesejem und mit der vernunft wahrgenommen wird,
 und von der all das gegriffen warden kann, was basser als Körper ist —
@@ -666,13 +791,13 @@ und (zweitens) diejenige (οὐσία), die zum Gebrauch der (ersten) notwendig
 *bestimmt wurde, die ὕλη, die Urquelle der Körper, „die mit &lt;un&lt; vernünftigem
 Sinne vorgestellt wird, die wird und vergeht, aber durchaus
 <note type="footnote">6 vgl. Kol 23 16= Joh 110 30= Platon Timaios 27 D</note>
-<note type="footnote">3 lies Abbrav statt Abbrav 4 ,,und die οὐσίαι der verständigen und
+<note type="footnote">3 lies Abbrav statt Abbrav 4 „und die οὐσίαι der verständigen und
 vernünftigen Geister“ Σ τὰς . . . .δυνάμεις ἀγγέλων καὶ πνευάτων, νοερῶν τε
-καὶ λογικῶν οὐσιῶν ζωῆς ὁμοῦ καὶ φωτὸς . . . .ἐμτίπλησιν L D 6 ,,und“ &lt;Σ
-1.Abbrav 7 ,,und (str. Abbrav) ermangelt er niemals der οὐσία der στοικεῖα zu
-geben“ Σ καὶ στοικείοις οὐσίας οὔποτε διαλιμπάνει παρέκων LD 9 ,,Werke“Σ
-ποιότητας LD 11 ,,bisweilen oὔποτε Σ ἄλλοτε ἄλλως L 30 ,,verderbt“ oder
-„verstümmelt wurde“ Σ 1. Abbrav | ,,die Urquelle“] wörtlich ,,die gebnurt“ wohl
+καὶ λογικῶν οὐσιῶν ζωῆς ὁμοῦ καὶ φωτὸς . . . .ἐμτίπλησιν L D 6 „und“ &lt;Σ
+1.Abbrav 7 „und (str. Abbrav) ermangelt er niemals der οὐσία der στοικεῖα zu
+geben“ Σ καὶ στοικείοις οὐσίας οὔποτε διαλιμπάνει παρέκων LD 9 „Werke“Σ
+ποιότητας LD 11 „bisweilen oὔποτε Σ ἄλλοτε ἄλλως L 30 „verderbt“ oder
+„verstümmelt wurde“ Σ 1. Abbrav | „die Urquelle“] wörtlich „die gebnurt“ wohl
 ἡ τῶν σωμάτων γένεσις | αἰσθήσει ἀλόγῳ δοξαστόν Platon Eus. 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.54"/>
@@ -687,7 +812,11 @@ Erden (sind), und die darauf sichtbaren Lebewesen und Pflanzen, so
 Ist auch in der verständigen, unsichtbaren οὐσία Eine gemeinsame Art
 <lb n="10"/> aller und verständigen
 Kräfte, während Myriaden mannigfacher unterschiede dabei vorhanden
-Sind. XXXVII. Eben dies also das aus ὕλη und Körpern gemacht
+Sind.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="37">
+<p>Eben dies also das aus ὕλη und Körpern gemacht
 Ist, das wir sinnliche Welt zu nennen gewohnt sind, und das aus
 Himmel und Erde Und dem, was darin ist, besteht, — mag verglichen
 <lb n="15"/> werden einer königlichen Stadt, in der Myriaden Bürger leben in der
@@ -697,7 +826,7 @@ Teils äuBere (Häuser) als Plätze für die Leibwächter, teils wiederum
 (solche) in der Ferne und vom Hof getrennt, den Geringen und Massen
 <lb n="20"/> überlassen. Zahlreich sind die Plätze im Himmel und zalreich die
 Unterhalb derselben: im Äther und in der Luft über der Erde, während
-Der Wohnitz auf Erden für die, welche auf ihr wandeln, weit ist, er, der <note type="marginal">Σ 15</note>
+Der Wohnitz auf Erden für die, welche auf ihr wandeln, weit ist, er, der <milestone unit="altnumbering" n="15"/>
 Uns allen bekannt ist. *Diejenigen aber, die jenseits des Himmels (wohnen),
 Sind hoher als alles Denken sie, *die ebenfalls drinnen im göttlichen
 <lb n="25"/> Königspalast *abgesondert sind, um den König des Alls kreisen, neben
@@ -743,7 +872,7 @@ Griechen und andere, denen es zu teil geworden ist, in der Mitte der
 (welt) enden zu wohnen, und (wie) ferner unter diesen allen die einen
 über Teile der Völker herrschen, die anderen aber das Unterwerfen
 vollenden, und (wie) beim Grobkönig aller (diese Nationen) einige 25
-<note type="marginal">Σ 16</note> (sind, die) als Freunde geachtet warden, andere, die zu vielen Würden
+<milestone unit="altnumbering" n="16"/> (sind, die) als Freunde geachtet warden, andere, die zu vielen Würden
 emporsteigen, andere, die wegen ihrer vorzüglichen Taten geehrt warden,
 andere, die den Rang der Sklaven ausfüllen, andere, die Lanzen
 tragen und mit Schilden sich umgürten, und ferner solche, die in
@@ -763,7 +892,11 @@ gehört vor <foreign xml:lang="abbr">ABBREV</foreign> 1. <foreign xml:lang="abbr
 geber als Großkönig vor. E saber läuft nach unten durch alle Herrscher
 und Untertanen und macht Einem königlichen Joch das ganze ihm
 unterstellte Geschlecht untertan und läßt die einen zur Ehre nach oben
-steigne, den andern aber vergilt er, wie sie es verdienen. XXXVIII. Demgemäß
+steigne, den andern aber vergilt er, wie sie es verdienen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="38">
+<p>Demgemäß
 <lb n="5"/> aber existiert Eine höchste, Zeugende, verständige und vernünftige
 οὐσία, und shcön hat man gesagt, daß Eines auch das Geschlecht dieser
 (Menschen) ist und (daß) sie in nichts sich unterscheiden von Brüdern,
@@ -783,7 +916,7 @@ Logos, die teils finsterer und schwärzer als alle Kuschiten (sind), ausgelösch
 da ihm die Fülle des Bösen zumal und des Guten zu teil wurde. Ein
 König aber, Eine einzigartige Macht, der Gott, der höher als alles, was
 im Himmel und über dem Himmel (ist), * er ist es, der die (Dinge) der
-Luft, die auf Erden und unter der Erde, der alles in allem durch <note type="marginal">Σ 17</note>
+Luft, die auf Erden und unter der Erde, der alles in allem durch <milestone unit="altnumbering" n="17"/>
 <lb n="25"/> königliches Gesetz und Wort beherrscht. Gesetz und Wort aber ist
 Einer: der in allem Lebendige, das wirksame Wort Gottes, (wirksam)
 keineswegs wie das sterbliche (Gesetz und Wort), das aus dem Munde
@@ -795,7 +928,7 @@ Plätze anweist: die nächstgelegenen gibt er der (Schar der)
 Glückseligkeit, die entgegengesetzten aber denen, die vom Besseren abgefallen
 sind, wie sie es verdienen, und alle zumal läßt er um neben
 <note type="footnote">7 vgl. Platon Politeia 415; Clemens Alex. Stromateis 705; Praep. XIII 13 18</note>
-<note type="footnote">9 „und von “Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 11„und einen entgegengesetzten Zustand“ Σ, aber
+<note type="footnote">9 „und von “Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 11 „und einen entgegengesetzten Zustand“ Σ, aber
 1.	<foreign xml:lang="abbr">ABBREV</foreign> 23 „und er“ Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 30 lies <foreign xml:lang="abbr">ABBREV</foreign> statt <foreign xml:lang="abbr">ABBREV</foreign> (Druckfehler)</note>
 
 <pb n="v.3.pt.2.p.57"/> 
@@ -806,7 +939,11 @@ ihrer Lehre zu preisen, auf daß sie dies Gesetz in ihren Herzen und
 natürchen Gedanken tragen: den Einen zu bekennen, der das Ebenbild <lb n="5"/>
 des Reiches ist, der der eingeborne Logos ist, der das Bild des
 unsichtbaren Gottes ist, der Erstgeborne aller Kreaturen, wie die göttlichen
-Worte mystisch lehren. XXXIX. Eben seiner Ehre haben *allzumal 
+Worte mystisch lehren.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="39">
+<p>Eben seiner Ehre haben *allzumal 
 alle Herrscher und Untertanen inallen Häusern und in allen
 Städten angehangen. Keineswegs (wie) mit seelenlosen, bunten Farben <lb n="10"/>
 auf Bildern, sondern drinnen in den Herzen mit ihrer vernünftigen
@@ -821,7 +958,11 @@ die im Gesetz mit einbegriffen, dennoch aber mehr ist als das <lb n="20 "/>
 Gesetz (d. h. den Namen Gottes) an sichgerissen haben, so daß sie (ihn)
 für das Geschlecht der sterblichen Menschen unten auf die Erde in 
 Körper, στοιχεῖα und Weltteile warfen, weswegen die Menschen die 
-Σ 18 Geschöpfe mehr fürchteten und bedienten als ihren Schöpfer. XL. Ferner
+<milestone unit="altnumbering" n="18"/>Geschöpfe mehr fürchteten und bedienten als ihren Schöpfer.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="40">
+<p>Ferner
 aber nannten sie auch eben die (dämonischen) Kräfte, die mit Gott <lb n="25"/>
 straiten und widerspenstig sind, die durch ihre eigene * Verkehrtheit so
 wurden, Götter — sie, die niemals sind! Aber mit Recht sind auch
@@ -862,14 +1003,18 @@ Wort lehrt, indem es so jedermann aufträgt, einen gottgeziemenden
 Höhe, preist ihn, ihr, alle seine Engel, preist ihn, ihr alle seine
 Kräfte, preist ihn, Sonne und Mond, preist ihn, all ihr Sterne
 und du, Licht, preist ihn, ihr Himmel der Himmel!“ Nach diesen
-(Dingen) zählt er (der Psalmist) *die (Wesen) auf Erden so auf: <note type="marginal">Σ 19</note>
-<lb n="25"/> „Preist Gott von der Erde “ (usw.), unter anderen auch das vor allem
+(Dingen) zählt er (der Psalmist) *die (Wesen) auf Erden so auf: <milestone unit="altnumbering" n="19"/>
+<lb n="25"/> „Preist Gott von der Erde“ (usw.), unter anderen auch das vor allem
 vernünftige Geschlecht der Menschen, welches er auch in besonderen
 Anzahlen von Ordnungen in folgender Weise abteilt: „Preist ihn, ihr
 Könige der Erde und all ihr Völker, ihr Großen und all ihr Richter 
 auf Erden, Jünglinge und Jungfrauen, Greise samt Kindern! Sie sollen
 <lb n="30"/> preisen den Namen des Herrn, weil sein Name allein groß ist und sein
-Lob auf Erden und im Himmel ist.“ XLI. Mit den Scharen also, die
+Lob auf Erden und im Himmel ist.“</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="41">
+<p>Mit den Scharen also, die
 im Himmel (sind), führte er auch die auf Erden xusammen zum Lobe
 des Köhigs des Alls in diesen (Worten). Denn ihn allein in Wahrheit
 und keinen anderen Gott, der jenseits von allem (waltet), ehren die
@@ -887,7 +1032,11 @@ Ihn umlaufen auch Sonne und Mond und die Sterne in den Kreisen
 weiter Welten mit langem Laufe &lt;und&lt; durcheilen die Kampfplätze <lb n="5"/>
 ätherischer Stadien, und die unsichtbaren Kräfte, die in der freien
 Ebene der Luft fliegen, bekennen den schuldigen und gebührenden
-Lobpreis. XLII. Wie also sollte überdies nur das στοιχεῖον der Erde
+Lobpreis.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="42">
+<p>Wie also sollte überdies nur das στοιχεῖον der Erde
 der Versorgung durchweg ermangeln und die (irdische) Natur, die alle
 diese Früchte hervorgebracht hat, vereinzelt dem Lobe fernstehen und <lb n="10"/>
 die alle Früchte tragende Wohnstatt auf Erden der vernünftigen Lebewesen
@@ -902,7 +1051,7 @@ der Engel der Mensch, der nach dem Bilde Gottes wurde, den Logos,
 seinen Vater, mit Hymnen und Lobpreisen ehrte. Sein Denken ging <lb n="20"/>
 nicht ire in der Herstellung seelenloser Götzen noch in trügerischen
 (und) dämonischen Halluzinationen, noch in den irrigen Mythen der Polytheisten.
-<lb n="Σ 20"/> Denn diese (Dinge) sind erst nach (einiger) Zeit neu entdeckt
+<milestone unit="altnumbering" n="20"/> Denn diese (Dinge) sind erst nach (einiger) Zeit neu entdeckt
 worden durch das Poetengefasel. Jene ersten alten Häupter unseres Geschlechts
 aber, die die Künste noch nicht gelernt hatten: Malerei, Tischlerei, <lb n="25"/>
 Schnitzarbeit und (noch) nicht die letzte: die Schmiedekunst zu bösen
@@ -924,7 +1073,11 @@ Stadien des Äthers und bringen ihm eilend Kränze“. Aber das <foreign xml:lan
 Gottkönig und seinem Logos, dem Erlöser des Alls, mit keuschem
 Lebenswandel und frommer Lebensführung. Deswegen waren sie der
 Offenbarung des göttlichen Logos, der Prophetie und der Lehre der
-Gerechtigkeit würdig. XLIII. So also füllte der göttliche Logos, der
+Gerechtigkeit würdig.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="43">
+<p>So also füllte der göttliche Logos, der
 <lb n="5"/> Schöpfer des Alls, alle Orte und alle Plätze oberhalb der Welt und im
 Himmel und dasz στοιχεῖον der Erde mit seimen Samen geistiger und
 vernünftiger οὐσία. Der auf die Erde fallends Same aber der geistigen
@@ -945,7 +1098,7 @@ hat, so *wird er wie einer, der vorzüglich geworden ist und die Kräfte
 seiner Vorzüglichkeit gesammelt hat, die (ihm) im Schat͌ hause des Guten
 aufbewahrt sind, vollendet mit Vollendeten leben. Ihm aber, dem Säemann
 des Alls und dem Pfleger, läßt er die vollkommene Frucht des
-<lb n="25"/> gottgeziemenden Lobes sprossen, deswegen weil er ihn allein, seinen <note type="marginal">Σ 21</note>
+<lb n="25"/> gottgeziemenden Lobes sprossen, deswegen weil er ihn allein, seinen <milestone unit="altnumbering" n="21"/>
 Vater, König nnd Herrn in diesem Leben erkannt und ihn allein, Gott
 seinen Werkmeister und Schöper, in den ihm verwandten und verschwisterten
 (geistigen Dingen) bekannt hat, so daß er ihn auch an dem
@@ -964,7 +1117,11 @@ Heikel 140 12</note>
 <pb n="v.3.pt.2.p.61"/>
 sondern ihn allein, über den alles Zeugnis ablegt, ihn, den die ganze
 sichtbare und  unsichtbare Schöpfung Gott nennt und verehrt als den,
-der allein die Ursache des Alls ist. XLIV. Dies also derart.</p>
+der allein die Ursache des Alls ist.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="44">
+<p>Dies also derart.</p>
 <p>Von neuem aber wollen wir uns wiederum der uns vorgenommenen
 Rede näher. Der HImmel also und die Plätze am Himmel, die mit <lb n="5"/>
 leiblichen Sinnen wahrgenommen werden, und die Erde und die Luft
@@ -990,7 +1147,7 @@ Haus hergerichtet werden. Deswegen *erschien zuerst der <lb n="25"/>
 Himmel als ein geeigneter Platz für die Bürger über ihm und in ihm,
 und die Gewölbe im Innern des HImmels wurden abgesondert für die
 Einwohner, die ihm entsprechen. Als die Bürger auf Erden aber würdest
-<note type="marginal">Σ 22</note> du, (liebe) Seele, weder je die wilden Tiere noch das Geschlecht der giftsprühenden
+<milestone unit="altnumbering" n="22"/> du, (liebe) Seele, weder je die wilden Tiere noch das Geschlecht der giftsprühenden
 Schlangen nennen, noch *alle die, welche an der Natur und <lb n="30"/>
 dem Namen der Unvernunft teil haben. Denn sie sind deine Sklaven, die
 durch Naturgesetz unterworfen werden und den vernünftigen (Wsen)
@@ -998,7 +1155,11 @@ als ihren Herren notwendig die gebührende Bedienung verrichten. Denn
 der Ochse, de Pflüger für die Menschen, wirft freiwillig zum Pflügen
 den Nacken ins Joch; der Esel bekennt, wenn er trägt, seine Natur; <lb n="35"/>
 das Pferd freut sich über seinen Herrn, der es reitet, und der Jagdhund
-umwedelt den, der ihn füttert. XLV. Schafe und Herden ferner sind  den
+umwedelt den, der ihn füttert.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="45">
+<p>Schafe und Herden ferner sind  den
 Menschen mit reichem Besitz gegeben und wilde Tiere sind eine Übung
 <note type="footnote">4 „von neuem“] „von oben“ Σ = ἄνωθεν 25 1. <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign>, da
 auch <foreign xml:lang="abbr">ABBREV</foreign> Singular 30 Lies <foreign xml:lang="abbr">ABBREV</foreign>, da auch im Folgenden Mask.</note>
@@ -1007,7 +1168,7 @@ auch <foreign xml:lang="abbr">ABBREV</foreign> Singular 30 Lies <foreign xml:lan
 für die Tapferkeit. Eben sie töten und unterwerfen wir und auch die
 Vögel, die in der Höhe fliegen, fangen wir mit Hülfe der Vernunft, und
 die (Fische), die unten in den Tiefen des Meeres und in seiner Mitte
-(schwimmen), bringen wir herauf. Offenbar lehrt die Natur, daβ alle
+(schwimmen), bringen wir herauf. Offenbar lehrt die Natur, daß alle
 <lb n="5"/> diese (Dinge) um des Menschen willen bestehen. Der Mensch aber ist
 ein Sprößling der göttlichen Vernunft, (ist) nicht um etwas anderen,
 sondern um seines Vaters willen Vernunft, damit er sehe und durch
@@ -1018,8 +1179,11 @@ Vater nacheifere: in Gesetz, Vernunft, Wissen und Weisheit, und damit
 er lebe, wie ihm als einem Bilde der Vorzüglichkeit gelehrt ist, und
 damit er lerne, zumal mit den Scharen im Himmel auch von der Erde
 nach Art der Propheten und *Priester die Lobpreise emporsenden,
-<lb n="15"/> die dem König des Alls und Gott, der Ursache des Alls gebühren.
-XLVI. In solchen Bildern also ruft der Logos, der Lehrmeister der
+<lb n="15"/> die dem König des Alls und Gott, der Ursache des Alls gebühren.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="46">
+<p>In solchen Bildern also ruft der Logos, der Lehrmeister der
 ganzen Natur, indem er sich wundert über die veränderliche Natur der
 Vorzüglichkeit in den menschen, in göttlichen Lobgesängen aus und sagt:
 Was ist der Mensch, daß du sein gedenkest, und der Mensch, daß du
@@ -1028,20 +1192,24 @@ mit Ehre und Ruhm ihn bekleidet, *du hast ihn zum Herrscher über
 das Werk deiner Hände gemacht und hast alles unter seine Füße gelegt,
 alle Schafe und Rinder, selbst die Tiere der Wüste, die Vögel unter
 dem Himmel und die Fische des Meeres, die in den Pfaden der Wasser
-<lb n="25"/> wohnen“, XLVII. das heißt: allein das vernünftige, gottliebende Geschlecht <note type="marginal">Σ 23</note>
+<lb n="25"/> wohnen“,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="47">
+<p>das heißt: allein das vernünftige, gottliebende Geschlecht <milestone unit="altnumbering" n="23"/>
 von denen auf Erden, über das ein anderer theologischer Prophet im
 Geheimnis deutlich so lehrt, daß es in seiner οὐσία nach dem Bilde
-Gottes sei: ,,Und es sprach Gott: Wir wollen einen Menschen machen
+Gottes sei: „Und es sprach Gott: Wir wollen einen Menschen machen
 nach unserm Bilde und nach unserer Ähnlichkeit, und sie sollen herrschen
 <lb n="30"/> über die Fische im Meere, über die Vögel des Himmels, über das Vieh,
 über die ganze Erde und über alles Gewürm, das auf Erden kriecht“.
-Und mit dem Worte verband er auch die Tat: ,,Und Gott machte den
-Menschen“ und er (der Prophet) spricht: ,,Nach dem Bilde Gottes hat
+Und mit dem Worte verband er auch die Tat: „Und Gott machte den
+Menschen“ und er (der Prophet) spricht: „Nach dem Bilde Gottes hat
 er ihn gemacht“. Und ferner noch mehr, er stellte das Bild der göttlichen
 <lb n="35"/> Ähnlichkeit aus dem göttlichen Odem her, indem er (der Prophet)
 <note type="footnote">19 = Psalam 85–9 28 = Gen 1 26 32. 33 = Gen 1 27
-14 1. <foreign xml:lang="abbr">ABBREV</foreign> (Druckfehler) 16 Statt: ,, in solchen Bildern“ ist vielleicht
-zu übersetzen: ,,Demgemäß“ = <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> 21 <foreign xml:lang="abbr">ABBREV</foreign> HS
+14 1. <foreign xml:lang="abbr">ABBREV</foreign> (Druckfehler) 16 Statt: „in solchen Bildern“ ist vielleicht
+zu übersetzen: „Demgemäß“ = <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> 21 <foreign xml:lang="abbr">ABBREV</foreign> HS
 1.	<foreign xml:lang="abbr">ABBREV</foreign> Lee</note>
 
 <pb n="v.3.pt.2.p.63"/>
@@ -1070,7 +1238,7 @@ Mit Recht warden diejenigen, die so meinen, gggefragt: weil alle Kräfte
 des Leibes in die fünf Sinne zusammengefaßt warden, welcher von ihnene <lb n="25"/>
 ist (den so) beschaffen, daß er den Menschen Theorie *und Lehre
 nur die Unterscheidungsfähigkeit von Farben und Formen. Wenn du
-<note type="marginal">Σ 24</note> aber das Gehör nennst, so nennst du das Organ, das die hellen und
+<milestone unit="altnumbering" n="24"/> aber das Gehör nennst, so nennst du das Organ, das die hellen und
 dumpfen Klänge, aber keineswegs die vernddünftige Theorie aufnimmt. <lb n="30"/>
 Der Geschmack ist wiederum ebenso der Sinn für Süßigkeit und Speise.
 Demgemäß ist auch das Riechvermögen eine Prüfung der Gerüche, aber
@@ -1096,11 +1264,11 @@ der Erde ist, und die leidensfähige Natur des Leibes ein und dieselbe
 ist, und der Sinn in nichts besser ist, und ferner Arbeit und Rube ebenso
 eine und die gleiche für uns alle ist, und die Vernichtung des Leibes
 und die Auflösung in seine στοιχεῖα (in derselben Weise erfolgt), — so
-<lb n="15"/> gehst du dennoch nicht soweit zu sagen, deβ (eines) von * diesen (Tieren)
+<lb n="15"/> gehst du dennoch nicht soweit zu sagen, deß (eines) von * diesen (Tieren)
 nach Art des vernünftigen Lebewesens den unkörnerlichen Theorien
 nahe gekommen sei und vernünftige Lehre davon getragen und Wissenschaft 
 in sein Gedächtnis aufgenommen und Worte über das Bessere
-und Schlechtere ersonnen habe, noch auch (daβ) die Philosophie jemals
+und Schlechtere ersonnen habe, noch auch (daß) die Philosophie jemals
 <lb n="20"/> ihm in den Sinn kam. Aber all dies will ich übergehen, weil nicht
 einmal alle Menschen es besitzen, indem ich (nur) dies deine vernunft
 frage: ob jemals eine Stadt gebaut is von den unvernünftigen (Tieren),
@@ -1108,25 +1276,25 @@ ode rob sie das Denken besitzen für ein Zimmermannswek oder für
 ein Gebäude oder für ein Erzeugnis der Webkunst oder für den Ackerbau,
 <lb n="25"/> oder ob jemals von ihnen ein Schiff genagelt ist, ode rob die wunderbare
 Kunst der Steuerung ihnen auch nur in den Sinn gekommen ist, obwohl
-die (Dinge) des Leibes bei ihnen eine viel gröβere Vorzüglichkeit
-haben als bei uns, deswegen weil ,, schwach ist das Geschlecht der
+die (Dinge) des Leibes bei ihnen eine viel größere Vorzüglichkeit
+haben als bei uns, deswegen weil „schwach ist das Geschlecht der
 Mednschen“, wie die Poeten singen, und das kleinste von allen Lebewesen.
-<lb n="30"/> Man kann nicht sagen, wie viel kleiner der Mensch ist an Leibesgröβe 
-als der Elefant. An Kraft und Überlegenheit kann er nicht einmal <note type="marginal">Σ 25</note>
+<lb n="30"/> Man kann nicht sagen, wie viel kleiner der Mensch ist an Leibesgröße 
+als der Elefant. An Kraft und Überlegenheit kann er nicht einmal <milestone unit="altnumbering" n="25"/>
 mit den Kamelen zusammengerechnet warden. An Stärke und
-Schnelligkeit der Füβe überläβt er Myriaden Tieren den Sieg. Wer
+Schnelligkeit der Füße überläßt er Myriaden Tieren den Sieg. Wer
 <note type="footnote">28 = Empedokles fr. 124 Diels</note>
-<note type="footnote">7 ,,und dennoch“] wörtlicher ,,obgleich“ 9 ,,jenner“ = <foreign xml:lang="abbr">ABBREV</foreign>, korrektur
-Lees in <foreign xml:lang="abbr">ABBREV</foreign> unnötig 12 <foreign xml:lang="abbr">ABBREV</foreign> ,,so“ hier = ὡσαύτως wie Σ 209 7 14 ,,Αuflösung
+<note type="footnote">7 „und dennoch“] wörtlicher „obgleich“ 9 „jenner“ = <foreign xml:lang="abbr">ABBREV</foreign>, korrektur
+Lees in <foreign xml:lang="abbr">ABBREV</foreign> unnötig 12 <foreign xml:lang="abbr">ABBREV</foreign> „so“ hier = ὡσαύτως wie Σ 209 7 14 „Αuflösung
 gegen seine στοιχεῖα“ Σ wohl = λύσις πρὸς τὰ στοιχεῖα 15 man erwartet 
 das Femininum, aber kaum zu korrigieren, da auch das Verb mask. ist.
-Zu ergänzen ist etwa wie im folgenden <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> ,,die Unvernünftigen“</note>
+Zu ergänzen ist etwa wie im folgenden <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> „die Unvernünftigen“</note>
 
 <pb n="v.3.pt.2.p.65"/>
 aber könnte genannt warden, der besser röche als die Spürhunde, die
 nach dem Geruch ihrer Nase zu gehen verstehen, und wer, der besser
 sähe als alle Gazellen, die eben um ihres Sehens willen in der griechi-
-schen Sprache den Namen ,,Seher‘‘ erhielten? Ist es ferner nötig zu
+schen Sprache den Namen „Seher“ erhielten? Ist es ferner nötig zu
 sagen, wie viel schwächer in seiner Natur der Leib des Menschen ist <lb n="5"/>
 als der der Bären, Löwen, Panther und Myriaden anderer (Tiere), und
 (wie) leicht er bezwungen wird von den Tieren, die ihn überfallen, und
@@ -1138,30 +1306,42 @@ es gibt in ihm irgend eine Natur, die besser ist als der Leib: die Kraft
 des Verstandes und der verständigen Seele, und (eben) durch die Vor-
 züglichkeit der Weisheit ersinnt er alle diese staunenswerten (Dinge). 
 Durch diese (Dinge) bist du als der geliebte Sohn von Gott geehrt. <lb n="15"/>
-Warum verkleinerst du deine Gröβe, indem du meinst, dein ganzes Du
+Warum verkleinerst du deine Größe, indem du meinst, dein ganzes Du
 sei Fleisch und Leib, und indem du das göttliche und vernünftige Wissen
 in dir *den unvernünftigen (Wesen) und solchen, die ganz zugrunde gehen,
 vergleichst? Überzeugt dich weder die Natur der unvernunftigen Lebe-
 wesen noch der gemeinsame Name der Unvernunft noch die offenbare <lb n="20"/>
 (und) nützliche Bedienung, in der sie sich niemals davon freigemacht haben,
 (Lasten) zu tragen und (das Land) zu bestellen, weil Gott dir die Voll-
-macht und die Königsherrschaft über alle diese gab? XLVIII. Der
+macht und die Königsherrschaft über alle diese gab?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="48">
+<p>Der
 Mensch also allein von den (Wesen) auf Erden, der nach dem Bilde
 Gottes wurde, führt und bringt die Tiere, wohin er will, bald die lenkend, <lb n="25"/>
 die zum Laufe passend sind, bald als Herden weidend, die hierzu ge- 
 schaffen sind, bald die Jochtiere zur Bedienung benutzend, indem er die
 wilde Natur zahm und friedlich macht: bald indem er zum frieden über-
 windet, was ihm gehorcht, bald indem er (es) auf manningfache Weise
-der Vernunft sammelt und ins Haus einschlieβt. Und nicht nur (dies), <lb n="30"/>
+der Vernunft sammelt und ins Haus einschließt. Und nicht nur (dies), <lb n="30"/>
 sondern auch das schädliche Gewürm nimmt er in seine Hand und spielt
 damit und sie, die Tod atmen und Gift sprühen, macht er zum Spiel
-<lb n="Σ 26"/> für sich. XLIX. Der Mensch allein von den (Wesen) auf Erden lieβ sich
+<milestone unit="altnumbering" n="26"/> für sich.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="49">
+<p>Der Mensch allein von den (Wesen) auf Erden ließ sich
 nicht überreden, in der Wüste in Höhlen und (Sand) hügeln zu wohnen,
-sondern baute Städte mit Mauern und schmückte sie mit Straβen, Burgen, <note type="marginal">35</note>
-Wohnhäusern und andern Gebäuden. L. Der Mensch allein von den (Wesen)
+sondern baute Städte mit Mauern und schmückte sie mit Straßen, Burgen, <note type="marginal">35</note>
+Wohnhäusern und andern Gebäuden.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="50">
+<p>Der Mensch allein von den (Wesen)
 auf Erden verschaffte sich, keineswegs in (derselben) unwandelbaren Art,
 <note type="footnote">8 vgl. Praep. VII 184 24 vgl. Gen 1 27</note>
-<note type="footnote">4 ,,Seher‘‘ = δορκάδες von δέρκομαι 18 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
+<note type="footnote">4 „Seher“ = δορκάδες von δέρκομαι 18 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.66"/>
 Nahrung wie die unvernünftigen Tiere sie gebrauchen. Denn dieses, des
@@ -1172,10 +1352,18 @@ Wissen reinigt es, verkleinert es so, würzt es ganz und gar und läßt
 will, zum Brote und bemüht sich, das Essen zu würzen, daß es zur gesunden
 Spaise werde. Jeden Nutzen vom Weinberg, vom Ölberg und
 von Obstbäumen mit allerlei Genüssen bringt er zustande, und er allein
-schafft dies zur Heilung des Leibers herbei. LI. Er allein von den
+schafft dies zur Heilung des Leibers herbei.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="51">
+<p>Er allein von den
 <lb n="10"/> (Wesen) auf Erden fand durch Gesetz und Vernunft eine geordnete
 Lebensfühung, wird ein στραηγός, mach ἆθλοι und bringt die Berufswissenschaften und die gewaltigen Lehrkünste durch die vernünftige
-Vorzüglichkeit hervor. LII. Er allein von den (Wesen) auf Erden hat,
+Vorzüglichkeit hervor.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="52">
+<p>Er allein von den (Wesen) auf Erden hat,
 indem er das Bild der Vorzüglichkeit bewahrte, die richtige Wage,
 <lb n="15"/> die Gewichte, Maße und Winkel(maße) ersonnen und unterscheidet,
 indem er durch die Vernunft gelenkt wird, das, was geschehen soll
@@ -1183,17 +1371,29 @@ und was nicht, und weiß jedermann zu geben, wie er es verdient.
 „Denn die Fische, wie es heißt, Vögel und Tiere fressen einander, deswegen
 weil e skein Gesetz unter ihnen gibt. Den Menschen aber hat
 <lb n="20"/> er die Gerechtigkeit gegeben, die besser ist für sie“, so sagt meiner
-Meinung nach sehr schön Einer von den Poeten. LIII. Er allein von
+Meinung nach sehr schön Einer von den Poeten.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="53">
+<p>Er allein von
 den (Wesen) auf Erden, der das Bild der göttlichen Vernunft in sich
 zeigt, hat ein Gerichtsgebäude in die Höhe gerichtet, handelt nach Art
 des gerechten Gerichtes Gottes und entscheidet Leben und Tod, indem
-<lb n="25"/> er den einen das Leben zutilt, den andern aber den Tod gibt. LIV. Er
+<lb n="25"/> er den einen das Leben zutilt, den andern aber den Tod gibt.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="54">
+<p>Er
 allein von den (Wesen) auf Erden vertraut dem kleinen Stück eines
-Baumes sein Leben an, hat die Weisheit der Schiffahrtskunst erfunden, <note type="marginal">Σ 27</note>
+Baumes sein Leben an, hat die Weisheit der Schiffahrtskunst erfunden, <milestone unit="altnumbering" n="27"/>
 lenkt das Schiff auf dem Rüchen des Meeres, überläßt sich
 der Tiefe der feuchten οὐσία und stößt den Tod zurück, der ihm zur
 <lb n="30"/> Seite steht, indem er nach oben in den Himmel schanut und an den Alllenker
-das Ziel der Rettung für die Fahrenden knüpft. LV. Der Mensch
+das Ziel der Rettung für die Fahrenden knüpft.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="55">
+<p>Der Mensch
 allein von den (Wesen) auf Erden hat die Lehre vom Laufe der Sterne
 gefunden; obwohl er (hier) unten im Leibe wandelt undmit der
 Schwere des Sterblichen bekleidet ist, steigt er doch in seinem Geiste
@@ -1205,29 +1405,47 @@ Schwere des Sterblichen bekleidet ist, steigt er doch in seinem Geiste
 <pb n="v.3.pt.2.p.67"/>
 kundigt *im Vorherwissen der kunftigen (Erscheinung durch die Theorie)
 sogar die Eklipse des Mondes an und sagt den Wandel der Perioden
-und den Wechsel der (Jahres-)zeiten voraus. LVI. Der Mensch allein
+und den Wechsel der (Jahres-)zeiten voraus.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="56">
+<p>Der Mensch allein
 von den (Wesen) auf Erden hat sich als Unterstutzer der Natur erwiesen
 und eine Methode der Heilung gefunden, hat die Kraft der Wurzeln <lb n="5"/>
 und Gifte und (ihre) Vermischund und Vermengung nach Gewicht und
 nach entsprechendem (Ma?e) in seinem Geist *beobachtet und (so) den
-kranken Leibern eine Heilung, dem Leben der Menschen eine Hulfe ersonnen.
-LVII. Er allein von den (Wesen) auf Erden, der keineswegs
+kranken Leibern eine Heilung, dem Leben der Menschen eine Hulfe ersonnen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="57">
+<p>Er allein von den (Wesen) auf Erden, der keineswegs
 zu einem Leben der Grasfresser gekommen ist, *folgte gut der Natur: <lb n="10"/>
 In der Zeit des Winters wirft er den Samen in die Erde und setzt die
 Muhe seines Schwei?es an die Bearbeitung (des Bodens), im Sommer aber
-erntet er die Fruchte seiner Arbeit. LVIII. Er allein von den (Wesen)
+erntet er die Fruchte seiner Arbeit.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="58">
+<p>Er allein von den (Wesen)
 auf Erden fuhrte durch vernunftige Wissenschaft eine Lehre des Alls,
 eine Disziplin und Komposition der Musik und eine Prufung durch Disputationen <lb n="15"/>
 herbei, ging dem Leben und Namen der Philosophie nach, pflegte
 eifrig die Liebe zur Tugend in sich und benutzte keineswegs den Sinn
-des Leibes, sondern die Kraft des Wissens und den Antrieb der Vernunft.
-LIX. Der Mensch allein von den (Wesen) auf Erden trug in
+des Leibes, sondern die Kraft des Wissens und den Antrieb der Vernunft.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="59">
+<p>Der Mensch allein von den (Wesen) auf Erden trug in
 seinem Gedachtnis Geschichten von dem, was fruher in Urzeiten geschehen <lb n="20"/>
 ist, verkehrt mit denen, die nicht (mehr) sind wie mit den Gegenwartigen,
 erforscht die Gedanken der Weisen, die je existierten, empfangt
 von ihnen mehr Unterstutzung als von denen, die mit ihm (leben), und
-<note type="marginal">Σ 28</note> ist durch die Kraft des Wortes, das dem Denken verwandt ist, mit denen
-zusammen, die fruher zugrunde gingen. LX. Er allein von den (Wesen) <lb n="25"/>
+<milestone unit="altnumbering" n="28"/> ist durch die Kraft des Wortes, das dem Denken verwandt ist, mit denen
+zusammen, die fruher zugrunde gingen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="60">
+<p>Er allein von den (Wesen) <lb n="25"/>
 auf Erden hat schon den artikulierten Laut mit einzelnen Artikulationsstellen
 geschaffen, durch die Kunst der Grammatik die ursprunglichen Buchstaben
 (des Alphabets) abgetrennt, die Teile und die kraft des Satzes
@@ -1237,7 +1455,11 @@ er im Gedachtnis und bringt gleichsam zu einem Haufen Worte
 des Schatzes des Alls, fa?t die fruheren Dinge und Geschichten
 in Einem Geiste, bringt diese, so oft er will, gleichsam aus einer unversieglichen
 Quelle nach Art eines Stromes hervor und la?t sie in die
-Ohren aller gegenwartigen uberflie?en. LXI. Der Mensch allein von <lb n="35"/>
+Ohren aller gegenwartigen uberflie?en.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="61">
+<p>Der Mensch allein von <lb n="35"/>
 den (Wesen) auf Erden ahnelt sich durch seine Taten dem uber alles
 (waltenden) Gott an und jeder, der will, bildet Leben, indem er die
 <note type="footnote">1 1. <foreign xml:lang="abbr">ABBREV</foreign> mit HS 2 "und" Σ=κα? 7 "verbunden" l.
@@ -1251,13 +1473,17 @@ Mit vernünftiger Kraft nacheifernd. (So) scjafft der Mensch den Menschen
 bald in Stein und bald in Holz, bald in Farbenschmelz und (bald)
 <lb n="5"/> in unveränderliche Bilder, und gestaltet alle arten der Tier und Pflanzen
 Auf dieselbe Weise und zeigt durch seine Taten vollkommen (deutlich)
-Die Kraft des Bildes Gottes. LXII. Er allein von den (Wesen) auf Erden
+Die Kraft des Bildes Gottes.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="62">
+<p>Er allein von den (Wesen) auf Erden
 Bildete auf der Erde, auf der er wandelt, das Gewölbe des Himmels
 Nach, groub das Bild eben des Himmels in die  ὔλη des Erzes, befestigte
 <lb n="10"/> daran ein Abbild der Planeten und Fixsterne, ordnete die Fristen der
-Perioden und Zeiten durch die bildende Kunst, umgab es auβen rings
-Mit Tierfiguren und bildete (so) das Himmelsgewölbe durch die Gröβe
-Des Wissens nach Art der geschauten Dinge. (Dies) lieβ er (dann), wie
+Perioden und Zeiten durch die bildende Kunst, umgab es außen rings
+Mit Tierfiguren und bildete (so) das Himmelsgewölbe durch die Größe
+Des Wissens nach Art der geschauten Dinge. (Dies) ließ er (dann), wie
 Der got des Himmels, auf der  Erde seine Drehung mit dem All vollziehen.
 <lb n="15"/> (So) kreist es sich in unendlichem Wunder und mit *den (wirklichen Dingen)
 Am Himmel *kreisen sich die auf Erden (befindlichen)
@@ -1265,36 +1491,43 @@ Irdisch-hylischen Abbilder. Mit lauter Stimme ruft der Engel der Hore n
 Allzumal warden sie in Einem Augenblick bewegt, die Türen öffnen sich
 Non selbst beim Kommen der Horen, die seelenlosen Bilder der Vögel,
 <lb n="20"/> die rings umher *angebracht sind, *rufen zirpend; der Mond, auf Erden
-(abgbldet), läuft mit dem am Hmmel, das Erz wandelt von selbst <note type="marginal">Σ 29</note>
+(abgbldet), läuft mit dem am Hmmel, das Erz wandelt von selbst <milestone unit="altnumbering" n="29"/>
 ihm(ausgehende) Licht bald halb bald abnehmend bald voll, und die Bilder der
 Horen entsprechen den Horen der Natur, und so wetteifert die (durch)
 <lb n="25"/> menschliche (Kunst konstruierte) Welt mit der Schöpfertätigkeit des göttlichen
-Logos. LXIII. Der Mensch allein von den (Wesen) auf Erden
+Logos.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="63">
+<p>Der Mensch allein von den (Wesen) auf Erden
 Ist imstande, durch unaussprechliche Worte, durch Gebete, die von Gott
 Geliebt  warden, und durch die Kraft eines gottesfürchtigen Wortes und
 Wandels die Natur der verborgenen, unsichtbaren Dämonen in die Ferne
 <lb n="30"/> zu treiben, aber er ist auch, indem er vom rechten Wege abging, so sehr
-Mächtig geworden, daβ er das durch die luft fliegende Geschlecht durch
+Mächtig geworden, daß er das durch die luft fliegende Geschlecht durch
 Abgesänge und Besprechungen unterwarf, und ferner schleppt er durch
 Das Mittle des Zwanges und durch die bezauberung physischer Knoten
 *die leiblosen, um die Erde gleich fliegenden Vögeln fliegenden Kräfte
 <note type="footnote">7 vgl. Gen 1 27</note>
-<note type="footnote">4 ,,Farbenschmelz“ wötlich ,,die Blüte der Farben“, wohl ἄνθος χρωμάτων
+<note type="footnote">4 „Farbenschmelz“ wötlich „die Blüte der Farben“, wohl ἄνθος χρωμάτων
 15 Statt <foreign xml:lang="abbr">ABBREV</foreign> lies <foreign xml:lang="abbr">ABBREV</foreign> 16 Statt <foreign xml:lang="abbr">ABBREV</foreign> lies <foreign xml:lang="abbr">ABBREV</foreign> entsprechend
 <foreign xml:lang="abbr">ABBREV</foreign> 20 Statt <foreign xml:lang="abbr">ABBREV</foreign> lies <foreign xml:lang="abbr">ABBREV</foreign> und ebenso statt <foreign xml:lang="abbr">ABBREV</foreign>:
 <foreign xml:lang="abbr">ABBREV</foreign> 34 Statt <foreign xml:lang="abbr">ABBREV</foreign> lies <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.69"/>
-und zerrt und fesselt sie, woe r will, und läβt sie auf sie auf Bildern wohnen,
+und zerrt und fesselt sie, woe r will, und läßt sie auf sie auf Bildern wohnen,
 (und  so) zeigt (der,) der (sich) Götter macht, eben durch seine Taten,
-daβ seine eigene Kraft besser ist als die von ihm verfertigte Gottheit.
-LXIV. Der Mensch allein zeigt, wie groβ die Vorzüglichkeit des geistigen,
-unkörperlichen Seins ist, beweist, daβ seine  Kraft weder unterjocht <lb n="5"/>
+daß seine eigene Kraft besser ist als die von ihm verfertigte Gottheit.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="64">
+<p>Der Mensch allein zeigt, wie groß die Vorzüglichkeit des geistigen,
+unkörperlichen Seins ist, beweist, daß seine  Kraft weder unterjocht <lb n="5"/>
 noch vermindert wird vom Bösen, bietet seinen Leib dem Feuer, dem
 Eisen, den wilden Tieren und der Tiefe des Meeres dar und nähert (ihn)
-jeder Art von Qualen. Er weiβ, daβ eben seine  Natur eiligst zugrunde
+jeder Art von Qualen. Er weiß, daß eben seine  Natur eiligst zugrunde
 geht, flüssig (d. h. vergäuglich) ist und aufgelöst wird, während er das,
-was drinnen sitzt (d.h. die Seele), nicht preisgibt. Daβ dies ein anderes <lb n="10"/>
+was drinnen sitzt (d.h. die Seele), nicht preisgibt. Daß dies ein anderes <lb n="10"/>
 ist als das, was geschlagen wird, beweist, er, indem er ausruft: „Schlage,
 schlage den Schafspelz; den mich schlägst du nicht“. Ein anderer
 wiederum ruft freimütig aus: ütig aus: „Verbrenne und röste den Leib! Sättige
@@ -1303,19 +1536,23 @@ die Sterne zur Erde herab und steigt die Erde zum Himmel hinauf, <lb n="15"/>
 ehe ein schmeichelndes Wort von mir dir begegnet“. Und Einer der
 Gottliebenden brachte, als er Böses ertrug, folgende  Worte vor: „Wer
 will mich scheiden von der Liebe Gottes? Betrübnis oder  Drangsal oder
-Verfolgung oder Hunger oder Blöβe oder Kälte oder Schwert? “ Auch
+Verfolgung oder Hunger oder Blöße oder Kälte oder Schwert?“ Auch
 ich aber habe jüngst (Leute) gesehen, teils mit herausgerissenen Augen, <lb n="20"/>
-teils durch Brenneisen ihrer Füβe beraubt, teils gekreuzigt. Ihr ganzer
+teils durch Brenneisen ihrer Füße beraubt, teils gekreuzigt. Ihr ganzer
 Leib verging und ihre sterbliche Natur ward zuschanden gemacht, aber 
-<note type="marginal">Σ 30</note> das gottliebende Wissen, das in ihnen wohnt, wurde nicht bewegt noch
+<milestone unit="altnumbering" n="30"/> das gottliebende Wissen, das in ihnen wohnt, wurde nicht bewegt noch
 unterworfen und nicht einmal (in) jenen schwersten (Stunden) preisgegeben,
 indem sie denen, die den Geist nicht *zugrunde richten, <lb n="25"/>
-deutlich zeigten, daβ die Kraft ihrer Vorzüglichkeit etwas anderes als
-das Vergängliche sei. LXV. Er allein von den Lebewesen auf Erden
+deutlich zeigten, daß die Kraft ihrer Vorzüglichkeit etwas anderes als
+das Vergängliche sei.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="65">
+<p>Er allein von den Lebewesen auf Erden
 ist des göttlichen Hauches teilhaftig geworden und des *Anblicks
 Gottes gewürdigt, redet mit den Engeln Gottes und hat das Vorauswissen
 des Zukünftigen erreicht bald durch Träume im Schlafe, 30
-bald freilich durch göttliche Kraft so geistbekleidet, daβ er sogar
+bald freilich durch göttliche Kraft so geistbekleidet, daß er sogar
 eine Prophezeiung des Zukünftigen sagt und seine Gemeinschaft
 <note type="footnote">11 = Wort des Anaxarch: Zeller I 5 963 13 Praep. VI 6 2 Trag. fr. 687
 17 = Röm 8 35</note>
@@ -1326,14 +1563,22 @@ wird“ Σ, besser liest man <foreign xml:lang="abbr">ABBREV</foreign> statt <fo
 lies <foreign xml:lang="abbr">ABBREV</foreign> des lies <foreign xml:lang="abbr">ABBREV</foreign> des „Anblicks“ mit HS. PSm will <foreign xml:lang="abbr">ABBREV</foreign> der „Oftenbarung“</note>
 
 <pb n="v.3.pt.2.p.70"/>
-mit der Gottheit durch Kundtun * solcher Thaten bestätigt. LXVI. Er
+mit der Gottheit durch Kundtun * solcher Thaten bestätigt.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="66">
+<p>Er
 allein kennt das, was durchweg gröBer und besser ist als alles Sichtbare:
 das, was mit den Augen nicht gesehen, durchs Tasten nicht wahrgenommen
 wird, noch mit Einem (andern) von den Sinnen des Leibes,
 <lb n="5"/> sondern von dem Verstande und Geiste allein gesehen wird. Er hat es
 durch seine eigene lehre und durch die Belehrung seiner Natur bekannt
 und Gott genannt, hat es gelobt und seine Vervandtschaft mit der
-Gottheit durch sieses Wissen gezeigt. LXVII. Er allein stand da als
+Gottheit durch sieses Wissen gezeigt.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="67">
+<p>Er allein stand da als
 Zuschauer der gewaltigen Taten des göttlichen Logos und ward würdig,
 <lb n="10"/> den oberhallo des Himmels (wohnenden) Vater mit gottgeziemenden
 Lobgesängen zu loben und sich der Schar der Engel im Himmel anzuähneln,
@@ -1342,14 +1587,21 @@ erlangte und durch sie ihn, der die Ursanche alles Guten ist, infolge
 seines natürlichen Denkens erkannte und sich verpflichtet fühlte, Lobgesänge
 <lb n="15"/> des Bekenntnisses und geziemenden Preis als den dem Vater
 schuldigen Tribut darzubrigen.</p>
-<p>LXVIII. Die Zeugnisse aller dieser (Dinge) bestätgt das Wort
+</div>
+	   
+<div type="textpart" subtype="chapter" n="68">
+<p>Die Zeugnisse aller dieser (Dinge) bestätgt das Wort
 göttlicher Lehre und Wissenschaft,  dab von unsterblicher und den
 Himmelsbürgern verwandter Natur er allein von den (Wesen) auf Erden
-<lb n="20"/> existiert &lt;wegen&gt; dieser geistigen und vernünftigen οὐσία in den Menschen,
+<lb n="20"/> existiert <add>wegen</add> dieser geistigen und vernünftigen οὐσία in den Menschen,
 und dab er das geliebte Kind des göttlichen Logos ist, des gemeinsamen
 Erlösers aller, der (ihn) nach dem Bilde and der Ähnlichkeit
-seines eigenen Vaters in seiner Natur vollendet. LXIX. Wenn also
-dies    vernünftige Lebewesen, er, der an so  grober Vorzüglichkeit teil <note type="marginal">Σ 31</note>
+seines eigenen Vaters in seiner Natur vollendet.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="69">
+<p>Wenn also
+dies    vernünftige Lebewesen, er, der an so  grober Vorzüglichkeit teil <milestone unit="altnumbering" n="31"/>
 <lb n="25"/> hat, er, der allein von den (Wesen) auf Erden nach dem Bilde
 Gottes (geschaffen ist), der Bruder der göttlichen Kräfte und der
 Engel im Himmel, in seiner Natur geziemend gelebt hätte und
@@ -1391,8 +1643,12 @@ ferner: „Selbst wenn wir im Leibe lebten, so dienen wir doch nicht nach <lb n=
 dem Fleische. “Und: „ Wir sind hinzugekommen zur Stadt des lebendigen
 Gottes Im Himmel und zu der Schar von Myriaden Engeln und zu einer
 Gemeinde von Erstgebornen, die im Himmel verzeichnet sind.“ Dies (sind)
-<note type="marginal">Σ 32</note> Worte von bekannten und gottliebenden Männern. LXX. Wenn aber viele <lb n="25"/>
-Toren die (Dinge) der hiesigen (irdischen) Lust *lieben,, solche die bis
+<milestone unit="altnumbering" n="32"/> Worte von bekannten und gottliebenden Männern.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="70">
+<p>Wenn aber viele <lb n="25"/>
+Toren die (Dinge) der hiesigen (irdischen) Lust *lieben „solche die bis
 jetzt (noch) in ihrem Denken unmündig sind, was besagyt dies gegenüber
 dem wahren Wort? Denn der, der im Leibe empfangen ist, freut
 sich über seinen gewohnten Ort, fürchtet sich vor der Veränderung
@@ -1415,7 +1671,11 @@ kommt in Blüte ein besseres und preiswürdigeres Leben durch groBen
 Reichtum, vielen Besitz, durch Vollmacht, Herrschaft und andere Stufen.
 <lb n="5"/> Das, was infolge seiner guten Geburt, und das, was infolge der Erziehung
 zur Entfaltung gebracht ist, und Myriaden anderes legt den Grund zu
-einem Leben von angenehmen Dasein. LXXI. Wenn sich aber eine
+einem Leben von angenehmen Dasein.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="71">
+<p>Wenn sich aber eine
 unnatürliche Umkehrung ereignet dessen, der im Leibe empfangen ist,
 was habe ich nötig das, was ihm bei seinem Hervorgehen, bei seiner
 <lb n="10"/> Goburt folgt, zu sagen? DaB das innen umgekehrte Kind sich weigert,
@@ -1425,14 +1685,18 @@ und mit Zwang an es herangebracht warden, und da Bes nicht
 einmal Einer Zeugung wert ist, noch des Lebens der Menschen, noch
 <lb n="15"/> ndessen, was ihm folgt? Da Bes im Gegenteil vielmehr von der Finsternis
 zur Finsternis hervorgeht und nicht nur des Lebens der Menschen,
-sondern auch des Namens beraubt ist? LXXII. DemgemäB also ist auch
+sondern auch des Namens beraubt ist?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="72">
+<p>DemgemäB also ist auch
 der, welcher ein menschliches Leben auf Erden führt, in nichts von einem
 unvernünftigen und unwissenden Säugling oder dem, der noch im Leib
 <lb n="20"/> getragen wird, unterschieden und ist, unvergleichbar mit den äuBeren
 Körpern der Engel und göttlichen Geister, sogar ein unwissendes Kind.
 Wegen der GröBe siner Kindlichkeit frut er sich über die Bekleidung
 Des Leibes, der ihn umgiebt, und liebt seinen Bauch, ohne zu kennen
-Den „Ort rings um ihn, wo Mord und Groll und die anderen Arten des <note type="marginal">Σ 33</note>
+Den „Ort rings um ihn, wo Mord und Groll und die anderen Arten des <milestone unit="altnumbering" n="33"/>
 <lb n="25"/> Schicksals wie auf Wiesen des Bösen in der Finsternis weiden,“ sagt
 Einer von den Alten, indem er zeigt, daB die feuchte und dunkle Luft
 Auf Erden aus vielen Mischungen von Myriaden aus der Erde (aufsteigenden)
@@ -1474,7 +1738,7 @@ und gar eintaucht und das keineswegs wie das Kind unfreiwillig, sondern
 freiwillig und auf den Rat seiner Freiheit, (wer) sich diese bösen
 (Dinge) erwählt und tut, wie sollte sein Ende offenkundig ein Abbild
 des gezeigten Beispiels sein? Denn nicht warden ihn die fröhlichen <lb n="25"/>
-<lb n="Σ 34"/> Gesichter und das Lachen gutter Engel sehen, noch warden ihn, sobald er
+<milestone unit="altnumbering" n="34"/> Gesichter und das Lachen gutter Engel sehen, noch warden ihn, sobald er
 zum Lichte hervorgeht, die Kräfte Gottes als Ammen aufnehmen, sondern
 indem er bei seinem Ende vor dem Hervorgehen flieht und sich in der
 innersten Verborgenheit des Leibes und in den Gliedern versteckt, warden
@@ -1492,45 +1756,53 @@ die guten Kräfte . . . . warden aufnehmen“ Σ 15 „tanzt“ Σ wohl = χορ
 
 <pb n="v.3.pt.2.p.74"/>
 wegen weil er nicht erzogen ward durch die Vernunft noch dem göttlichen
-Gesetze entsprach, obwohl er konnte. LXXIII. Denn das nach
+Gesetze entsprach, obwohl er konnte.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="73">
+<p>Denn das nach
 dem (gewählten) Beispiel (im Leibe) empfangene Kind ist in allem gering
-und ermangelt in allem der Draft, so daβ es sich noch nicht einmal
+und ermangelt in allem der Draft, so daß es sich noch nicht einmal
 <lb n="5"/> des Denkens der Seele noch der Sinne des Leibes bedient. Der aber
 noch kndliche Verstand in den Menschen ist *gleichsam in prüfender
 Vergleichung mit den körperlosen, göttlichen &lt;und&lt; vernünftigen (Wesen)
-im Himmel mit Recht ganz und gar ,,kindlich” genannt worden. Und
-selbst wenn es ,,der Weiseste ist von allen Menschen” und selbst wenn
+im Himmel mit Recht ganz und gar „kindlich” genannt worden. Und
+selbst wenn es „der Weiseste ist von allen Menschen” und selbst wenn
 <lb n="10"/> es der Vollkommenste ist von denen auf Erden, so ist er nichts besser
 als ein Kind, wenn er an sich selber mit seiner (späteren) Vollkommenheit
 verglichen wird. Wie er aber in seiner Vorzüglichkeit wird, sobeald
 er zum Manne(salter) gekommen ist, ist leicht so zu prüfen: Denn wen er, bis jetzt noch Kind und in die feste Mauer der irdischen und
 <lb n="15"/> vergänglichen οὐσία eingeschlossen, solche Kraft der Vorzüglichkeit (in
-sich) trägt, daβ  er keinswegs nur die (Dinge) auf Erden kennt und
+sich) trägt, daß  er keinswegs nur die (Dinge) auf Erden kennt und
 künstlerisch schafft, sondern (wenn er) sich auch dem Leben im Himmel,
 eben Gott, vorher anähnelt und, sobald er will, Abbilder der (Dinge)
 im Himmel und auf Erden schafft &lt;und alles das, was kürzlich aufgezählt
 <lb n="20"/> ist, ebenso wirken kann, während er in den Kot des Leibes
-und Blutes getaucht ist, *wie müssen wir glauben, daβ er (erst) wirken
-kann, sobald er Zum vollkommenen Maβe der Reife des Mannes hervorgegangen
+und Blutes getaucht ist, *wie müssen wir glauben, daß er (erst) wirken
+kann, sobald er Zum vollkommenen Maße der Reife des Mannes hervorgegangen
 ist und aus den schädlichen und vergänglichen, den flüssigen
 und feuchten Fesseln des Leibes gelöst ist und teil hat an dem unvergänglichen
 <lb n="25"/> Leben und dem unsterblichen Leibe? Denn wenn der Same
-der vernünftigen Kraft allein so sehr auf Erden mächtig und kräftig <note type="marginal">Σ 35</note>
+der vernünftigen Kraft allein so sehr auf Erden mächtig und kräftig <milestone unit="altnumbering" n="35"/>
 ist, obwohl er noch nicht seine vollkommene Triebkraft empfangen hat,
 sondern sogar obwohl er in den feuchten, kotigen Ort des vergänglichen
 Leibes geworfen ist, so ist es möglich, hieraus zu erkenne, wie
-<lb n="30"/> groβ die Triebkraft des Samens der vollkommenen Früchte in den
+<lb n="30"/> groß die Triebkraft des Samens der vollkommenen Früchte in den
 Seelen ist, sobald er an dem geziemenden Acherbau teil hat und von
 hier verändert und an den vorzüglichen Ort in gutes und ertragreiches
 Land gepflanzt ist, wo der himmlische Logos, der Säemann des Alls und
 der Pflanzer alles Guten seinen eigenen Samen empfängt und auf den
 <lb n="35"/> leib- und körperlosen Seelenwiesen wie im Paradies der Gottliebenden
 <note type="footnote">8 f. vgl. Heraklit fr. 83 Diels (dazu: Wendland in Stud. 152ft.) 33 vgl. Ps. Sal. 142.3.</note>
-<note type="footnote">6 ,,und wie” Σ lies <foreign xml:lang="abbr">ABBREV</foreign> 7 ,,und” &lt; Σ, lies <foreign xml:lang="abbr">ABBREV</foreign> 19 ,,und” &lt; Σ lies <foreign xml:lang="abbr">ABBREV</foreign> 21 ,,und wie” Σ 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
+<note type="footnote">6 „und wie” Σ lies <foreign xml:lang="abbr">ABBREV</foreign> 7 „und” &lt; Σ, lies <foreign xml:lang="abbr">ABBREV</foreign> 19 „und” &lt; Σ lies <foreign xml:lang="abbr">ABBREV</foreign> 21 „und wie” Σ 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.75"/>
 seine eigene Pflanze tränkt und zur  Vollkommenheit aufzieht und zur
-Blüte von gewaltigen guten (Dingen) bringt. LXXIV.  Du wirst aber
+Blüte von gewaltigen guten (Dingen) bringt.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="74">
+<p>Du wirst aber
 die Größe der vorzüglichen Vollkommenheit des Menschen (im Unterschied)
 von dem hiesigne Wandel und sein Wachstum erkennen, wenn
 dul bedenkst, daß das eben geborne Kind nichts Besseres ist als ein <lb n="5"/>
@@ -1544,7 +1816,7 @@ wenn sie ihn sehen, entscheiden können, ob er derselbe sei, der im
 Leibe gesät und in Finsternis empfangen wurde, ob er derselbe sei, der
 aus der Finsternis hervorging, der mit Milch und in Windeln großgezogen 
 wurde. wie der, der jetzt als Mensch in Weisheit und Wissen <lb n="15"/>
-die ganze Welt betrachtet &lt;und&gt; der alle die Dinge auf Erden unterwirft.
+die ganze Welt betrachtet <add>und</add> der alle die Dinge auf Erden unterwirft.
 Wenn aber jemand gleichsam durch einen Vergleich der Kraft
 Gottes und der Engle mit der des eben ggebornen Kindes in die Mitte
 den vollkommenen Mann stellen wollte, so ist eine völlige Übereinoder
@@ -1554,12 +1826,16 @@ von der Kraft der engel. Denn das eben geborne menschliche
 Kind gleicht in seinem Wesen nicht einmal den eben gebornen unvernünftigen <lb n="25"/>
 Tieren. Wer aber zum vollkommenen Gemeinschaft mit dem
 göttlichen Geiste, redet mit den Engeln, gewinnt Zuneigung und Liebe
-<note type="marginal">Σ 36</note> für den himmlischen verkehr und bereitet sich durch ein keusches und
+<milestone unit="altnumbering" n="36"/> für den himmlischen verkehr und bereitet sich durch ein keusches und
 gottesfürchtiges Leben vorher vor für die  keineswegs in weiter Zeitferne <lb n="30"/>
 (liegende) Übereinstimmung mit den engeln, und wird an (ihrem) Leben
 und an (ihrer) Vorzüglichkeit teil haben, was auch der göttliche Logos
 zeigt,  indem er sagt: „ Was ist der Mensch, daß du sein wenig unter die
-Engel erniedrigt, hast ihn mit Ehre und Preis bekleide“. LXXV. Wenn <lb n="35"/>
+Engel erniedrigt, hast ihn mit Ehre und Preis bekleide“.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="75">
+<p>Wenn <lb n="35"/>
 also das Kind, sobald es größer wird in seiner natürlichen Gestalt und
 zu der ihm gebührenden Nahrung und Erziehung gelangt, einen so
 <note type="footnote">33 = Psalm 8 5.6</note>
@@ -1595,7 +1871,7 @@ wird sie weise. Und so oft sie weise wird, wendet sie ihr Angesicht
 weg von der Gemeinschaft der Sterblichen und gibt sich auf der Stelle
 dem keuschen Wissen hin und verzichtet ein wenig auf den Antrieb
 der Natur des Leibes. Und sie wird mit Recht noch glänzender, richtiger
-<lb n="30"/> und aufgeweckter, sobald sie mächtig ist entsprechend ihrem eigenen <note type="marginal">Σ 37</note>
+<lb n="30"/> und aufgeweckter, sobald sie mächtig ist entsprechend ihrem eigenen <milestone unit="altnumbering" n="37"/>
 Reichtum. Dann hatt sie teil am Wissen, an der Weisheit und an aller
 Vorzüglichkeit, sobald  sie vom Antrieb dedr Leidenschaften des leibes
 ihr Antilitz wegwendet. Aber sie halt es nicht einmal für würdig, sich
@@ -1603,7 +1879,7 @@ den Augen des Leibes zu nähern noch durch seine anderen Sinne zu
 <lb n="35"/> wirken, solange sie über die Vorzüglichkeit nachsinnt. So oft sie aber
 kräftig sich verschließt und sich innerlich sammelt und weit weggeht
 <note type="footnote">5 „seiner“] „ihrer“ (der Engel) Σ. Falsches Explizitum 17 „für sich selbst
-existiert“] ist hinter <foreign xml:lang="abbr">ABBREV</foreign> etwas ausgefallen? Etwa „in sich selber &lt;gut&gt; wird“;
+existiert“] ist hinter <foreign xml:lang="abbr">ABBREV</foreign> etwas ausgefallen? Etwa „in sich selber <add>gut</add> wird“;
 vgl. Z. 26 dagegen 773 18 man erwartet <foreign xml:lang="abbr">ABBREV</foreign> 31 „Reichtum“ Σ, lies vll.
 <foreign xml:lang="abbr">ABBREV</foreign> = κατασκευή „Αnlage“</note>
 
@@ -1624,37 +1900,40 @@ aber wird nach unten in die Tiefe weichen und voll warden von Irrtum,
 Unverstand und aller Torheit. Was haben wir also nötig, uns vor dem
 trennendden Tode zu fürchten, dem Befreeier der Seele vom Leibe? Und <lb n="15"/>
 warum sollen wir das Ablegen des schlechteren nicht zur Hilfe des
-Besseren annehmen und bekennen, daβ dann in Wahrheeit rein und selig
+Besseren annehmen und bekennen, daß dann in Wahrheeit rein und selig
 das leben der Gottliebenden sein werde, sobald nichts von entgegengesetzter
 (Natur) sie hindert? Denn wenn er, während die vernünftige
-Natur an diesem Ort und in diesem Gafäβ ist und auf Erdden wohnt und <lb n="20"/>
+Natur an diesem Ort und in diesem Gafäß ist und auf Erdden wohnt und <lb n="20"/>
 mit einem dichten und irddischen Leibe nach Art von etwas *Tönernem
-Bekleidet ist, so sehr trotz seines Gewandes sich anstrengt, daβ er im
+Bekleidet ist, so sehr trotz seines Gewandes sich anstrengt, daß er im
 Geeiste in die Höhe springt und die Glieder des  Leibes samt den Begierden
 durch enthaltsamkeit und Unterdrückung der Begierden tötet
 und vielmehr eifrig sich müht un bemüht um das Leben der Leiblosen, <lb n="25"/>
 sich hunter Führung der Weisheeit zu jeder Zeit absondert und
 frei macht von der Mischung des Schlechteren, und bereits vorher
 zu jeder Zeit *sich übt zu sterben, falls er einmal vonseinen fesseln
-<note type="marginal">Σ 38</note> gelöst wird, *so wird er Schwingen wachsen lassen infloge seiner
+<milestone unit="altnumbering" n="38"/> gelöst wird, *so wird er Schwingen wachsen lassen infloge seiner
 hiesigen Fürsorge und Übung, dann bei seinem Ende fliegen, den Ort <lb n="30"/>
 auf Erden vertauschen und (im Himmel) das treffen, was er liebt. Wie
 das geschehen wirdd, frage nicht! Denn der Verkehr mit den Engeln im
 Himmel, dessen er gewürdigt ist, wird dann, sobald er an seinem Leeibe,
 dessen Natur sich von der Vergänglichkeit zur Unvergänglichkeit ändert,
 <note type="footnote">34 vgl. I Kor 15 54</note>
-<note type="footnote">9 ,,und“ &lt; Σ, lies Abbrav 11 ,,und so wird“ Σ, streic he da Abbrav 211.
-Abbrav 22 ,,sich anstrengt“] Abbrav = ἐπίπονος Σ 196 12 25 ,,sich beeilt
-und eilt“ Σ = σπεύδει καὶ σπουδάζει 28 ,,sich übt“] ,,sich ergötzt“ Σ 1.
-Αbbrav entsprechend dem folgenden Abbrav 29 ,,und so wird er“ Σ str.
+<note type="footnote">9 „und“ &lt; Σ, lies Abbrav 11 „und so wird“ Σ, streic he da Abbrav 211.
+Abbrav 22 „sich anstrengt“] Abbrav = ἐπίπονος Σ 196 12 25 „sich beeilt
+und eilt“ Σ = σπεύδει καὶ σπουδάζει 28 „sich übt“] „sich ergötzt“ Σ 1.
+Αbbrav entsprechend dem folgenden Abbrav 29 „und so wird er“ Σ str.
 abbrav vor Abbrav</note>
 
 <pb n="v.3.pt.2.p.78"/>
 *das Bild des Lichtes und das Bild des Glanzes empfangen hat, eintreten
 in der Art, in der auch das Geschlecht der göttlichen Engel lebt, entsprechend 
 der (im Menschen) eingeschlossenen Vernunft. Natürlich wird
-er auch teil haben an der Vorzüglichkeit jener zumal und an der Unsterblicheit.
-<lb n="5"/> LXXVI. Denn wie be idem Samen, der auf die Erde
+er auch teil haben an der Vorzüglichkeit jener zumal und an der Unsterblicheit.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="76">
+<lb n="5"/><p>Denn wie be idem Samen, der auf die Erde
 fällt, die Triebkraft, — der sogenannte Keim, — derart ist, daß sie den
 moisten verborgen liegt, sie, die zwar jetzt in dem Samen *eingeengt,
 aber ruhig nach Art eines Funkens drinnen im dichten Leibe eingeschlossen 
@@ -1663,7 +1942,11 @@ ist, und (wie) eben dieser Same, sobald er in die Erde fällt
 aufgelöst wird, dann als lebendig sich erweist, und (wie) er die Kraft, die
 in ihm (liegt), bewegt und von der ὕλη unter sich nimmt, und (wie) er
 äußere alte und dichte Gewand anuszieht, und vielmehr ein neues anlegt,
-<lb n="15"/> das besser ist als das alte, LXXVII. demgemäß ist auch die Natur der
+<lb n="15"/> das besser ist als das alte,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="77">
+<p>demgemäß ist auch die Natur der
 vernünftigen Kraft im Menschen, die jetzt an den vergänglichen Leib
 * gebunden ist und schlechter als die ihr eigentümliche Kraft wirkt.
 Wenn sie aber von dem Vergänglichen befreit wird, das sie umgibt,
@@ -1691,7 +1974,7 @@ man (??) 32 Der syr. Übersetzer denkt an den  persönlichen Logos, da er das
 Mask. gebraucht</note>
 
 <pb n="v.3.pt.2.p.79"/> 
-<note type="marginal">Σ 39</note> angeähnelt hat, sollte nicht einmal sein wie die Samen(körner), die zur
+<milestone unit="altnumbering" n="39"/> angeähnelt hat, sollte nicht einmal sein wie die Samen(körner), die zur
 Erde fallen? Oder (ist der Mensch) nicht viel besser? Denn er trägt
 Keineswegs Grannen noch Gräser, sondern die vollkommenen und dichten
 Ähren seiner Vorzüglichkeit, dann wenn er dem irdischen Verderben
@@ -1700,7 +1983,9 @@ den Verkehr im Himmel gegen den auf Erden eingetauscht hat.
 Sobald er neben Gott tritt, läßt er in Wahrheit wie die Engel gottgeliebte
 Früchte sprossen, deren Same und Kraft früher im sterblichen
 Leibe eingeschlossen und wie in einem Ofen eingeengt war.</p>
-<p>LXXVIII. Nachdem all dies zum beweise der geistigen und vernünftigen <lb n="10"/>
+</div>
+<div type="textpart" subtype="chapter" n="78">
+<p>Nachdem all dies zum beweise der geistigen und vernünftigen <lb n="10"/>
 οὐσία im Menschen gesagt ist, wollen wir fortan in unserm
 Sermon zum Folgenden kommen. Wenn also der Mensch, der im Verkehr
 auf Erden aufgewachsen ist, seine eigene Größe kennte und sich
@@ -1726,7 +2011,7 @@ die lüsternen Begierden des Leibes der ihm eigenen Grüße vorgezogen,
 hat die Gerechtigkeit seines Vaters im Himmel und sein Lob
 vernachlässigt und hat die unvernünftigen Antriebe des Wahnsinns und
 der Phantasie ausgesucht, was die törichtsten der Kinder zu tun pflegen, <lb n="35"/>
-<note type="marginal">Σ 40</note> die die fürsorgliche Lehre und Zucht derer fliehen, die ihr Denken
+<milestone unit="altnumbering" n="40"/> die die fürsorgliche Lehre und Zucht derer fliehen, die ihr Denken
 *groß gemacht haben. Das, was für den Augenblich angenehm ist,
 <note type="footnote">20 Statt <foreign xml:lang="abbr">ABBREV</foreign> „die“ lies <foreign xml:lang="abbr">ABBREV</foreign> „und“ 23 „berufswissenschaften“ vgl.zu S. 6611
 26 Statt <foreign xml:lang="abbr">ABBREV</foreign> (Genitiv) lies <foreign xml:lang="abbr">ABBREV</foreign> „und“ 34 Gemeint sind die Antriebe zum Götzendienst
@@ -1744,26 +2029,32 @@ treibt sie von oben in die Tiefen des Bösen, damit alle, die auf Erden (sind), 
 <lb n="10"/> und (damit) die Frucht des Bösen an Stelle des Samens der Vorzüglich-
 keit *erblühe. (So) fiel derjenige, der der allerfriedlichste, weiseste und vernünftigste war von allen auf Erden, in die äußerste Wildheit und
 Unvernunft, so daß einer von den Gettliebenden über die Katastrophe
-seines Falles weint, ausruft und spricht: ,,Der Mensch in seiner Ehre
+seines Falles weint, ausruft und spricht: „Der Mensch in seiner Ehre
 15 hatte keine Einsicht, sondern wurde dem Tiere gleichgemacht und ihm
-angeähnelt“. LXXIX. Deswegen war also mit Recht ein großer Erlöser,
+angeähnelt“.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="79">
+<p>Deswegen war also mit Recht ein großer Erlöser,
 der größber ist als alle Menschen, ihnen erforderlich, und dies war eben
 jener Fürsorger, der sich um alles Kümmert, der Logos Goittes, der nach
 Art eines guten und liebenden Vaters durch Taten seine Fürsorge für
 <lb n="20"/> die vernünftigen Seelen auf Erden zeigte und der sich eifrig bemühte
 durch eigene Botschaft um das Aufsuchen und die Heilung derer, die
 des Weges zogen und zu Grunde gingen.</p>
-<p>zu Ende ist der erste Sermon des Cäsareensers.</p>
+</div>
+<note>zu Ende ist der erste Sermon des Cäsareensers.</note>
 <note type="footnote">14 = Psalm 49 (LXX: 48) 21.</note>
-<note type="footnote">3 ,,Während so alle Menschen sich befinden, stellt die Vermehrung des
-Bösen“ . . . . Σ, aber lies <foreign xml:lang="abbr">ABBREV</foreign> 6 ,,Reichtum“ Σ, aber lies <foreign xml:lang="abbr">ABBREV</foreign>
-=κατασκευή 11 lies <foreign xml:lang="abbr">ABBREV</foreign> Bernstein 14 ,,seines“] ,,ihres“ Σ κατὰ σύνεσιν
-15 παρασυνεβλήφη LXX ,,wurde überliefert“ Σ 20 ,,eilen“ Σ = σπεύδω</note></div>
+<note type="footnote">3 „Während so alle Menschen sich befinden, stellt die Vermehrung des
+Bösen“ . . . . Σ, aber lies <foreign xml:lang="abbr">ABBREV</foreign> 6 „Reichtum“ Σ, aber lies <foreign xml:lang="abbr">ABBREV</foreign>
+=κατασκευή 11 lies <foreign xml:lang="abbr">ABBREV</foreign> Bernstein 14 „seines“] „ihres“ Σ κατὰ σύνεσιν
+15 παρασυνεβλήφη LXX „wurde überliefert“ Σ 20 „eilen“ Σ = σπεύδω</note></div>
 
 <div type="textpart" subtype="book" n="2">
 <pb n="v.3.pt.2.p.81"/>
-<note type="marginal">Σ 41</note> <head>Der zweite Sermon: Gegen die Philosophen.</head>
-<p>I. Gott als Erloser, meine Geliebten, war notig dem Geschlechte
+<milestone unit="altnumbering" n="41"/> <head>Der zweite Sermon: Gegen die Philosophen.</head>
+<div type="textpart" subtype="chapter" n="1">
+<p>Gott als Erloser, meine Geliebten, war notig dem Geschlechte
 der Menschen und Gott als Helfer, der allein Uberflu? zu geben vermag
 denen, die in Verzweiflung, und Leben denen, die dem Tode verfallen
 sind, und das Kommen Gottes und die gOttliche Offenbarung <lb n="5"/>
@@ -1771,16 +2062,22 @@ eben des gemeinsamen Erlosers aller-von ihm sagen wir, da? er notwendig
 den Menschen aufleuchtete, weil durch den au?ersten (Grad)
 des Bosen, durch die Tiefe des gottlosen Irrtums, durch den Wahnsinn
 des Polytheismus und durch den eifrigen Neid der Damonen alles, was
-auf Erden (ist), verderbt war. II. Damit aber noch besser bekannt <lb n="10"/>
+auf Erden (ist), verderbt war.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="2">
+<p>Damit aber noch besser bekannt <lb n="10"/>
 werde die Ursache der gottlichen Offenbarung des gemeinsamen Erlosers
 aller unter den Menschen, wollen wir fortan vor allem beginnen,
 uber den tiefen Fall des Geschlechts der Menschen, ihren gesetzlosen
 Frevel und ihre Ruchlosigkeit zu reden. Dann aber wollen wir uns
 wieder zu den geheimnisvollen Tiefen der gottlichen Offenbarungslehre <lb n="15"/>
 wenden.</p>
-<p>III. Denn lag es nicht auf dem Menschen wie eine Krankheit, die
-wider alle machtig wurde? Aber uber alles Bose und Scheu?liche hinaus
-fuhrte &lt;und&gt; weidete nach Art einer todbringenden Seuche das ganze
+</div>
+<div type="textpart" subtype="chapter" n="3">
+<p>Denn lag es nicht auf dem Menschen wie eine Krankheit, die
+wider alle machtig wurde? Aber uber alles Bose und Scheuliche hinaus
+fuhrte <add>und</add> weidete nach Art einer todbringenden Seuche das ganze
 menschliche Geschlecht der bose Damon so (sehr), da? er den (Menschen), <lb n="20"/>
 der der allerfriedlichste war, zu dem au?ersten (Grade) der Wildheit
 trieb und (da?) der Vernunftigste der Allerunvernunftigste wurde. Seitdem
@@ -1798,37 +2095,56 @@ und <foreign xml:lang="abbr">ABBREV</foreign> 19 Man erwartet <foreign xml:lang=
 jederzeit der Welt nahe und in ihr ist, der allem die Ursache alles
 Guten ist, die Vorsehung, den Erlöser, den Fürsorger, den Geber des
 Regens, den Spender des Lichts, den Fürsten des Lebens und den
-Schöpfer dieses Alls, sondern legten der Sonne, dem Monde, dem Himmel <note type="marginal">Σ 42</note>
+Schöpfer dieses Alls, sondern legten der Sonne, dem Monde, dem Himmel <milestone unit="altnumbering" n="42"/>
 <lb n="5"/> selbst und den Gestirnen den Namen der Verehrung (d. h. Gottes) bei.
-Aber nicht einmal hierbei blieben sie stehen, IV. sondern sie nannten auch
+Aber nicht einmal hierbei blieben sie stehen,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="4">
+<p>sondern sie nannten auch
 die warme und kalte, feuchte und trockene οὐσία, eben das Wasser,
 die Erde, die Luft und das Feuer, deren Natur seelen- und vernunftlos
 ist, wie wir mit unseren eigenen Augen sehen, und die übrigen Teile
 <lb n="10"/> der Welt:  Poseidon, Hephaistos, Zeus, Hera und andere derart und
 ehrten sie mit dem göttlichen Beinamen. Aber nicht einmal hierbei
-blieben sie stehen; V. sie vielmehr  machten auch die irdische Natur,
+blieben sie stehen;</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="5">
+<p>sie vielmehr  machten auch die irdische Natur,
 die Früchte, die aus der Erde (sprossen), und die mannigfachen Nahrungsmittel
-des Leibes zu Göttern &lt;und&gt; machten Demeter, Kore, Dionysos
+des Leibes zu Göttern <add>und</add> machten Demeter, Kore, Dionysos
 <lb n="15"/> und auderes ihnen Verwandte zu Götzen. Aber nicht einmal hierbei
-blieben sie stehen, VI. sondern sie zögerten auch nicht, die Gedanken
+blieben sie stehen,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="6">
+<p>sondern sie zögerten auch nicht, die Gedanken
 ihres Geistes und eben das Wort, den Dolmetscher jener (Gedanken),
 Götter zu nennen, ihren Geist aber nannten sie Athene und ihr Wort
 Hermes und die der Lehren fähigen Kräfte (des Geistes) nannten sie
-<lb n="20"/> Mnemosyne und Musen. Aber nicht einmal hierbei blieben sie stehen;
-VII. indem sie vielmehr wuchsen in der Vielheit des Betruges und in
+<lb n="20"/> Mnemosyne und Musen. Aber nicht einmal hierbei blieben sie stehen;</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="7">
+<p>indem sie vielmehr wuchsen in der Vielheit des Betruges und in
 der Größe des Frevels, machten sie ihre eigenen Leidenschaften, die *sie
 fortstoßen und mit keuschem Sinn heilen sollten, — sie machten diese zu
-Göttern &lt;und&gt; nannten ihre eigene Begierde, die  lüsterne und leidenschaftliche
+Göttern <add>und</add> nannten ihre eigene Begierde, die  lüsterne und leidenschaftliche
 <lb n="25"/> Krankheit der Seelen, die Glieder und Teile des Leibes, die
 zu schändlichem Tun hinziehen und ferner den Wahnsinn, der zu *schändlichen
 Lüsten (führt): Eros, Priepos, Aphrodite und andere, die diesen
-verwandt sind. Aber nicht einmal hierbei blieben sie stehen, VIII. sondern
+verwandt sind. Aber nicht einmal hierbei blieben sie stehen,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="8">
+<p>sondern
 auch auf die Geburten der Leiber und das untere sterbliche Leben
 <lb n="30"/> verfielen sie, machten sterbliche Menshen zu Göttern, verkündeten
 <note type="footnote">4–6 = Laus 235 19–21 12–S. 85, 6 = Laus 235 21–237 20.
 12 „sie vielmehr“] ἀλλὰ καὶ und οἵδε καὶ L 14 l. <foreign xml:lang="abbr">ABBREV</foreign> 21 ἐπὶ
 μεῖζον δ᾿ αὔξοντες ἀτοπίας ὑπερβολῇ δυσσεβείας τὰ οἰκεῖα πάθη, ἃ δὴ ἐχρῆν ἀποτρέπεσθαι
-(„entfernen“ Σ lies <foreign xml:lang="abbr">ABBREV</foreign>) καὶ λόγῳ σώφρονι θεραπεύειν, [οἵδε]
+( „entfernen“ Σ lies <foreign xml:lang="abbr">ABBREV</foreign>) καὶ λόγῳ σώφρονι θεραπεύειν, <del>οἵδε</del>
 ἐθέωσαν L 24 l. <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> | καὶ τὴν ἐμπαθῆ καὶ ἀκόλαστον τῶν
 ψυχῶν νόσον L] „und die lüsterne Krankheit und die Leidenschaften der Seele“ Σ 
 l. vielleicht <foreign xml:lang="abbr">ABBREV</foreign> 26 l. <foreign xml:lang="abbr">ABBREV</foreign> mit HS | τά τε ὁλεὰ πρὸς αἰσχρουργίαν
@@ -1837,20 +2153,35 @@ l. vielleicht <foreign xml:lang="abbr">ABBREV</foreign> 26 l. <foreign xml:lang=
 
 <pb n="v.3.pt.2.p.83"/>
 sie nach dem gemeinsamen Tode als Halbgötter (ἡμίθεοι) und Götter
-&lt;und&gt;  glaubten, daß um die Gräber und Grabmale das göttliche
+<add>und</add>  glaubten, daß um die Gräber und Grabmale das göttliche
 (und) unsterbliche Sein schweife. Aber nicht einmal hierbei blieben
-sie stehen, IX. sondern sie ehrten auch die mannigfachen Arten der
+sie stehen,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="9">
+<p>sondern sie ehrten auch die mannigfachen Arten der
 unvernünftigen Tiere und das schädliche Gewünrm mit dem verehrungswürdigen <lb n="5"/>
-Namen (Gott). Aber nicht einmal hierbei blieben sie stehen,
-<note type="marginal">Σ 43</note> X. sondern sie fällten auch Bäume, hieben Felson aus, durchforschten
+Namen (Gott). Aber nicht einmal hierbei blieben sie stehen,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="10">
+<milestone unit="altnumbering" n="43"/><p>sondern sie fällten auch Bäume, hieben Felson aus, durchforschten
 die Bergwerke der Erde nach Erz, Eisen und anderem Material, bildeten
-Formen von Weibern und Gestalten von [männlichen] Männern und
+Formen von Weibern und Gestalten von <del>männlichen</del> Männern und
 Bildnisse von Tieren und Schlangen und legten dann diesen den Namen <lb n="10"/>
-der Götter bei. Aber nicht einmal hierbei blieben sie stehen, XI. sondern
+der Götter bei. Aber nicht einmal hierbei blieben sie stehen,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="11">
+<p>sondern
 sie legten auch den Dämonen, die in die (Götzen)bilder kriechen und
-in den finstern innersten Winkel eingetaucht sind &lt;und&gt; an den Spenden
+in den finstern innersten Winkel eingetaucht sind <add>und</add> an den Spenden
 und dem Fett der Opfer lecken, *eben denselben Namen der Götter bei.
-Aber nicht einmal hierbei blieben sie stehen, XII. sondern (eben) sie <lb n="15"/>
+Aber nicht einmal hierbei blieben sie stehen,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="12">
+<p>sondern (eben) sie <lb n="15"/>
 zogen auch mit gewissen Knoten verwerflicher Zauberei, mit zwingenden
 (und) ungesetzlichen Gesängen und Besprechungen die unsichtbaren
 Kräfte, die in der Luft fliegen, als Genossen sich herbie und benutzten
@@ -1869,7 +2200,7 @@ zögerten sie nicht, alle Arten scheußlicher Lebewesen und die
 <note type="footnote">1 ἡμιθέους Σ ἥρωας L 2 1. <foreign xml:lang="abbr">ABBREV</foreign> und <foreign xml:lang="abbr">ABBREV</foreign> mit
 HS 9 „von männlichen Männern“ καὶ ἀρρένων ἀνθρῶν σχήματα L ἀνδρῶν &lt;
 Wilamowitz 13 1. <foreign xml:lang="abbr">ABBREV</foreign> Schultheß 14 „lecken“] λιχνεύουσιν; man erwartet
-<foreign xml:lang="abbr">ABBREV</foreign> Hoffmann | streiche <foreign xml:lang="abbr">ABBREV</foreign> „und“vor <foreign xml:lang="abbr">ABBREV</foreign> Schultheß 18„und
+<foreign xml:lang="abbr">ABBREV</foreign> Hoffmann | streiche <foreign xml:lang="abbr">ABBREV</foreign> „und“vor <foreign xml:lang="abbr">ABBREV</foreign> Schultheß 18 „und
 benutzten –20 hatten “&lt; L 22 ἡμιθέων Σ ἡρώων L 27 σταθμήσασθαι
 παρ’ ἑαυτοῖς καὶ λογίσασθαι L. Das <foreign xml:lang="abbr">ABBREV</foreign> steht besser vor <foreign xml:lang="abbr">ABBREV</foreign> als vor
 <foreign xml:lang="abbr">ABBREV</foreign> 29 διὸ δὴ πᾶν εἶδος εἰδεχθῶν κνωδάλων καὶ παντοίων ζώων γένη
@@ -1885,8 +2216,10 @@ Kiliker den Mopsos, die Thebaner den Amphiareos, und bei anderen
 wiederum ehrte man andere mit dem Namen der Gotter, die ihrer Natur
 nach sich in nichts unterschieden von den Sterblichen, sondern in Wahrheit
 allein dies: Menschen waren.</p>
-<lb n="10"/>  <p>XIII. Allzumal also Ägypter, Phöniker, Griechen (und) das ganze
-sterbliche Geschlecht, soweit der Glanz Sonne leuchtet, haben die <note type="marginal">Σ 44</note>
+</div>
+<lb n="10"/>  <div type="textpart" subtype="chapter" n="13">
+<p>Allzumal also Ägypter, Phöniker, Griechen (und) das ganze
+sterbliche Geschlecht, soweit der Glanz Sonne leuchtet, haben die <milestone unit="altnumbering" n="44"/>
 Teile der Welt, die στοιχεῖα, die Früchte, die aus der Erde sprossen,
 ihre eigenen Leidenschaften, ferner auch den dämonischen Wahnsinn
 und die (dämonischen) Phantasien und vor diesen die sterblichen
@@ -1922,14 +2255,18 @@ behauptet wird, sondern (obwolh) sie selbst Zeugen dafür
 sind und Irrtum, TRauer und Tod und vor diesen Ehebruch, Schändung
 der Männer und Raub der Weiber (von ihren Göttern) bekannten, füllten
 sie nichts desto weniger alle Städte, Dörfer und Länder mit Tempeln, <lb n="5"/>
-Bildern und Heiligtümern. XIV. Und nicht nur dies, sondern sie
+Bildern und Heiligtümern.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="14">
+<p>Und nicht nur dies, sondern sie
 Nahmen auch aus den Worten, die sie über ihre Götter machten, die
 Hilfsmittel zu (eigenem) schändlichen und widergesetzlichen Leben und
 Verderbten durch alle Arten der Lüsternheit zumal ihre Leiber und
 Seelen zusammen. Welcher Art das war, was sie taten indem sie sich <lb n="10"/>
 Ihren Göttern anähnelten, können wir aus der Nähe an dem uns benachbarten
 Phönizien betrachten, indem wir sehen, was bis jetzt in
-<note type="marginal">Σ 45</note> Baalbek *geschieht, wie dort die Überbleibsel der alten (Dämonen- )
+<milestone unit="altnumbering" n="45"/> Baalbek *geschieht, wie dort die Überbleibsel der alten (Dämonen- )
 Schäden und die Spuren des verderblichen Bösen bis jetzt wirksam
 Sind, sodaB die dortigen Frauen sich nicht eher in gesetzlicher (Ehe- ) <lb n="15"/>
 Gemeinschaft verbinden, als bis sie zuvor durch auBergesetzliche (Verderbung
@@ -1937,7 +2274,11 @@ Geschändet sind und an dem ungesetzlichen Mysterienkult der
 Aphrodite teilgenommen haben. Aber jetzt ist diese Stadt allein an
 Diesem Wahnsinn krnak zum Beweise des alten Bösen. Früher nämlich
 Litten Myriaden derart, als die Krankheit der Dämonen noch mehr <lb n="20"/>
-Mächtig war. XV. Und nicht allein dies, sondern auch diejenigen
+Mächtig war.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="15">
+<p>Und nicht allein dies, sondern auch diejenigen
 Männer, welche den genannten Göttern geweiht (verfallen) waren &lt;und&lt;
 Aus Lobgesängen und Liedern, Opfern und Mysterien, Schriften und
 Gelübden von Bildern gelernt haben, daB der Vater und Lenker aller
@@ -1947,7 +2288,11 @@ Der Natur, gingen über unsagbare *Taten hinaus und betrugen sich
 Ohne Scheu frech gegeneinander, was zu hören unglaublich ist: „Männer
 Begingen Unanständigkeit gegen Männer und trugen an sich den gebührenden
 Lohn für ihre Verirrung davon“, wie die göttlichen Schriften <lb n="30"/>
-Sagen. XVI. Und nicht nur dies, sondern sie verkehrten auch das gemeine
+Sagen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="16">
+<p>Und nicht nur dies, sondern sie verkehrten auch das gemeine
 <note type="footnote">6 – 10 = Laus 240 2 – 6 10 ff. vgl. Vita Const. 105 2 ff. Hkl, praep. IV 16 22
 26 – 31 = Laus 240 6 – 11 28 = Röm 1 27 31 — S. 86, 6 vgl. Laus 240 11 – 18</note>
 <note type="footnote">1 ειτα τοιαῦτα οὐχ υφ᾿ ἑτέρων διαβαλλόμενα φάσκοντες L „und eben dies
@@ -1962,7 +2307,11 @@ Zwange die Wesensschaffung und Anordnung des Alls bei, führten ein
 tierisches Dasein und ein Leben, das nicht lebenswert war, erforschten
 nicht das Wesen der Seele, erwarteten nicht das gerechte, göttliche
 <lb n="5"/> Gericht und nahmen sich weder die Siegespreise der Tugend noch ferner 
-die Strafen eines gottlosen Lebens zu Herzen. XVII. Und nicht nur
+die Strafen eines gottlosen Lebens zu Herzen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="17">
+<p>Und nicht nur
 dies, sondern auch mitten in das Theater liefen sie wie Herden rennen,
 Greise zumal und Jünglinge und Mütter mit *ihren Söhnen und Töchtern
 und dem Anhang der Sklaven, und wurden (so) mit allem Schändlichen
@@ -1971,7 +2320,7 @@ waren Männer zumal mitsamt den Weibern, wenn sie zusammen waren.
 Wie sollten sie das Gute tun, sie die ihre Ohren nicht dem Hören
 keuscher und gottesfürchtiger Worte, noch ihre Augen der Hilfe für
 ihre Seele, sondern der Lehre schändlicher Worte und dem Anblick der
-<lb n="15"/> bildlichen Darstellung aller Lüsternheit *darboten? Denn derartig war <note type="marginal">Σ 46</note>
+<lb n="15"/> bildlichen Darstellung aller Lüsternheit *darboten? Denn derartig war <milestone unit="altnumbering" n="46"/>
 das, was alle Scharen zu sehen bekamen, die sich bekümmerten um die
 Dinge, die in diesen (Schauspielen gezeigt wurden): wahnsinniger Pferdewettkampf, 
 gottloses Ergötzen an denen, die von wilden Tieren gefressen
@@ -1981,8 +2330,11 @@ törichtes Vergnügen an Musik, lüsterner Anblick derer, die Weiber
 darstellten, und starkes Geschrei bei Liedern. Denn bei diesen und derartigen
 (Dingen) waren Myriaden Scharen unverständiger Massen vereinigt
 mitsamt ihren Fürsten, Strategen und *Hegemonen und wurden
-<lb n="25"/> mit den Verderbnissen durchtränkt, die die Seelen zum Verfaulen bringen.
-XVIII. Und nicht nur dies, sondern sie bauten auch Schulen für gottlose
+<lb n="25"/> mit den Verderbnissen durchtränkt, die die Seelen zum Verfaulen bringen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="18">
+<p>Und nicht nur dies, sondern sie bauten auch Schulen für gottlose
 Worte in den Provinzen und in den Städten. Statt der gerechten
 und weltfördernden Lehren und statt der keuschen und gottgeliebten
 Belehrung nahmen sie durch das frevelhafte Gefasel der Poeten, die es
@@ -1994,13 +2346,13 @@ der trügerischen, dramatischen Werke der Komöden und Tragöden in
 <lb n="35"/> ihr Gedächtnis auf. Diese verderblichen und schädlichen (Dinge) des
 <note type="footnote">1 vermutlich ἀλόγῳ εἱμαρμένῃ καὶ φυσικῇ ἀνάγκῃ τὴν τοῦ παντὸς οὐσίωσίν
 τε καὶ σύστασιν ἀνετίθεσαν vgl. L 8 1. (??) 10 „bekannt“] wörtlicher
-„bekleidet“(Syriasmus) 15„darboten“]1. (??) mit HS 42 1. (??) 
+„bekleidet“(Syriasmus) 15 „darboten“]1. (??) mit HS 42 1. (??) 
 mit HS 31 „und Leidenschaften, voll von allerlei Schande“ Σ, aber (??)
 muß an verkehrter Stelle stehen 32 „Verbrechen“] „Trauer“ Σ = συμφορά</note>
 
 <pb n="v.3.pt.2.p.87"/>
 Lebens säten sie sunächst in sich und dann in den Seelen der Jünglinge
-aus. Der Frevel aber, der von allen der erste und letzte (ist), war, daβ
+aus. Der Frevel aber, der von allen der erste und letzte (ist), war, daß
 vollständig alle Menschen, die Fürsten zumal und die  Untertanen, die
 Könige der Völker und die Gesetzgeber, die Heerscharen und Massen
 in den Dörfern und Städten, unter Griechen und Barbaren das Lob, das <lb n="5"/>
@@ -2011,13 +2363,15 @@ auf Erden brachten weder das Lob (nach Art) des Priesters noch <lb n="10"/>
 das mit ihren Brüdern im Himmel, den heiligenEngeln und göttlichen
 Geistern, die den Allkönig loben, das mit ihnen zusammenstimmende *Lob
 dar, sondern sangen ein ungebührliches und nicht zusammenstimmendes
-<note type="marginal">Σ 47</note> (Lob) an Feiertagen und Festen den betrügerischen Geistern, die die
-Welt verderben, und fügten ihnen die Ehre der Anbetung zu, sodaβ <lb n="15"/>
+<milestone unit="altnumbering" n="47"/> (Lob) an Feiertagen und Festen den betrügerischen Geistern, die die
+Welt verderben, und fügten ihnen die Ehre der Anbetung zu, sodaß <lb n="15"/>
 fortan das ganze στοιχεῖον der Erde übereinstimmend mit allen Völkern
 in der ganzen Welt nichts anderes war als ein im Sturm befindliches
 Schiff, dessen schwer (beschädigtes) Wrack durch einen *anderen Sturm
 sofort mit völligem Untergang bedroht ist.</p>
-<p>XIX. Mit Recht also war wegen aller dieser (Dinge) Gott als Erlöser <lb n="20"/>
+</div>
+<div type="textpart" subtype="chapter" n="19">
+<p>Mit Recht also war wegen aller dieser (Dinge) Gott als Erlöser <lb n="20"/>
 und Helfer nötig für das Geschlecht der Menschen.  Wären nur die
 Massen zu dieser Verirrung geführt, so ware das Böse vielleicht gering.
 Jetzt aber waren völlig die Häupter der Städte, die Lenker der  Völker,
@@ -2025,8 +2379,8 @@ die Könige der Länder, die Führer der Ortschaften und die  Fürsten der
 Völker allzumal übereinstimmend an derselben dämonischen und polytheistischen <lb n="25"/>
 Verirrung erkrankt. Ferner fürwahr aber auch diejenigen,
 die sich rühmten unter den Griechen der Philosophie und bekannten,
-daβ sie ein reicheres Wissen besäβen als die moisten Menschen, (die)
-auf den Straβen prunkten, indem sie sich aufblähten und breit in ihre
+daß sie ein reicheres Wissen besäßen als die moisten Menschen, (die)
+auf den Straßen prunkten, indem sie sich aufblähten und breit in ihre
 Stola hüllten, schweiften auf der weiten und langen Erde umher und <lb n="30"/>
 *bettelten sich von anderen Völkern die herrlichen Lehrsätze zusammen,
 von hier die Geometrie, von der andern Richtung die Arithmetik,
@@ -2034,7 +2388,7 @@ wiederum aber von anderer Seite die Musik und die Heilkunde und
 <note type="footnote">28 vgl. Praep. X 4 27 f.</note>
 <note type="footnote">10 vgl. o. s. 62 14 und L 222 29 ff. 12 Das eine <foreign xml:lang="abbr">ABBREV</foreign> „Lob“ ist
 wohl Druckfehler 17 „war“] wörtlich „waren“ (Plural κατὰ σύνεσιν) 18 „anderem“]
-„letzten“ Σ 1. ΑΒBREV Schultheβ mit HS 24 „die Fürsten“] .vielleicht
+„letzten“ Σ 1. ΑΒBREV Schultheß mit HS 24 „die Fürsten“] .vielleicht
 ABBREN  vgl. Hoffmann in Stud. 70 f. 29 „ die . . . . prunkten“] Σ Ηauptsatz 
 31 „bettelten“] „befreiten“ Σ 1. ΑBBREV</note>
 
@@ -2054,7 +2408,7 @@ ein Logow der über allem (waltet), noch ein Anfang noch
 ein Ende existiere, sondern daß allein die unzerlegbaren vernunftund
 seelenlosen Atome — es sind dies aber winzige Körper, die
 <lb n="15"/> eben wegen ihrer vorzüglichen Kleinheit nicht einmal in die Sinne
-fallen — daß eben diese seelen- , vernunft- und anfangslosen (Dinge) <note type="marginal">Σ 48</note>
+fallen — daß eben diese seelen- , vernunft- und anfangslosen (Dinge) <milestone unit="altnumbering" n="48"/>
 die ersten seien, nicht gezeugt, unendlich an Menge und von unübersehbaren
 Zeiten her, wie es sich gerade traf, zerstreut? Indessen
 aber, obwohl sie derart sind, hat man gesaft, daß sie die Ursache des
@@ -2069,7 +2423,11 @@ mitten unter den Griechen lebendig. Obwohl sie aber so die
 Besseren waren, schmiegten sie sich (heuchlerisch) den Massen an.
 Bald wandelten sie mit den Scharen zum Tempel, bald stellten sie sich
 <lb n="30"/> gottesfürchtig aus Furcht vor der gesetzlichen Strafe. Aber diese, die
-für die Lust kämpften, (waren) derart. XX. Andere aber setzten die
+für die Lust kämpften, (waren) derart.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="20">
+<p>Andere aber setzten die
 Grenze der Vorsehung bis zum Monde fest. Von den übrigen Teilen
 der Welt schloß die Schar der Schüler des Aristoteles sie aus, die eben- 
 <note type="footnote">6 vgl. Praep. XIV 145 23 1 ff. 7 vgl. Praep. XIV 20 13 22 vgl. Diog.
@@ -2081,24 +2439,24 @@ ist von Σ wohl fälschlich zum Vorhergehenden gezogen</note>
 
 <pb n="v.3.pt.2.p.89"/>
 falls als den höchsten Gradd der Glückseligkeit weder Tugend noch
-Philosophie definierten, auβer wenn sie zufällig mit Reichtum an Besitz,
-mit Überfluβ an Gold und silber, mit (vornehmer) Familie und Berühmtheit
+Philosophie definierten, außer wenn sie zufällig mit Reichtum an Besitz,
+mit Überfluß an Gold und silber, mit (vornehmer) Familie und Berühmtheit
 verbunden ist, die bei vielen (anerkannt sind). Und was himdert sie,
 sich ebenfalls dessen zu rühmen? Leute, die bis zum Monde die über <lb n="5"/>
-alles (sich erstreckende) Vorsehung gleichsam hinter Schloβ und Riegel
-gefangen gehalten, und (die) gesagt haben, daβ die geistige undd vernünftige
+alles (sich erstreckende) Vorsehung gleichsam hinter Schloß und Riegel
+gefangen gehalten, und (die) gesagt haben, daß die geistige undd vernünftige
 Leibe, sondern ihm entspreche an Art und Gestalt, (weswegen) sie
 sie auch Entelechie zunnen pflegen. An die Spitze des Guten Stellten <lb n="10"/>
-sie demgemäβ weder das philosphische Leben noch die Haupttugend,
+sie demgemäß weder das philosphische Leben noch die Haupttugend,
 sondern sie verfielen auf zufällige Dinge, auf Reichtum, Macht und
 Familie. Denn mit diesen Dingen, sagen sie, existiere auch die Tugend,
 die der Vernunft würdig sei, ohne  sie aber sei *sie niemals. Nichts
-Besseres gebe es für den Weisen, auβer wenn er auch reich sei, noch <lb n="15"/>
-se idem, der sich um keuschheeit bemüht, etwas Gutes nahe, auβer wenn
+Besseres gebe es für den Weisen, außer wenn er auch reich sei, noch <lb n="15"/>
+se idem, der sich um keuschheeit bemüht, etwas Gutes nahe, außer wenn
 er ein Sohn (vornehmer) Familie sei, noch sei di Gerechtigkeit und
 die mit der Tugend übereinstimmende (geistige) Beschaffenheit, falls sie
 in der Seele des Menschen existiere, genügend zu einem glückseligen
-<note type="footnote">Σ 49</note> Leben, auβer wenn ihm eine schöne Ordnung der Glieder des Leibes <lb n="20"/>
+<milestone unit="altnumbering" n="49"/> Leben, außer wenn ihm eine schöne Ordnung der Glieder des Leibes <lb n="20"/>
 zufällig eigne. Eben sie aber glauben, dab die Gottheit irgendwo auberhalb
 von den Dingen der Menscchen oberhalb des Mondes existiere und behaupten,
 dab die vorsehung Gottes die Dinge auf Erden nicht sehe. Auch den geneinnicht,
@@ -2107,72 +2465,118 @@ die Götter in Stadt und Land. Des eine redeten sie weise mit ihren Theoremen,
 ein anderes aber taten sie in ihrer Praxis und leisteten den Eid bei
 den Göttern in ihren allgeemeein (zugänglichen) Schriften und Worten, in
 ihrem Denken aber war nichts Derartiges, sondern um der menge zu
-gefallen, heuchelten sie solches Tun, sodaβ sie daher, eher Dämonen als <lb n="30"/>
-Menschen, von jeder gesunden Philosophie verachtet warden. XXI. Andere
+gefallen, heuchelten sie solches Tun, sodaß sie daher, eher Dämonen als <lb n="30"/>
+Menschen, von jeder gesunden Philosophie verachtet warden.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="21">
+<p>Andere
 <note type="footnote">1 vgl. Praep. XV 3. 4 10 8 vgl. Praep. XV 96.101 ff. vgl. Areios
 didymos boi Stob. Ech. Ecl. II 125 (ed. Wachsmuth)</note>
-<note type="footnote">14 Abbrav ,,sei nichts“ 1. Abbrav 26 ,,mit ihren Theeoremen“] „mit
-ihren Wissenden“ Σ. Εntweder = ,,mit den Wissenden“ oder τὰ θεωρητικά mibverstanen
-als οἱ θεωρητικοί 28 ,,allgenein (zugänglicchen)“]  ,,in ihren gemeinsamen
+<note type="footnote">14 Abbrav „sei nichts“ 1. Abbrav 26 „mit ihren Theeoremen“] „mit
+ihren Wissenden“ Σ. Εntweder = „mit den Wissenden“ oder τὰ θεωρητικά mibverstanen
+als οἱ θεωρητικοί 28 „allgenein (zugänglicchen)“]  „in ihren gemeinsamen
 Schriften und Worten“ Σ. Vermutliche Anlehnung an den aristotelischen
 Ausdruck ἐν κοινῷ γιγνόμενοι λόγοι, vgl. Bernays: Die dioaloge des Aristoteles 
 S. 18 ff.</note>
 
 <pb n="v.3.pt.2.p.90"/>
 aber abgesehen von diesen, die sich brüsten, die besten Philosophen zu
-sein, haben gewagt, mit gottlosem Munde zu sagen, daβ Gott ein Körper
-sei, seiner Natur nach in nichts unterschieden vom Feuer. Ies ist die andere Verirrung: der Stoiker, die diese sinnliche Welt als Gott ausgegeben
-<lb n="5"/> und (so) eine ruchlose, ganz verderbliche Lehre aufgestellt haben. Denn die schaffenskräftige Ursache und die leidensfähige Hyle bestehen (nach ihnen) aus ein und derselben οὐσία und beides sind wirkende und gewirkte Körper. Der Allkönig Gott, der über allem (steht), ist vom sinnlichen Feuer in nichts unterschieden, sondern wird auch mit
-<lb n="10"/> allem zumal vermicscht gemäβ  dem periodischen Feuer zu bestimmten Zeiten. Groß ist das Böse, daß Gott, wie sie sagen, verwandelt und dann verbrannt wird. Dies also ist die Lehre der stoischen Philosophen, daß die ganze οὐσία, wie sie sagen, und die ganze Welt bisweilen mit Gott vermischt wird und sich alles ,,ins Feuer verwandelt wie in einen
-<lb n="15"/> Samen und wiederum aus diesem der schmuck des Alls vollendet wird, wie es fuüher war”. Götter aber gibt es so viele wie es Teile der Welt gibt. Deswegen weil auch die ganze Welt aus lauter Teilen besteht, ist sie vollkommen Gott. Eben dieselben haben ferner gesagt, daß die verständige und vernünftige Seele im menschen (ebenso) vergänglich
-<lb n="20"/> wie körperlich sei. Was wollte sie den (daran) hinder, sie, die gegen den Allkönig Gott solches zu sagen sich erfrecht haben? <note type="marginal">Σ50  </note>
-Diese Seelen sollen ferner nach ihrer Definition aus Hyle und Körpern bestehen und nichts weiter sein als der Qualm und Rauch der Körper. Ferner bleiben nach dem Lebensende keineswegs die Seelen aller, sondern
-<lb n="25"/> nur die der Philosophen (gewisse) Zeiten hindurch, die ihnen bestimmt sind, am Ende aber warden auch sie mit dem Brande des Alls brennen mit Gott zumal und der ganzen Welt, und die Seelen der Ungerechten zumal und der Gerechten, der Frommen mitsamt den Gottlosen warden von Einem Feuer aufgezehrt warden, als ob sie geschmolzen
-<lb n="30"/> würden. Dann aber warden von neuem aus dem Feuerfraß des Alls Welten geboren, die in nichts vershieden, sondern in allem ähnlich sind den früheren, so sehr, daß von neuem eben dieselben (Menschen) geboren werdenund ein und dieselbe Nachfolge geboren wird. Die Lebensweisen ferner sind derart, daß sie in allem ähnlich und nicht
+sein, haben gewagt, mit gottlosem Munde zu sagen, daß Gott ein Körper
+sei, seiner Natur nach in nichts unterschieden vom Feuer. Dies ist die 
+andere Verirrung: der Stoiker, die diese sinnliche Welt als Gott ausgegeben
+<lb n="5"/> und (so) eine ruchlose, ganz verderbliche Lehre aufgestellt haben. 
+Denn die schaffenskräftige Ursache und die leidensfähige Hyle bestehen 
+(nach ihnen) aus ein und derselben οὐσία und beides sind wirkende 
+und gewirkte Körper. Der Allkönig Gott, der über allem (steht), ist 
+vom sinnlichen Feuer in nichts unterschieden, sondern wird auch mit
+<lb n="10"/> allem zumal vermicscht gemäß  dem periodischen Feuer zu bestimmten 
+Zeiten. Groß ist das Böse, daß Gott, wie sie sagen, verwandelt und 
+dann verbrannt wird. Dies also ist die Lehre der stoischen Philosophen, 
+daß die ganze οὐσία, wie sie sagen, und die ganze Welt bisweilen mit 
+Gott vermischt wird und sich alles „ins Feuer verwandelt wie in einen
+<lb n="15"/> Samen und wiederum aus diesem der schmuck des Alls vollendet wird, 
+wie es fuüher war”. Götter aber gibt es so viele wie es Teile der 
+Welt gibt. Deswegen weil auch die ganze Welt aus lauter Teilen 
+besteht, ist sie vollkommen Gott. Eben dieselben haben ferner gesagt, 
+daß die verständige und vernünftige Seele im menschen (ebenso) vergänglich
+<lb n="20"/> wie körperlich sei. Was wollte sie den (daran) hinder, sie, 
+die gegen den Allkönig Gott solches zu sagen sich erfrecht haben? <milestone unit="altnumbering" n="50"/>
+Diese Seelen sollen ferner nach ihrer Definition aus Hyle und Körpern 
+bestehen und nichts weiter sein als der Qualm und Rauch der Körper. 
+Ferner bleiben nach dem Lebensende keineswegs die Seelen aller, sondern
+<lb n="25"/> nur die der Philosophen (gewisse) Zeiten hindurch, die ihnen bestimmt 
+sind, am Ende aber warden auch sie mit dem Brande des Alls
+brennen mit Gott zumal und der ganzen Welt, und die Seelen der Ungerechten 
+zumal und der Gerechten, der Frommen mitsamt den Gottlosen 
+warden von Einem Feuer aufgezehrt warden, als ob sie geschmolzen
+<lb n="30"/> würden. Dann aber warden von neuem aus dem Feuerfraß des Alls 
+Welten geboren, die in nichts vershieden, sondern in allem ähnlich 
+sind den früheren, so sehr, daß von neuem eben dieselben (Menschen) 
+geboren werdenund ein und dieselbe Nachfolge geboren wird. Die 
+Lebensweisen ferner sind derart, daß sie in allem ähnlich und nicht
 <lb n="35"/> verwandelt sind, die Moden, Gebräuche, Sitten und Leidenschaften 
 <note type="footnote">1 vgl. Praep. XV 16 1 4 vgl. Praep. XV 15 1 6 vgl. Praep. XV 14 1 ff. 14—16 = Praep XV 18 3 (Aeriow Didymos) 19 vgl. Praep. XV 20 2 ff. 21 1 ff.</note>
-<note type="footnote">10 ,,periodischen”] wörtlich ,,im Lauf”, vermutlich κατὰ περιόδους 14 ,,ins Feuer” vom Σ fälschlich zum Vorhergehenden gezogen, 1. (??) (??) 32 ,,von neuem”] wórtlich ,,von oben”, vermutlich ἄνωθεν</note>
+<note type="footnote">10 „periodischen”] wörtlich „im Lauf”, vermutlich κατὰ περιόδους 14 „ins Feuer” vom Σ fälschlich zum Vorhergehenden gezogen, 1. (??) (??) 32 „von neuem”] wórtlich „von oben”, vermutlich ἄνωθεν</note>
 
 <pb n="v.3.pt.2.p.91"/>
 warden eben dieselben sein und so warden auch eben dieselben Ereig-
 nisse, Ehrungen, Freuden und Schmerzen eben denselben wiederum be-
-gegnen, sodaβ wiederum eine Helena und ein Unheil von Ilion zu
+gegnen, sodaß wiederum eine Helena und ein Unheil von Ilion zu
 erwarten ist, und wiederum ein Anytos und Meletos und das tödliche
 Gift des Sokrates und wiederum eben dieselben Streitigkeiten und <lb n="5"/>
 Spaltungen der Philosophen, und am Ende wird wiederum alles vom
 Feuer verzehrt, und nachdem es verbrannt ist, wird es wieder von
 neuem zurückkehren und wieder in denselben Gleisen verharren. Aber
-auch diese (Philosophen) hängen so notwendig ihrem Irrtum an. XXII.
-Die Philosophen aber, die die ersten Physiker heiβen, die vor allen <lb n="10"/>
+auch diese (Philosophen) hängen so notwendig ihrem Irrtum an.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="22">
+<p>Die Philosophen aber, die die ersten Physiker heißen, die vor allen <lb n="10"/>
 (anderen) auftraten, gründeten den Anfang des Alls auf ein seelenloses
 στοιχεῖον, ohne einen Gott, eine Vorsehung, einen Schöpfer und Werk-
 meister des Alls zu kennen. Eitel aber und ohne Grund legten sie
 sich lügnerisch den Namen und das Gebaren der Philosophen bei.
-Denn teils sagten sie, daβ die Erde und eine trockene οὐσία der An- <lb n="15"/>
+Denn teils sagten sie, daß die Erde und eine trockene οὐσία der An- <lb n="15"/>
 fang des Alls sei, teils nannten sie den Ozean und so eine feuchte οὐσία,
 *das Wasser als den Allerzeuger, teils das Feuer, teils die Luft, teils
 Mischungen aus diesen, und führten viele männliche wie auch weibliche
 Gottheiten ein und Hochzeiten und Kindergeburten, &lt;und&lt; änderten in
-<lb n="Σ 51"/> physikalische Allegorien das Mythengefasel der Poeten durch schöne <lb n="20"/>
-Worte zum Ruhmesschmuck, sodaβ auch sie gleichsam durch Verkehrt-
+<milestone unit="altnumbering" n="51"/> physikalische Allegorien das Mythengefasel der Poeten durch schöne <lb n="20"/>
+Worte zum Ruhmesschmuck, sodaß auch sie gleichsam durch Verkehrt-
 heit von oben von der Höhe wieder auf die στοιχεῖα der Hyle und auf die
-sinnlichen Teile der Welt niederfielen. XXIII. Andere aber, abgesehen
+sinnlichen Teile der Welt niederfielen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="23">
+<p>Andere aber, abgesehen
 von diesen, fabrizierten (gerade) Entgegengesetztes all dem, abgesehen
 von diesen, fabrizierten (gerade) Entgegengesetztes all dem, was gesagt
-ist, behauptend, daβ es nichts Göttliches in dem Seienden gebe, weder <lb n="25"/>
-den höchsten Gott noch die lokalgötter, daβ der Name (Gott) vielmehr
-besser und über die οὐσία gesetzt sei, die nicht ist, sodaβ sie in groβen
-Frevel des Bösen sich ausgebreitet haben.
-XXIV. Platon allein von allen Griechen scheint mir vorzüglich der
-Philosophie anzuhängen und halt mit Recht daran fest, daβ das Gute <lb n="30"/>
+ist, behauptend, daß es nichts Göttliches in dem Seienden gebe, weder <lb n="25"/>
+den höchsten Gott noch die lokalgötter, daß der Name (Gott) vielmehr
+besser und über die οὐσία gesetzt sei, die nicht ist, sodaß sie in großen
+Frevel des Bösen sich ausgebreitet haben.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="24">
+<p>Platon allein von allen Griechen scheint mir vorzüglich der
+Philosophie anzuhängen und halt mit Recht daran fest, daß das Gute <lb n="30"/>
 das Erste und die Ursache des Alls ist, und redet mit Recht weise
-über den Zweiten, der der Schopfer des Alls ist. XXV. Er hat auch
-schön und richtig festgestellt, daβ Himmel, Sonne, Mond, Sterne und 
+über den Zweiten, der der Schopfer des Alls ist.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="25">
+<p>Er hat auch
+schön und richtig festgestellt, daß Himmel, Sonne, Mond, Sterne und 
 überhaupt die ganze Welt zumal von dem Gotte des Alls (geschaffen)
-wurden. XXVI. Er hat auch gesagt, daβ die οὐσία der Seele körperlos <lb n="35"/>
+wurden.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="26">
+<p>Er hat auch gesagt, daß die οὐσία der Seele körperlos <lb n="35"/>
 und der Vergänglichkeit fremd sei. Er hat auch geistige οὐσίαι ge-
 <note type="footnote">10 vgl. Praep. XIV 16 12f. 30 vgl. Praep. XI 16ff.</note>
-<note type="footnote">17 streiche <foreign xml:lang="abbr">ABBREV</foreign> ,,und‘‘ vor <foreign xml:lang="abbr">ABBREV</foreign> 19 statt <foreign xml:lang="abbr">ABBREV</foreign> 1. <foreign xml:lang="abbr">ABBREV</foreign>
+<note type="footnote">17 streiche <foreign xml:lang="abbr">ABBREV</foreign> „und“ vor <foreign xml:lang="abbr">ABBREV</foreign> 19 statt <foreign xml:lang="abbr">ABBREV</foreign> 1. <foreign xml:lang="abbr">ABBREV</foreign>
 und vgl. Praep. II 6 17 24 Man erwartet das Femininum <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.92"/>
@@ -2182,16 +2586,28 @@ als Herrscher über das All nach Art eines Steuermannes, der schön und
 sicher für alles sorgt, und wies (ihn) als Lenker nach. Er allein von
 <lb n="5"/> allen Griechen bekannte den Logos Gottes, den Schöpfer der Welt,
 gleich wie wir selbst. Abe res ist am Platze, ihn (selbst) zu hören, in
-welcher Art er über Gott redet: XXVII. ,,Und Ehren wollen wire r-
+welcher Art er über Gott redet:</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="27">
+<p> „Und Ehren wollen wire r-
 weisen, nicht dem für ein Jahr und jenem für einen Monat und anderen
 aber überhaupt keinen Anteil und keine Zeit zuerteilen, in der er seine
 <lb n="10"/> Bahn durchläuft und die Weltordnung (mit) vollendet, die der aller* gott-
 lichste Logos sichtbar anordnete, den, wer immer glückselig ist, zuerst
 bewundert, zu deme r dann aber Liebe faßt, um (ihn) kennen zu lernen,
-soweit es die sterbliche Natur vermag“. XXVIII. Er nannte auch den, <note type="marginal">Σ 52</note>
-*den ere ben als ,,göttlichen Logos“ bezeichnet hat, den ,, Vater“ und
-<lb n="15"/> ,,Herrn“ des Alls und den ,,Lenker“ des Alls mit denselben Worten
-wie wir und sagte so: XXIX. ,,Diesen Brief sollt ihr alle, die ihr drei
+soweit es die sterbliche Natur vermag“.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="28">
+<p>Er nannte auch den, <milestone unit="altnumbering" n="52"/>
+*den ere ben als „göttlichen Logos“ bezeichnet hat, den „Vater“ und
+<lb n="15"/> „Herrn“ des Alls und den „Lenker“ des Alls mit denselben Worten
+wie wir und sagte so:</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="29">
+<p> „Diesen Brief sollt ihr alle, die ihr drei
 seid, lessen, besonders in Gemeinschaft, wenn aber (dies) nicht (mög-
 lich), so zu zweien zusammen, nach Kräften soviel ihr könnt, &lt;und&lt;
 sollt dies als herrschendes Übereinkommen und Gesetz *gebrauchen, in-
@@ -2199,21 +2615,25 @@ sollt dies als herrschendes Übereinkommen und Gesetz *gebrauchen, in-
 Eifer zumal und mit der Zucht, der Schwester des Eifers, bei dem
 &lt;Gotte&lt; des Alls, dem Lenker des Seienden und Kommenden und dem
 richtig philosophieren, wir alle deutlich kennen nach der Kraft glück-
-<lb n="25"/> seliger Menschen“. XXX. Er lehrte auch, daß ein gerechtes Gericht
+<lb n="25"/> seliger Menschen“.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="30">
+<p>Er lehrte auch, daß ein gerechtes Gericht
 Gottes stattfinden werde, welches einem jedem vergelte, wie er es ver-
 diene. Daß der Gipfel des Guten der sei, 	ähnlich zu warden der Gott-
 <note type="footnote">7—13 =  Ps. Platon Epinomis 986 C; Praep. XI 161 16—25 = Ps. Platon
 6. Brief 323 C; Praep. XI 162 25 vgl. Platon Politeia 614. Phaidon 113; Praep.
 XI 35 ff. 27 vgl. Platon Theaitet 176 B</note>
-<note type="footnote">10 ,,Weltordnung“] κόσμον ,,Welt“ Σ | ,, göttlichste“] φεθίτατις ,,Gott“ Σ l.
-<foreign xml:lang="abbr">ABBREV</foreign> 11 ὁρατὸν zieht Σ zu κόσμον ,,die sichtbare Welt“ 14 l. <foreign xml:lang="abbr">ABBREV</foreign>
-mit HS | ,,und“] wörtlich ,,auch“ 17 Man vermibt ein zu <foreign xml:lang="abbr">ABBREV</foreign> gehöriges <foreign xml:lang="abbr">ABBREV</foreign>
-ἐπομνύντας] ,,sollt bedenken (aber lies <foreign xml:lang="abbr">ABBREV</foreign> Lee) das Übereinkommen
+<note type="footnote">10 „Weltordnung“] κόσμον „Welt“ Σ | „göttlichste“] φεθίτατις „Gott“ Σ l.
+<foreign xml:lang="abbr">ABBREV</foreign> 11 ὁρατὸν zieht Σ zu κόσμον „die sichtbare Welt“ 14 l. <foreign xml:lang="abbr">ABBREV</foreign>
+mit HS | „und“] wörtlich „auch“ 17 Man vermibt ein zu <foreign xml:lang="abbr">ABBREV</foreign> gehöriges <foreign xml:lang="abbr">ABBREV</foreign>
+ἐπομνύντας] „sollt bedenken (aber lies <foreign xml:lang="abbr">ABBREV</foreign> Lee) das Übereinkommen
 und das Gesetz, und be idem Herrm, der die Gerechtigkeit ist, schwören“. Es mübte
 mindestens heiben <foreign xml:lang="abbr">ABBREV</foreign> 22 καὶ τὸν τῶν πάντων θεὸν ἠγεμόνα τῶν τε ὄν-
-των καὶ τῶν μελλόντων] ,,und be idem Lenker des Alls, dessen was ist und dessen
+των καὶ τῶν μελλόντων] „und be idem Lenker des Alls, dessen was ist und dessen
 was kommt“ &lt;φεὸν Σ mit Unrecht 24 εἰσόμεφα πάντες σαρῶς εἰς δύωαμιν
-ἀνφρώπων εὐσαιμόνων] wörtlich ,,nach unsere Kraft aus glückseligen Menschen“ Σ</note>
+ἀνφρώπων εὐσαιμόνων] wörtlich „nach unsere Kraft aus glückseligen Menschen“ Σ</note>
 
 <pb n="v.3.pt.2.p.93"/>
 heit, der Tugend anzuhängen und mit ihr (wie ein Zwilling) verhunden
@@ -2235,10 +2655,14 @@ toten Vogels die Gottheit zu versöhnen. Er nannte aber ferner diejenigen <lb n=
 wohl daran, und er bekanute auch, daß sie Vorfahren seien von sterblichen
 Menschen und redete recht. Dennoch aber riet er, eben sie als
 Götter zu verechen *weil er sich mit der Menge zu (ihrem) Irrtum erniedrigte,
-&lt;und&gt; mit Recht auch sie als Ursache (des Alls) anzunehmen, <lb n="20"/>
+<add>und</add> mit Recht auch sie als Ursache (des Alls) anzunehmen, <lb n="20"/>
 weil er unter dem Schein (σχῆμα) der Philosophie das Wort der Wahrheit
-<note type="marginal">Σ 53</note> verbarg, das der Lüge aber erheuchelte. Höre jedoch, was er *im
-Timaios sagt: XXXI. „Über die anderen Dämonen aber zu redden und
+<milestone unit="altnumbering" n="53"/> verbarg, das der Lüge aber erheuchelte. Höre jedoch, was er *im
+Timaios sagt:</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="31">
+<p> „Über die anderen Dämonen aber zu redden und
 ihre *Geburt kennen zu lernen, ist zu groß für uns. Wir müssen uns
 vielmehr überzeugen lassen von denen, die vor uns gesagt haben, sie <lb n="25"/>
 seien Söhne der Götter, wie sie behauptet haben, und kennten ihre Vorfahren
@@ -2248,7 +2672,7 @@ glauben, obwohl sie ohne zwingende Wahrscheinlichkeits-  und Beweis-
 16 vgl. Platon Timaios 40 D 23—S. 94, 8 = Platon Timaios 40 D; Praep. II 7 1 f.
 u. Parall.</note>
 <note type="footnote">10 1. <foreign xml:lang="abbr">ABBREV</foreign> Lee „das Fest der Bendideen“ Σ 17 ὡμολόγησεν
-αὐτοὺς εἶναι [ἐξ?] ἀνθρώπων θνητῶν „Vorherwissende “ Σ = προγνώστας, verlesen
+αὐτοὺς εἶναι <del>ἐξ?</del> ἀνθρώπων θνητῶν „Vorherwissende “ Σ = προγνώστας, verlesen
 aus προγόνους? vgl. Z. 26 94 27. Schultheß schlägt vor: <foreign xml:lang="abbr">ABBREV</foreign> 
 „daß sie seien ursprünglich Geborne von sterblichen Menschen“ 19. 20 <foreign xml:lang="abbr">ABBREV</foreign> „und“
 vor <foreign xml:lang="abbr">ABBREV</foreign> steht besser vor <foreign xml:lang="abbr">ABBREV</foreign> | „in ihre Ursache geschrieben zu werden“
@@ -2260,20 +2684,30 @@ gründe reden, sondern dem Gesetze anhangend müssen wir ihnen glauben,
 da sie vorgeblich eigene (Familiengeschichten) erzählen. So also, wie
 sie sagen, möge sich die Geburt in betreff dieser Götter verhalten und
 gesagt warden: Kinder der Erde und des Himmels waren Okeanos und
-<lb n="5"/> Tethys, und deren: Phorkys, Kronos, Rhea &lt;und alle, die mit diesen
-waren&gt;, von Kronos und Rhea aber: Zeus, Hera und andere, soviele wir
+<lb n="5"/> Tethys, und deren: Phorkys, Kronos, Rhea <add>und alle, die mit diesen
+waren</add>, von Kronos und Rhea aber: Zeus, Hera und andere, soviele wir
 kennen als alle ihre sogenannten Brüder und ferner andere als die
-Sprößlinge dieser“. XXXII. Du siehst, daß der Philosoph von oben, von
+Sprößlinge dieser“.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="32">
+<p>Du siehst, daß der Philosoph von oben, von
 den Bildern oberhalb der Welt und von den körperlosen, geistigen
 <lb n="10"/> οὐσίαι nach unten auf die Erde und auf den Ozean wie in die Tiefe
 des Bösen hinabgetaucht ist und Göttergeburten einführte, er der allein
-besser als (sonst) die Menschen mit hochtönendem Geist sagen konnte:
-XXXIII. „Was ist das immer Seiende, aber niemals Werdende? &lt;Und
-was ist das immer Werdende, aber niemals Seiende?&gt; Das eine wird
+besser als (sonst) die Menschen mit hochtönendem Geist sagen konnte:</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="33">
+<p> „Was ist das immer Seiende, aber niemals Werdende? <add>Und
+was ist das immer Werdende, aber niemals Seiende?</add> Das eine wird
 <lb n="15"/> durch das mit Vernunft (begabte) Wissen wahrgenommen und ist immer
 sich selber gleich. Das andere aber wird mit unvernünftigem Sinne
-gewähnt, ist werdend und vergehend, aber völlig seiend *niemals“.
-XXXIV. Derselbe wackere (Mann) also ehrt eben dasselbe, was wird,
+gewähnt, ist werdend und vergehend, aber völlig seiend *niemals“.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="34">
+<p>Derselbe wackere (Mann) also ehrt eben dasselbe, was wird,
 vergeht und durchaus niemals ist, wegen seines Werdens und Vergehens
 <lb n="20"/> jetzt mit dem Namen der Götter. Eben derselbe sagt ferner, indem er diejenigen
 widerlegt, die diesen Göttermythos ausgestreut haben, daß sie
@@ -2281,7 +2715,7 @@ keineswegs infolge „ zwingender Wahrscheinlichkeits-  und Beweisgründe“
 den Irrtum (betreffs) der anogeblichen Götter vorbrachten. Neachdem er
 sie in dieser Weise beschuldigt hat, sagt er hinterdrein, daß wir ihnen
 <lb n="25"/> glauben und sie für wahrhaftig halten müssen, obwohl sie nichts Wahrhaftiges
-reden, aber obwohl er sie sogar Göttersöhne nennt, ist ihm <note type="marginal">Σ 54</note>
+reden, aber obwohl er sie sogar Göttersöhne nennt, ist ihm <milestone unit="altnumbering" n="54"/>
 (doch) offenbar bewußt, daß er ihre Vorfahren als sterblich, jedermann
 ähnlich einführt und ferner an sterbliche Götter und sterbliche, ihren
 Vorfahren ähnliche Söhne erinnert, die sagen, „daß sie ihre Vorfahren
@@ -2293,13 +2727,13 @@ und fügt hinzu, daß „wir sie für wahrhaftig halten müssen, da sie vor-
 <note type="footnote">5 φόρκυς] φρόκυς Σ |καὶ ὅσοι μετὰ τούτων Ρ &lt; Σ 1. <foreign xml:lang="abbr">ABBREV</foreign>
 <foreign xml:lang="abbr">ABBREV</foreign> 13 καὶ τί τὸ γινόμενον μὲν ἀεί, ὂν δὲ οὐδέποτε Ρ &lt; Σ 1. <foreign xml:lang="abbr">ABBREV</foreign>
 <foreign xml:lang="abbr">ABBREV</foreign>  17 „völlig“]
-ὄντως Ρ |„niemals“] 1. <foreign xml:lang="abbr">ABBREV</foreign> mit HS 19 „wegen“ Σ besser
+ὄντως Ρ | „niemals“] 1. <foreign xml:lang="abbr">ABBREV</foreign> mit HS 19 „wegen“ Σ besser
 wohl „trotz“</note>
 
 <pb n="v.3.pt.2.p.95"/>
 geblich eigene (Familiengeschichten) erzählen“. Durchaus
 aber sagt er nicht: „da sie erzählen“, sondern „da sie
-„Wir müssen uns vielmehr überzeugen “, sagt er,
+„Wir müssen uns vielmehr überzeugen“, sagt er,
 seien Söhne der Götter“. Woher hat er (denn) dies zu
 „wie sie behauptet “? Denn sie haben dies behauptet, nicht ich. <lb n="5"/>
 das heißt aber: Dennoch, da sie über sich selbst aussagen, wenn
@@ -2308,7 +2742,11 @@ selbst (betreffenden Tatsachen) feststellen können, — dennoch
 wir ihnen. Hinterher sagt er: „So also, wie sie sagen, sagen, sich die
 Geburt der Götter verhalten“. Notwendig bemerkt er, „wie sie sagen“. <lb n="10"/>
 Denn keineswegs nach meiner, sondern nach ihrer Meinung soll dies
-gesagt sein (will er damit ausdrücken). XXXV. Du siehst also, daß
+gesagt sein (will er damit ausdrücken).</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="35">
+<p>Du siehst also, daß
 rät, wir üßten dem Irrtum nachfolgen. Weswegen aber stellt er
 fest? Um keiner anderen Ursache als um des Gesetzes, das heißt,
 des Todes willen, der am Gesetze hängt. Eben dies bekennt er offen, <lb n="15"/>
@@ -2316,7 +2754,11 @@ indem er sagt: „Dem Gesetze folgend glauben “. Geht denn die
 Furcht vor den Menschen und dem Gesetz *bei den Philosophen über
 die Furcht und das Gesetz der Wahrheit hinaus? Wo sind die vorzüglichen
 und weisen (Worte) jener schönen Sprache, mit denen er
-durchaus staunenswerter Sprache gewaltig so redete: XXXVI. „Denn <lb n="20"/>
+durchaus staunenswerter Sprache gewaltig so redete:</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="36">
+<p> „Denn <lb n="20"/>
 kein Gesetz und keine Ordnung ist besser als das Wissen, und nicht
 ist es recht, daß der Verstand irgend einem Dinge unterworfen
 Untertan sei, sondern er ist der Führer aller Dinge, wenn er in
@@ -2325,8 +2767,11 @@ selber stellt, indem er glaubt, daß es das beste sei, dort muß er
 wie mir scheint, bleiben trotz des Sturmes, indem er nichts bedenkt,
 weder den Tod noch irgend etwas anderes vor dem Schimpf“.
 sagt er: „Denn die Furcht vor dem Tode, ihr Männer,
-<note type="marginal">Σ 55</note> nichts anderes als wähnen, weise zu sein, obwohl man es
-XXXVII. Warum also, Weiser, wirst du nach diesen Worten vom <lb n="30"/>
+<milestone unit="altnumbering" n="55"/> nichts anderes als wähnen, weise zu sein, obwohl man es nicht ist“.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="37">
+<p>Warum also, Weiser, wirst du nach diesen Worten vom <lb n="30"/>
 Tode bewegt und heuchelst, sterbliche Götter um des Gesetzes
 <note type="footnote">20–24 = Piaton Nomoi 875 C 24–27 = Piaton Apologia 28
 XIII 10 3 28. 29 = Piaton Apologia 29 A; Praep. XIII 10 5</note>
@@ -2345,16 +2790,26 @@ machst du zu Schanden und schüttelst ab, was sie durchaus
 noch auf Grund irgend eines Beweises über ihre Vorfahren gesagt
 <lb n="5"/> haben. Wie kannst du, nachdem du sie so beschuldigt hast, den
 Menschen (noch) raten, ihnen zu glauben? Was ihre Väter sind,
-wir prüfen! XXXVIII. Die Erde, heißt es, und der Himmel
+wir prüfen!</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="38">
+<p>Die Erde, heißt es, und der Himmel
 Kinder Okeanos und Tethys, und ferner Phorkys, Kronos und Rhea,
 und dann nach diesen allen Zeus und Hera. Zeus nach der Erde und
 <lb n="10"/> dem Himmel! Zeus nach Kronos und Rhea, nach allen diesen! Was
 sagst du, wackerer Mann? Wo ist Zeus, der Gewaltige im Himmel,
 der den fliegenden Wagen treibt? Oder wars nicht dein eigenes Wort,
-über das jedermann in lautes Staunen ausbricht, wenn du so sagst:
-XXXIX. „Der gewaltige Zeus also im Himmel, der den fliegenden Wagen
-<lb n="15"/> treibt und lenkt und dem nachfolgen die Heere der Götter
-XL. Aber das weiß ich nicht, warum (erst) nach der
+über das jedermann in lautes Staunen ausbricht, wenn du so sagst:</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="39">
+<p> „Der gewaltige Zeus also im Himmel, der den fliegenden Wagen
+<lb n="15"/> treibt und lenkt und dem nachfolgen die Heere der Götter und Dämonen.“</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="40">
+<p>Aber das weiß ich nicht, warum (erst) nach der
 nach dem Meere, nach Okeanos, Rhea und Kronos, den Sterblichen,
 Zeus erschien und wie (dies) dein Wort jenem (anderen) entspricht:
 „Wir müssen uns überzeugen lassen von denen, die vor uns
@@ -2367,7 +2822,11 @@ sich die Geburt betreffs dieser Götter verhalten und
 Götter, die die Poeten sagen, versichert uns obendrein und
 „Von Kronos und Rhea (stammten) Zeus und Hera und alle, von denen
 wir wissen, *daß sie alle als ihre üder genannt werden, und
-andere als Spröblinge dieser“. XLI. Prüfst du also, während dieser mann <note type="marginal">Σ 56</note>
+andere als Spröblinge dieser“.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="41">
+<p>Prüfst du also, während dieser mann <milestone unit="altnumbering" n="56"/>
 <lb n="30"/> erzählt? Und erzählt er nicht Dinge, die leicht sind, wohl
 die gottlos und seiner eigenen Philosophie entgegengesetzt sind? Denn
 eben er treibt in der Politeia vornehm diejenigen, die er jetzt Göttersöhne
@@ -2404,14 +2863,21 @@ liebende und das, was aus seiner Lehre sich ergibt, als todbringend beschuldigt 
 werden mag, und obwohl er glaubt, daß es keine Götter
 heuchelt er indessen dennoch, als ob er ein anderes Leben nicht kenne,
 denn nur das gegenwärtige.</p>
-<p>XLII. Die Peripatetiker aber hingen einer Meinung, die derjenigen
+</div>
+
+<div type="textpart" subtype="chapter" n="42">
+<p>Die Peripatetiker aber hingen einer Meinung, die derjenigen
 des Anfängers dieser Philosophie ähnlich war, so an, daß sie sogar <lb n="25"/>
 meinten, die Seele im Menschen sei sterblich, und behaupteten, ihre Ge-
 stalt und ihr Körper sei die „Entelechie“. Zu gunsten des
-<note type="marginal">Σ 57</note> Lebens, das sie allein kannten, gerieten sie unter die Menge und heu-
+<milestone unit="altnumbering" n="57"/> Lebens, das sie allein kannten, gerieten sie unter die Menge und heu-
 chelten Götter, obwohl sie glaubten, daß diejenigen, die nach
 der πολιτεία (verehrt werden mußten), niemals existierten, aus Furcht <lb n="30"/>
-vor dem Tode und vor der gesetzlichen Strafe. XLIII. Die Stoiker
+vor dem Tode und vor der gesetzlichen Strafe.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="43">
+<p>Die Stoiker
 wiederum, die lehrten, daß alles körperlich und daß
 Welt allein Gott sei, und sich einredeten, daß ihre Teile Götter
 <note type="footnote">8 vgl. Piaton Phaidros 247 C 15 vgl. Praep. XIII 14 3 17 vgl. Aristoteles
@@ -2426,7 +2892,11 @@ sollten das tun dürfen, was ihren Lehren entspricht, selbst wenn
 ist? Deswegen weil sie die Teile der Welt Götter nannten und die
 οὐσία verehrten, sollten sie ohne Tadel sein? Sie aber, die die στοιχεῖα
 als den Anfang des Alls festsetzten, sollten dem entspreched die στοιχεῖα
-<lb n="5"/> verehren dürfen? XLIV. Er aber (Piaton) setzte wie durch göttliche
+<lb n="5"/> verehren dürfen?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="44">
+<p>Er aber (Piaton) setzte wie durch göttliche
 fest, was „das immer Seiende, aber niemals Werdende“
 was „das durch Wissen mit der Vernunft Wahrgenommene und immer
 sich selbst “ sei, und sagte, wie weit es reiche, und redete offen-
@@ -2446,7 +2916,7 @@ die der Hunde, Affen, Ameisen, Pferde, Esel und der übrigen unvernünftigen
 Tiere sei unsterblich und in nichts unterschieden von der Seele der
 Philosophen ihrer οὐσία nach. Agyptisierend sagt er, daß nach
 Meinung eben diese (Seelen) allerlei Leiber wechseln und die der Menschen
-<lb n="25"/> in die Natur der Tiere umgegossen werden. Um dieser (Dinge) willen <note type="marginal">Σ 58</note>
+<lb n="25"/> in die Natur der Tiere umgegossen werden. Um dieser (Dinge) willen <milestone unit="altnumbering" n="58"/>
 wird er auch darin verachtet, worin er die Wahrheit gesagt Δαὶ, wie jemand,
 mand, der auf der andern Seite lügt. Denn wenn dieser Mann auch
 wundernswert ist (darin), ß er den Werkmeister und Schöpfer
@@ -2469,8 +2939,11 @@ daß sie geworden, vergänglich ihrer
 seien *aus Feuer, Erde und den übrigen στοιχεῖα *und betet sie
 an zumal, ehrt sie und nennt sie Götter. Hinterher aber bekennt er
 dann wiederum, daß sie auflösbar und vergänglich seien. Doch is es <lb n="5"/>
-an der Zeit, ihn selber zu hören wie er im Timaios sagt: XLV.
-Gótter der Götter, deren Bildner ich bin. Alles also,
+an der Zeit, ihn selber zu hören wie er im Timaios sagt:</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="45">
+<p>Gótter der Götter, deren Bildner ich bin. Alles also,
 wird, ist auflösbar. Deswegen weil ihr geworden seid, seid
 nicht unsterblich und völlig unauflösbar“. Ferner aber sagt
 ihr Werden, woher es ist und wie es begrenzt wurde: „daß (sich) das <lb n="10"/>
@@ -2488,7 +2961,11 @@ entstanden ist, von irgend einem Anfang ausgehend“, antwortet er
 sich selber und sagt: „Er ist entstanden; denn er ist sichtbar und *tastbar
 bar und hat einen Körper. Alles derartige aber ist wahrnehmbar
 das Wahrnehmbare wird durch die Vorstellung begriffen und erscheint
-<note type="marginal">Σ 59</note> als geworden“. XL VI. Er also, der so über diese (Dinge) schön und <lb n="25"/>
+<milestone unit="altnumbering" n="59"/> als geworden“.</p>  
+</div>
+
+<div type="textpart" subtype="chapter" n="46">
+<p>Er also, der so über diese (Dinge) schön und <lb n="25"/>
 richtig geredet hat, entfernte er sich nicht weit von der gesunden Meinung,
 indem er sie Götter nannte, (zugleich) aber bekannte, daß
 seien aus der vergänglichen ὕλη der Körper des Feuers,
@@ -2530,7 +3007,9 @@ ganz deutlich zugibt, daß sie durch die Fesseln Gottes,
 des Alls, *gebunden seien und aus seelenlosen στοιχεῖα, (aus) Feuer,
 <lb n="25"/> Wasser, Luft und Erde best:ünden. Aber auch der (Piaton möge)
 (beendigt sein).</p>
-<p>XLVII. Was habe ich jetzt (noch) nötig, ans klare Licht zu
+</div>
+<div type="textpart" subtype="chapter" n="47">
+<p>Was habe ich jetzt (noch) nötig, ans klare Licht zu
 wie die Weisen sich gleichsam in Reihen sammelten, sich entzweiten
 und trennten von einander, sich wie in Schlachtreihe und Kampf
 <lb n="30"/> mächtig widereinander rüsteten. „Sie begegneten sich aber
@@ -2546,9 +3025,17 @@ und durch “ Σ 24 1. <foreign xml:lang="abbr">ABBREV</foreign> entsprechend <f
 
 <pb n="101"/>
 <p>Denn eine „Gigantenschlacht“ nennt Piaton ihren gegenseitigen Kampf,
-<note type="marginal">Σ 60</note> indem er so sagt: XLVIII. „Und fürwahr es schien unter ihnen
+<milestone unit="altnumbering" n="60"/> indem er so sagt:</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="48">
+<p> „Und fürwahr es schien unter ihnen
 eine Gigantenschlacht zu sein wegen des gegenseitigen Streites über die
-οὐσία“. XLIX. Aber er, Piaton, redete dies über diejenigen, die vor ihm oder
+οὐσία“.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="49">
+<p>Aber er, Piaton, redete dies über diejenigen, die vor ihm oder
 über die, die mit ihm Philosophen waren. Daß aber ebenso diejenigen, <lb n="5"/>
 die er zu seiner Xachfolge aufrief, sich wider ihn mit der Waffe versahen,
 dafür ist das Zeugnis klar. Denn aus der durch seine Worte
@@ -2580,7 +3067,7 @@ für jenes zu ringen und zu kämpfen, und wo es
 für wäre, selbst für die Wahrheit willig zu sterben
 auf sich zu nehmen wie Menschen die sich ühmen, Philosophen zu sein.
 Eben jene aber waren hierin liebevoll gegen einander, indem sie sich <lb n="35"/>
-Σ61 vereinigten zur Lüge; aber dort, wo es nicht geziemend war zu kämpfen
+<milestone unit="altnumbering" n="61"/> vereinigten zur Lüge; aber dort, wo es nicht geziemend war zu kämpfen
 <note type="footnote">2—4 = Piaton Sophistes 246 A; Praep. XIV 4 9 13 vgl. Praep. XI 4 2</note>
 <note type="footnote">9 „Jünglinge“ Σ (= νεώτεροι?) ß 33 „und" &lt;Σ 1.</note>
 
@@ -2593,7 +3080,10 @@ Worthieben. Was habe ich ötig, *festzustellen, ß die Weisen in ihren
 Krieg verfielen, weil sie menschliche Weisheit benutzten und
 sterbliche Erwägungen (und) Gedanken, aber nicht Gott als
 trafen?</p>
-<p>L. Was also? Warum hatten diejenigen keinen Gott, die um diese
+</div>
+
+<div type="textpart" subtype="chapter" n="50">
+<p>Was also? Warum hatten diejenigen keinen Gott, die um diese
 <lb n="10"/> (Dinge) kämpften, obwohl doch die Schar der Götter
 war? Mochte auch der von Delphi und der von Lebadia weissagen,
 mochte der von Kolophon Antwort erteilen und der von Milet orakeln,
@@ -2618,7 +3108,7 @@ die Tempel, Heiligtümer und (Götter)bilder auf Erden
 ihre (der Götter) Macht prüfen und (durften) infolge
 fernerhin nicht (mehr) ihre Worte über die Vorsehung oberhalb des
 Himmels noch oberhalb des Mondes festhalten, sondern mußten
-überzeugen, ß es auch auf Erden Götter gebe, und daß sie sich um <note type="marginal">Σ 62</note>
+überzeugen, ß es auch auf Erden Götter gebe, und daß sie sich um <milestone unit="altnumbering" n="62"/>
 <lb n="35"/> die Menschen kümmern, mit denen sie zusammen sind. Von eben
 (mußten sie) lernen, daß es ihnen nicht erlaubt sei,
 denen zu kämpfen, die ihnen entgegentraten, (darum), ob die Seele
@@ -2651,12 +3141,15 @@ obwohl sie in Wahrheit Götter (waren), verachteten, waren sie
 weise, sondern Toren und Idioten. Wenn sie aber in Wahrheit die
 Liebe zur Weisheit gepflegt und Überfluß an Wissen mehr als die meisten
 gehabt hätten, so wäre dies klar, daß sie mit reinem
-Torheit der Menge aller Wahrscheinlichkeit nach gespottet hätten. <lb n="25"/>
-LI. Wenn die (so)genannten Götter aber in Wahrheit existierten,
+Torheit der Menge aller Wahrscheinlichkeit nach gespottet hätten. <lb n="25"/></p>
+</div>
+
+<div type="textpart" subtype="chapter" n="51">
+<p>Wenn die (so)genannten Götter aber in Wahrheit existierten,
 traf es sie, in dem Verkehr auf Erden wohnen zu müssen? Gewiß
 um der Gesamtheit aller Menschen zu helfen? Wenn aber dies der
 Fall war, warum unterließen sie dann nicht jene jene
-<note type="marginal">Σ 68</note> und verkündeten (lieber) jedermann, was zum Erwerb der Tugend hilft? <lb n="30"/>
+<milestone unit="altnumbering" n="63"/> und verkündeten (lieber) jedermann, was zum Erwerb der Tugend hilft? <lb n="30"/>
 Warum boten sie sich nicht selber an, den Menschen Gesetze zu geben,
 indem sie *recht machten die Sitten der Allgemeinheit und für
 Werke anordneten zu einem besseren Leben? Warum kümmerten
@@ -2686,7 +3179,11 @@ rühmten, Philosophen zu sein, dieses Namens wert seien. Denn
 <lb n="15"/> sie in Wahrheit weise gewesen wären, so ätten sie jene
 Götter gehalten, da sie etwas Götterwürdiges
 noch das Göttliche diejenigen zu lehren vermochten, die sich um
-Wissen dieser (Dinge) kümmerten. LH. Sie aber, die nicht so
+Wissen dieser (Dinge) kümmerten.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="52">
+<p>Sie aber, die nicht so
 sondern der Menge heuchelten und Götter diejenigen nannten, von
 <lb n="20"/> sie besser als jedermann (und) genau wußten, daß sie
 welches Namens sind sie würdig? Ich brauche nichts weiter zu
@@ -2694,7 +3191,7 @@ als daß sie, die ihre Haarlocken (lang) herabfallen ließen,
 Gastwirten, verworfenen Männern und Huren in die Tempel
 Was fragten denn jene Weisen von den Göttern? Das, was den
 <lb n="25"/> nützt? Niemand dürfte das von ihnen behaupten. So also
-wurden die Götter ihnen nicht zu hülfreichen Lehrern des Wissens, <note type="marginal">Σ 64</note>
+wurden die Götter ihnen nicht zu hülfreichen Lehrern des Wissens, <milestone unit="altnumbering" n="64"/>
 sondern sie waren, wie man sagt, brauchbare und hilfreiche Orakelgeber
 im Leben der meisten, um aufzufinden, wenn ein Sklave zufällig
 entflieht, oder wenn ein Gefäß verloren geht, oder um ein
@@ -2729,15 +3226,20 @@ das ganze Geschlecht der Menschen schädigte, wie haben
 wir da nicht mit Recht gesagt, daß Gott als Erlöser und die göttliche
 Offenbarung und ein gemeinsamer Helfer aller unserem Leben erforderlich
 war?</p>
-<p>LIII. So weit aber waren ferner viele zum Wahnsinn geführt, daß <lb n="20"/>
+</div>
+<div type="textpart" subtype="chapter" n="53">
+<p>So weit aber waren ferner viele zum Wahnsinn geführt, daß <lb n="20"/>
 sie auch ihr Liebstes opferten denen, die Götter (zu sein) schienen und
 kein *Mitleid hatten mit der Natur, sondern sogar ihre einzigen und
 geliebten Kinder im Wahnsinn und in der Raserei des Verstandes töteten.
 Denn welcher Wahnsinn könnte größer sein als der, Menschen
-<note type="marginal">Σ 65</note> zu opfern und alle ihre Städte und alle ihre Häuser mit dem eigenen <lb n="25"/>
+<milestone unit="altnumbering" n="65"/> zu opfern und alle ihre Städte und alle ihre Häuser mit dem eigenen <lb n="25"/>
 Blut zu besudeln? Oder bezeugen nicht eben dies die Hellenen, und
-ist nicht ihre ganze Geschichte voll von der Erinnerung daran? LIV.
-Denn dem Kronos opferten die Phöniker jedes Jahr ihre geliebten und
+ist nicht ihre ganze Geschichte voll von der Erinnerung daran?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="54">
+<p>Denn dem Kronos opferten die Phöniker jedes Jahr ihre geliebten und
 einzigen Kinder. Eben demselben wurde ferner auch auf Rhodos am
 sechsten im Monat Kanôn ein Mensch geschlachtet. Diese Sitte war sehr <lb n="30"/>
 mächtig, wurde dann aber geändert. Denn Einen von denen, die von
@@ -2752,7 +3254,11 @@ l. <foreign xml:lang="abbr">ABBREV</foreign></note>
 <pb n="v.3.pt.2.p.106"/>
 des Kronos auf. Als aber das Fest begann, führten sie den Mann
 den Toren heraus (bis) gegenüber dem Bilde der
-ihn mit Wein und töteten ihn. LV. In dem jetzt (so) genannten
+ihn mit Wein und töteten ihn.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="55">
+<p>In dem jetzt (so) genannten
 dem früheren Koroneia, wurde in dem Monat, der bei den
 <lb n="5"/> Aphrodisios heißt, der Agraulos, der Tochter des Kekrops
 der agraulischen Nymphe, ein Mensch geschlachtet. Diese Sitte dauerte
@@ -2764,16 +3270,30 @@ dreimal den Altar, dann schlug ihn der Priester mit der Lanze auf den
 στόμαχος und verbrannte ihn darauf ganz auf dem zusammengebrachten
 Scheiterhaufen. Dieses Gesetz aber schaffte Diphilos, der König
 Kypern ab, der um die Zeit des Theologen Seleukos lebte, und änderte die
-<lb n="15"/> Sitte in ein Stieropfer um. LVI. Es schaffte aber auch zu Heliopolis
-in Agypten Amosis das Gesetz, daß Menschen geopfert wurden, ab,
-Manethos bezeugt in den (Büchern) über den Anfang und über
-Gerechtigkeit. LVIL Sie wurden aber [auch] der Hera geopfert und
-ausgewählt, wie reine Kälber geprüft und
-<lb n="20"/> wurden aber drei am Tage geopfert. Dafür befahl Amosis, daß
-ihnen (an Zahl) entsprechende (Bilder) aus Wachs auferlegt würden.
-Man opferte aber auch in Chios dem *Omadios Dionysos einen Menschen,
-indem man ihn zerriss, und in Tenedos, wie Euelpis, der Karystier, sagt. <note type="marginal">Σ 66</note>
-LIX. Auch die Lakedämonier opferten, wie Apollodoros sagt, dem
+<lb n="15"/> Sitte in ein Stieropfer um.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="56">
+<p>Es schaffte aber auch zu Heliopolis
+in Agypten Amosis das Gesetz, daß Menschen geopfert wurden, ab, wie
+Manethos bezeugt in den (Büchern) über den Anfang und über die
+Gerechtigkeit.</p>
+</div>
+  
+<div type="textpart" subtype="chapter" n="57">
+<p>Sie wurden aber <del>auch</del> der Hera geopfert und
+ausgewählt, wie reine Kälber geprüft und geschlachtet werden. Es
+<lb n="20"/> wurden aber drei am Tage geopfert. Dafür befahl Amosis, daß gleiche
+ihnen (an Zahl) entsprechende (Bilder) aus Wachs auferlegt würden.</p>
+</div>
+  
+<div type="textpart" subtype="chapter" n="58">
+<p>Man opferte aber auch in Chios dem *Omadios Dionysos einen Menschen,
+indem man ihn zerriss, und in Tenedos, wie Euelpis, der Karystier, sagt. <milestone unit="altnumbering" n="66"/></p>
+</div>
+
+<div type="textpart" subtype="chapter" n="59">
+<p>Auch die Lakedämonier opferten, wie Apollodoros sagt, dem
 <lb n="25"/> einen Menschen. Die Phöniker aber opferten bei großen
 wie Kriegen oder Seuchen oder Hungersnöten einen der
 der ausgewählt wurde, dem Kronos. Voll aber ist die Geschichte
@@ -2792,19 +3312,38 @@ vor KlJoVs 16 Ἄμωσις] „Amosios“ Σ 17 ἐν τῷ Περὶ ἀρχα
 <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> 29 Βύβλιος] „Byblos“ Σ</note>
 
 <pb n="107"/>
-die griechische Sprache in acht Büchern übersetzte. LX. Istros aber 
+die griechische Sprache in acht Büchern übersetzte.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="60">
+<p>Istros aber 
 sagt in der Sammlung der kretisechen Opfer, ß die Kureten früher &lt;dem
 Kronos) Kinder opferten. Die Menschenopfer aber, die (fast) an jedem
 Ort waren, wurden abgeschafft, sagt Pallas, der am vorzüglichsten über
 die Mysterien des Mithras gesammelt hat, in den Tagen des Königs <lb n="5"/>
-Hadrian. LXI. Geopfert wurde aber zu Laodikea in Syrien der Athena
-jedes Jahr eine Jungfrau, heute aber eine Hirschkuh. LXII. Auch die
+Hadrian.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="61">
+<p>Geopfert wurde aber zu Laodikea in Syrien der Athena
+jedes Jahr eine Jungfrau, heute aber eine Hirschkuh.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="62">
+<p>Auch die
 Karchedonier in Libyen brachten das Opfer dar, das Iphikrates aufhören
 ließ. Die Dumatener aber in Arabien opferten jedes Jahr
 Kind, das sie unter dem Altar begruben, den sie als Götzenbild beinsgesamt <lb n="10"/>
-nutzten. LXIII. Phylarchos aber schreibt, daß früher
-insgesamt Menschen opferten, bevor sie in den Krieg hinauszogen.
-LXIV. Und ich übergehe die Thraker und Skythen, und daß auch
+nutzten.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="63">
+<p>Phylarchos aber schreibt, daß früher
+insgesamt Menschen opferten, bevor sie in den Krieg hinauszogen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="64">
+<p>Und ich übergehe die Thraker und Skythen, und daß auch
 Athener die Tochter des Erechtheus und der Praxithea töteten.
 wem wäre verborgen, daß bis jetzt in der Hauptstadt am Feste des <lb n="15"/>
 latiarischen Zeus ein Mensch geopfert wird? Bis jetzt aber opfern keines-
@@ -2813,7 +3352,7 @@ wegs nur in Arkadien alle insgesamt Menschen am Feste des *Lykäers
 um der gesetzlichen Erinnerung willen in jedem Jahr eigenes (Stammes)blut
 fortwährend an die Altäre“. Daß dies so sei, bezeugen auch die <lb n="20"/>
 erlesensten Philosophen. Diodoros aber, der die Bibliotheken ver-
-<note type="marginal">Σ 67</note> kleinerte, sagt, daß die Libyer dem Kronos zweihundert der
+<milestone unit="altnumbering" n="67"/> kleinerte, sagt, daß die Libyer dem Kronos zweihundert der
 Kinder von Staatsivegen opferten, daß sie aber dreihundert andere,
 *geringer(en Standes) als diese, dem Opfer (der Vorfahren) hinzufügten.
 Der Historiker der römischen Geschichte, mit Namen Dionysius, aber <lb n="25"/>
@@ -2841,7 +3380,11 @@ Ursache der Verwüstung des Landes. So große Verderbnis
 vernichtete das Leben der Menschen, daß sie eine andere Hoffnung
 Erlösung (sich) nicht verschreiben konnten als die von Gott,
 der allein — und kein anderer — dem sterblichen Geschlecht nötig
-<lb n="10"/> war. LXV. In solchen (Zuständen) der Seele waren alle Menschen
+<lb n="10"/> war.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="65">
+<p>In solchen (Zuständen) der Seele waren alle Menschen
 jedem Ort.</p>
 <p>Nicht genügte ihnen aber ausser diesen (Dingen)
 sondern sie wurden auch von außen her an jedem Ort und in
@@ -2859,7 +3402,7 @@ Lebens mit Kämpfen und Kriegen wider einander beschäftigt
 <lb n="25"/> sodaß es nicht möglich war, irgendwohin in Geshäften
 wenn man nach Art des *Kriegers gerüstet war, und (sodaß)
 Dörfern und auf den Ackern die Feldarbeiter mit Schwertern
-waren und mehr *Ausrüstung als äte be- <note type="marginal">Σ 68</note>
+waren und mehr *Ausrüstung als äte be- <milestone unit="altnumbering" n="68"/>
 <note type="footnote">12–8. 109, 2 = Laus 239 19—240 2</note>
 <note type="footnote">1 καρπῶν . . . . καὶ βοσκημάτων Ρ „Früchten und “ Σ (= βλαστημάτων?)
 4 ἀφαιρουμένους L „ausgewählt“ Σ (= ἐξαιρουμένους, wohl nicht
@@ -2874,15 +3417,19 @@ Art des “ Σ = πολέμου τρόπον] πολεμίου τρόπον 
 <pb n="v.3.pt.2.p.109"/>
 saßen und die Plünderung und der Menschenraub aus (dem
 Nachbarn für etwas Tugendhaftes galt. Dies unser Wort bezeugt
-ganze Geschichte der Griechen und Barbaren. [Denn] (auch) die
+ganze Geschichte der Griechen und Barbaren. <del>Denn</del> (auch) die
 Schriften, die es unter den Juden giebt, lehren, daß es vor den
 des Augustus und Tiberius, in deren Tagen unser Erlöser in der Welt <lb n="5"/>
 erschien, früher durchaus in jeder Stadt und in jedem
-und Fürsten der Länder gab. LXVI. Sogleich also, als
+und Fürsten der Länder gab.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="66">
+<p>Sogleich also, als
 nach dem Auszug aus Ägypten durch Mose, in das Land Palästina
 kamen, verfolgten sie dreißig Könige an der Zahl
 Es blieben aber, ohne ausgerottet zu werden, indem sie ihre Einwohner, <lb n="10"/>
-ihren Wohnort und ihre Könige (auch fernerhin) [in Gebrauch]
+ihren Wohnort und ihre Könige (auch fernerhin) <del>in Gebrauch</del>
 diejenigen, die in Gaza und Askalon wohnten. Joppe und Asdod ferner wurden
 den besonders für sich beherrscht. Skythopolis und die Städte um es
 herum wurden so regiert, daß es sich daher ereignete, daß sie die ganze
@@ -2892,15 +3439,19 @@ wurde, den Salomo baute, was habe ich nötig zu sagen, wieviel
 hinterher auch vom Volk der Juden aus Rache feführt wurden
 Vernachlässignung der Verehrung ihres Gottes, sodaß deswegen
 sich von einander trennten und wider einander erhoben, sodaß sie verschiedene <lb n="20"/>
-schiedene und *feindliche Könige [in Gebrauch] hatten, von denen
+schiedene und *feindliche Könige <del>in Gebrauch</del> hatten, von denen
 einen das früher (so)genannte Samarien, jetzige Sebaste
 inne hatten, die anderen aber in Jerusalem wohnten und immerfort mit
-ihren Stammesgenossen kämpften und sie mit ihnen. LXVII. Ihnen
+ihren Stammesgenossen kämpften und sie mit ihnen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="67">
+<p>Ihnen
 aber litten auch die, welche im Lande Arabien wohnten. Denn zahlreich <lb n="25"/>
 waren auch bei jenen die Orstfürsten. Ebenso waren auch die
 ihren eigenen Königen untertan. Die Phöniker
 ihre Ortschaften, damit niemand mit ihnen verkehre oder durch sie hin-
-<note type="marginal">Σ 69</note> durchziehe, indem sie fortwährend das Land ihrer
+<milestone unit="altnumbering" n="69"/> durchziehe, indem sie fortwährend das Land ihrer
 und indem sie fortwährend Städtebelagerung und gegenseitige <lb n="30"/>
 Gefangennahme ausübten. Und nicht nur dies, sondern auch ganz
 und Agypten war allen Fürsten und Königen
@@ -2920,7 +3471,7 @@ denjenigen, die unter ihrer Herrschaft (standen), so machten sie ihre
 <lb n="5"/> Nachbarn zu Feinden und Hassern, sodaß daher auch sie die ganze Zeit
 ihres Lebens mit Kriegen verbrachten und wider einander in Aufruhr
 gerieten, dementsprechend, daß sie *viele Fürsten *und
-[in Gebrauch ] hatten. Von dort aber begann auch die Verirrung des
+<del>in Gebrauch </del> hatten. Von dort aber begann auch die Verirrung des
 Polytheismus weidete wie eine böse
 <lb n="10"/> *die übrigen Orte der Völker. Die Ägypter waren mehr als
 Menschen in der Verehrung der Götter (bewandert) und hätten
@@ -2931,14 +3482,18 @@ die jetzt den Augen sichtbaren Gründe ihres Friedens und
 Deswegen wurden sie durch Kriege und Kämpfe wider einander
 ganze Zeit ihres Lebens gequält und füllten ihre Länder
 (Stammes)blut und Mord, indem die Götter als Frucht ihrer
-ihnen *diese und derartige *Werke förderten. LVIII. Wenn aber
+ihnen *diese und derartige *Werke förderten.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="68">
+<p>Wenn aber
 <lb n="20"/> (Dinge) nicht jedermann bekannt sein sollten, wem von meinen Freunden
 sollte das verborgen sein, was man von den Griechen liest? Der Krieg
 der Peloponnesier und Athener, den Thukydides beschrieb, wo Griechen
 mit Griechen kämpften, wie sie die *Potidäer einschlossen, wie
 Thebaner und ergriffen, Platäer ergriffen, wie die Thraker und
 <lb n="25"/> die Athener unterstützten, bisweilen aber eben diesen
-waren, wie die Athener die Korinther einschlossen, wie sie das Land <note type="marginal">Σ 70</note>
+waren, wie die Athener die Korinther einschlossen, wie sie das Land <milestone unit="altnumbering" n="70"/>
 der *Epidaurier und Trözenier verwüsteten, wie sie (das Land)
 verwüsteten und selbst wiederum Entsprechendes von
 Lakedämoniern erlitten, indem diese nach Attika kamen und das
@@ -2962,7 +3517,10 @@ Göttern redeten, die mit ihnen zusammen waren und lebten auf
 und sie äufig durch Orakel und Offenbarungen unterstützten.
 die Früchte dieser Götterverehrung waren diese:
 und Gefangenschaft.</p>
-<p>LXIX. Wenn du aber das prüfen willst, was älter ist als dies, so <lb n="10"/>
+</div>
+
+<div type="textpart" subtype="chapter" n="69">
+<p>Wenn du aber das prüfen willst, was älter ist als dies, so <lb n="10"/>
 richte deinen Geist auf den, der in Delphi den Griechen vorsitzt, auf
 den Pythier, meine ich, der bei allen Griechen gepriesen wird. Eben
 er rief dem Lydier (Krösus) zu und war war stark, indem er sagte:
@@ -2978,7 +3536,7 @@ während der Pythier auf die Griechen sah und die übrigen
 Argiver mit den Korinthern kämpften und die Lakedämonier
 Trözeniern und die Lokrer wiederum mit anderen Griechen
 und die Kerkyreer mit anderen, als Messene viermal von den Lakedämoniern <lb n="25"/>
-<note type="marginal">Σ 71</note> eingenommen wurde, als die Arkadier bedrángt und die
+<milestone unit="altnumbering" n="71"/> eingenommen wurde, als die Arkadier bedrángt und die
 der Orchomenier zerstört wurden, als die Athener die Agineten
 und ferner die Megarer die Korinther, die Lakedämonier die
 die Athener die Booten, die Lokrer die Phokeer und alle diese Griechen
@@ -3008,7 +3566,11 @@ soll, von den kriegsliebenden, die Menschen hassenden und mit Gott
 Denn diese waren die Ursache für alles dies, weil sie
 liebten und auf der Stelle, so oft ihnen (dies) durch Kriege unmöglich
 war, sich durch Menschenopfer in jeder Stadt voll füllten
-an vergossenem Menschenblute freuten. LXX. Eines also von zweien
+an vergossenem Menschenblute freuten.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="70">
+<p>Eines also von zweien
 <lb n="15"/> (gilt): Entweder waren sie nichts und eine böse Verirrung hatte
 die Menschen erfaßt, daß daß sie seelenlose Bilder
 eitel und unnütz ihre eigenen geliebten (Kinder) im Wahnsinn
@@ -3020,8 +3582,11 @@ außer wenn (sie) zur Hilfe und Erlösung
 denen sie wTohnten. Wenn sie aber böse Dämonen
 sie in allem das Gegenteil des Guten tun. Welcher Beweis ist zwingender
 <lb n="25"/> hierfür als die Früchte ihrer eigenen Verwaltung? Denn an
-seinen Früchten wird der Baum erkannt.“</p> <note type="marginal">Σ 72</note>
-<p>LXXL Es ist also Zeit zu prüfen, welches die Früchte
+seinen Früchten wird der Baum erkannt.“<milestone unit="altnumbering" n="72"/></p>
+</div> 
+  
+<div type="textpart" subtype="chapter" n="71">
+<p>Es ist also Zeit zu prüfen, welches die Früchte
 und Kämpfe sind — nicht der Feinde und nicht der Barbaren, die
 wider die Griechen erhoben — sondern der Griechen selst, welche
 <lb n="30"/> die Götter ihrer Vorfahren bekannten und wider einander rasend
@@ -3031,7 +3596,7 @@ Verehrung entsprechenden (Dinge) gaben sie denen, die sie verehrten?
 Etwa vor allem Frieden, in ruhigem Leben und Genuß zu leben,
 <note type="footnote">24 = Matth 12 33</note>
 <note type="footnote">1 1. <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> = ὁ ἐν Βραγχίδαις 4 vgl. ο. S. 83 14 = L 236 16 |
-„und“ Σ = καί 5 Vielleicht ist zu übersetzen: ,,Die Griechen aber wurdn . . .
+„und“ Σ = καί 5 Vielleicht ist zu übersetzen: „Die Griechen aber wurdn . . .
 von den liebenden und sorgenden, den die Griechen liebenden und schützenden
 Göttern gehindert“ Die Worstellung im Σist unsinnig 6 „und“ Σ1. <foreign xml:lang="abbr">ABBREV</foreign>
 <foreign xml:lang="abbr">ABBREV</foreign> Bernstein 29 „schrieben“ Σ = ἐπιγράφομαι 33 „oder“ Σ = ἢ</note>
@@ -3056,15 +3621,23 @@ Wenn sie also derart Täter des Bösen waren, ist es
 die Fürsten des Bösen genannt werden. Wenn sie aber
 es von andern getan wurde, übersahen, so waren sie wiederum Verräter 
 ihrer Freunde und keineswegs hilfreich, sondern hinterlistig und deshalb
-böse. LXXII. Denn wenn sie keine Götter, auch ihrer Natur nach nichts <lb n="20"/>
+böse.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="72">
+<p>Denn wenn sie keine Götter, auch ihrer Natur nach nichts <lb n="20"/>
 Besseres als wir selbst, sondern Menschen waren, nur daß sie mit
 versehen waren wegen ihrer Tugend und Weisheit, warum traten sie
 (dann) nicht ins Mittel und befreiten ihre Freunde vom Kampf, indem 
 sie sie entweder durchs Wort überzeugten oder mit Gewalt trennten und
 weit von einander entfernten und ihnen das rieten, was recht ist, indem <lb n="25"/>
-<note type="marginal">Σ 73</note> sie die Taten guter Menschen wirkten und sie von der Feindschaft
+<milestone unit="altnumbering" n="73"/> sie die Taten guter Menschen wirkten und sie von der Feindschaft
 befreiten und sie zum Friedenzusamenführten, da sie ja ihre Freunde
-sind? LXXIII. Was also? Auch gute Menschen würden dies tun,
+sind?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="73">
+<p>Was also? Auch gute Menschen würden dies tun,
 es ihnen begegnete. Die Götter aber vernachlässigten ihre
 sie ihnen nahe und bei ihnen waren, inmitten der Griechen wandelten <lb n="30"/>
 und von allen geehrt wurden, indem sie sie dem Blut (vergießen),
@@ -3084,7 +3657,11 @@ konnten, obwohl sie wollten, verdienen sie Verzeihung wegen ihrer
 Schwäche. Wenn sie aber demnach so waren, ist die Aussage, daß
 <lb n="5"/> Götter seien, überflüssig und wurde der Name „hilfreich“ ihnen
 mit Recht zugeschrieben, weil sie nicht einmal den Menschen zur Erlösung
-halfen wegen der Schwäche der Natur. LXXIV. Wenn
+halfen wegen der Schwäche der Natur.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="74">
+<p>Wenn
 aber das Fatum über uns setzt (der Art), daß es alles und selbst
 Götter beherrscht, und (anführt), daß eben dies die Ursache des
 <lb n="10"/> und alles dessen sei, was unter den Menschen geschieht, so wird eben
@@ -3100,10 +3677,13 @@ denen keine Kraft war, dem Bösen der Menschen zu helfen, und
 <lb n="20"/> offenbar (als solche) erschienen, welche sich freuen an schändlichen
 verwerflichen Göttergeschichten und an den bösen
 Opfern der Menschen. Daher also müssen wir glauben, daß
-die solches mit den damaligen Menschen taten wegen ihrer das Böse <note type="marginal">Σ 74</note>
+die solches mit den damaligen Menschen taten wegen ihrer das Böse <milestone unit="altnumbering" n="74"/>
 und den Krieg liebenden Natur, aus ihren eigenen Werken widerlegt
 <lb n="25"/> seien.</p>
-<p>LXXVI. Aber auf der Stelle jetzt zu unserer Zeit, wo alle Fürsorge
+</div>
+
+<div type="textpart" subtype="chapter" n="76">
+<p>Aber auf der Stelle jetzt zu unserer Zeit, wo alle Fürsorge
 für jene genannten ötter) vergessen ist und jene Äußerungen)
 alten Krankheit verringert sind, leben alle Städte und Ortschaften
 den Provinzen und in den Ländern in tiefem Frieden. Ganz
@@ -3137,13 +3717,15 @@ geraten sind und (wo) alle jene Götter, die einst an jedem
 Orte riefen, aus Scham oder aus Furcht schweigen, *sind alle Städte, <lb n="15"/>
 Provinzen und Länder zugleich durch die rechte Hand) der Liebe zum
 Frieden gebracht worden und genießen unter Einer Herrschaft von
-<note type="marginal">Σ 75</note> aus Ordnung zumal und Eintracht. Früher aber, als sie die Götter viel
+<milestone unit="altnumbering" n="75"/> aus Ordnung zumal und Eintracht. Früher aber, als sie die Götter viel
 mehr sogar als ihre geliebten (Kinder) ehrten, in welcher Lebensverfassung
 sich da die Völker Griechenlands und der Barbaren befanden. <lb n="20"/>
 brauchen wir nicht weiter in längerer Rede darzutun, da diese Dinge
 in kurzem klargelegt sind. Aber derart (sind) die alten (Überlieferungen)
 der Geschichte.</p>
-<p>LXXVII. Die neueren aber — wie sollte jemand sagen, wieviele
+</div>
+<div type="textpart" subtype="chapter" n="77">
+<p>Die neueren aber — wie sollte jemand sagen, wieviele
 Herrschaften seit dem Makedonier Alexandros, kurz vor dem Erscheinen <lb n="25"/>
 unseres Erlösers, bestanden? Denn *Aridaios, der Bruder
 empfing das Königtum von
@@ -3163,7 +3745,11 @@ wurde getötet. *Perdikas drang in Ägypten ein mit
 <pb n="v.3.pt.2.p.116"/>
 Ptolemaios eroberte Kypern, Demetrios plünderte Syrien, ein
 wiederum ging nach einem anderen Orte und besiegte mit seiner Räuberbande
-seine Grenznachbarn. LXXVIII. So also wurde eins nach dem
+seine Grenznachbarn.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="78">
+<p>So also wurde eins nach dem
 andern in derselben Zeit vollendet in allen Teilen der Welt, und friedlos
 <lb n="5"/> und unversöhnlich wurde ihre Feindschaft
 wáhren die Verehrung vieler Götter in jener Zeit
@@ -3173,12 +3759,15 @@ war das Götterwort bei den
 <lb n="10"/> und Massen ehrten in den Dörfern und an jedem Ort, so
 den Häusern, selbst in den Schatzkammern und
 Altären und Bildern die (Götter)
-sie so waren, unterschieden sie sich in nichts von dämonischen Menschen, <note type="marginal">Σ 76</note>
+sie so waren, unterschieden sie sich in nichts von dämonischen Menschen, <milestone unit="altnumbering" n="76"/>
 deren Seelen in Wahnsinn verkehrt, die die ganze Zeit ihres Lebens mit
 <lb n="15"/> dem Blute ihrer Ortsgenossen befleckt und in Wahrheit dämonisch waren,
 indem bei den gegenseitigen Kriegen und häufigen Städtebelagerungen
-die die Welt verderbenden Dämonen ihnen dabei
-LXXIX. Diejenigen aber, die für Götter gehalten wurden, gaben ihren
+die die Welt verderbenden Dämonen ihnen dabei behilflich waren.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="79">
+<p>Diejenigen aber, die für Götter gehalten wurden, gaben ihren
 Verehrern Orakel und Vorauswissen, verstanden aber nicht ihr eigenes
 <lb n="20"/> Verderben vorauszuwissen und vorauszusagen, das sich ihnen allen bei
 dem Erscheinen unseres Erlösers unter den Menschen
@@ -3191,7 +3780,11 @@ anderer der großen Dämonen wußte das eigene Verderben voraus noch
 sagte vorher den, der kommen werde als Vernichter und Zerstörer aller,
 noch sah alle diejenigen voraus, die aus den Griechen- und Barbarenvölkern
 <lb n="30"/> dem Irrtum des Polytheismus sich abwenden und den
-Einen über alles (herrschenden) Gott erkennen würden. LXXX. Welcher
+Einen über alles (herrschenden) Gott erkennen würden.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="80">
+<p>Welcher
 Orakelgeber aber oder Seher oder welcher ἡμίθεος oder Dämon oder
 Gott weissagte voraus, daß ihre eignen Herrlichkeiten verlöschen
 wenn ein Neuer, wer auch immer es sei, im Leben der Menschen erscheinen
@@ -3214,7 +3807,7 @@ aber waren die Fürsorger dieser (Bilder), die ihren
 nicht halfen, als sie von den Menschen zerstört wurden? Wo waren <lb n="10"/>
 diejenigen, die früher Kriege bewirkten, bei ihrem Unheil aber
 selbst Zerstörenden susahen, während diese im tiefsten Frieden waren?
-Wunderbar zu sagen aber ist es, daß, als ihre Tempel vernichtet
+<milestone unit="altnumbering" n="77"/>Wunderbar zu sagen aber ist es, daß, als ihre Tempel vernichtet
 ein das Schöne und *Gute fördernder Friede
 beherrschte, daß das gerade Gegenteil aber eintrat, als die Götter im <lb n="15"/>
 Frieden waren. Kriege also und Kämpfe und Aufruhre
@@ -3226,8 +3819,10 @@ gute Dämonen waren, sondern im Gegenteil böse
 deren Macht Ursache war für das Böse
 aber das Kommen des Guten für jedermann *förderte.
 das Volk der Griechen in Verwirrung war und wie die Völker
-ganzen Erde verwirrt waren, haben wir (nunmehr) wie in Kürze erkannt.</p> <lb n="25"/>
-<p>LXXXI. Wie aber die Sitten, deren Arten wechseln, das ganze
+ganzen Erde verwirrt waren, haben wir (nunmehr) wie in Kürze erkannt.</p>
+</div> <lb n="25"/>
+<div type="textpart" subtype="chapter" n="81">
+<p>Wie aber die Sitten, deren Arten wechseln, das ganze
 Leben verkehrten, kann man daraus erkennen: Denn die Ägypter haben
 ein Gesetz, ihre Schwestern zu heiraten, die Perser, mit ihren Müttern
 verbrecherischen und frevelhaften Umgang zu halten, andere aber, ihre
@@ -3253,10 +3848,14 @@ andern aber verzehrten sogar Menschenfleisch. Ferner aßen
 Geliebten, die alt geworden waren, bevor sie der Tod erreichte, vorher,
 nachdem sie sie zuvor geopfert hatten. *Die einen stürzten diejenigen,
 <lb n="10"/> die sich dem Greisenalter näherten, vom Felsen, die
-sie der Schlinge. Die einen warfen sie den Hunden vor, während sie <note type="marginal">Σ 78</note>
+sie der Schlinge. Die einen warfen sie den Hunden vor, während sie <milestone unit="altnumbering" n="78"/>
 (noch) lebendig waren, die andern aber als Tote. Die einen begruben,
 die anderen töteten (zu gleicher Zeit) mit ihnen auf
-die Lebenden, die von den Toten geliebt wurden. LXXXII. So also war
+die Lebenden, die von den Toten geliebt wurden.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="82">
+<p>So also war
 <lb n="15"/> fortan das ganze Menschengeschlecht zum äußersten (Grad) der
 geführt, und er, der vernünftig ist,
 Kein anderes (Wesen) von denen, die auf Erden sind, war
@@ -3289,12 +3888,14 @@ wurden"] „mit ihnen kämpften“ Σ (=σχμ-πλἑχομαι?)</note>
 ergriffen hatte. Deswegen besonders war Gott der Erlöser
 (uns) als solchen, die in den äußersten (Grad) des Bösen
 und keine andere bessere Heilung und Hilfe als die durch die Theophanie
-unserem Leben erforderlich.</p> <lb n="5"/>
-<p>LXXXIII. Was also war nach diesen (Dingen) dem Logos, dem
+unserem Leben erforderlich.</p>
+</div> <lb n="5"/>
+<div type="textpart" subtype="chapter" n="83">
+<p>Was also war nach diesen (Dingen) dem Logos, dem
 Vater der Vernünftigen, recht zu tun, dem Erlöser
 der Vorsehung, dem Hirten der vernünftigen
 Erden, damit er zu großer Ehre das geistige und vernünftige
-<note type="marginal">Σ 79</note> den Menschen hinaufführe, das in große Tiefe gefallen war, und damit <lb n="10"/>
+<milestone unit="altnumbering" n="79"/> den Menschen hinaufführe, das in große Tiefe gefallen war, und damit <lb n="10"/>
 er den als seinen vertrauten (Freund) sehe, der durch sich selbst die
 Ursache des Untergangs sich zugezogen hatte? Ist es recht, daß jemand
 über die Erlösung seiner Geliebten hinweggeht und
@@ -3331,7 +3932,11 @@ Fische) in der verborgenen Tiefe und die Vögel in
 machte, der Mensch, dem er die Kraft des Wissens zur Aufnahme
 <lb n="5"/> mannigfacher Lehre gewährte, dem er auch die Schauspiele am Himmel
 enthüllte und die Läufe der Sonne, die
-die Gleise der Planeten und Fixsterne offenbarte. LXXXIV. Wie sollte
+die Gleise der Planeten und Fixsterne offenbarte.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="84">
+<p>Wie sollte
 also nach diesen (Dingen) die Fúrsorge des Vaters gelähmt
 alles (waltende) Vorsehung (zu) schwach sein zur Heilung der vernünftigen
 <lb n="10"/> οὐσία in den Menschen? (Er), der sich richtig kümmerte um
@@ -3340,14 +3945,18 @@ alle Arten der Nahrung und alle Arten der Heilung und Gesundheit
 des Leibes, und der Größe,
 und Überfluß an Besitz zum Gebrauch gab, *sollte
 <lb n="15"/> für das, was besser ist im Menschen, für die Seele
-verständige οὐσία, die *töricht geworden sind? Aber so würde jemand <note type="marginal">Σ 80</note>
+verständige οὐσία, die *töricht geworden sind? Aber so würde jemand <milestone unit="altnumbering" n="80"/>
 mit Recht die Schwäche tadeln, nicht das von der Herde
 sondern besonders die Nachlässigkeit des Hirten, ferner
 deren Seele krank ist und denen es übel ergeht, sondern besonders die
 <lb n="20"/> Nichtbeachtung und Schwäche des Arztes, wenn er
 Arten der heilenden und helfenden Arzneien denen nicht giebt, die (ihrer)
 bedürfen. Daber rief jeder Zwang den Fürsorger
-zur Heilung seiner Schafe. LXXXV. Mit Recht also hielt es der barmherzige
+zur Heilung seiner Schafe.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="85">
+<p>Mit Recht also hielt es der barmherzige
 Logos Gottes als ein guter Hirte, Erlöser
 <lb n="25"/> seine Theophanie zu veranstalten, als es offenbar seiner vernünftigen
 Herde auf Erden am schlimmsten erging, da er keine Zeit jemals verstreichen
@@ -3371,15 +3980,18 @@ den Menschen, durch Prophetie und (unterredenden) Verkehr die Gottheit
 seines Vaters und das Leben in der Tugend denen verkündete,
 die im Geheimnis der Gottesverehrung wandeln konnten, *in jener Zeit,
 wo er unseren Vätern als solchen, die noch kindlich und im Bösen <lb n="5"/>
-nicht erfahren waren, das Wissen von seiner (eigenen Person) gab.
-LXXXVI. Weil sie aber in unschöner Verkehrtheit von der Freiheit und
+nicht erfahren waren, das Wissen von seiner (eigenen Person) gab.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="86">
+<p>Weil sie aber in unschöner Verkehrtheit von der Freiheit und
 dem Denken ihres Willens Abstand nahmen und aus dem Leben der
 Tugend ins Böse gerieten, bemühte sich wiederum mit Recht der Logos
 Gottes als Arzt der Seelen um diejenigen, die an dieser Krankheit litten <lb n="10"/>
 mit passenden Hilfsmitteln (und) brachte durch bittere Arzneien diejenigen
 zur Umkehr, die bei seiner (freundlichen) Gabe nicht besser geworden
 waren. Sie also strafte er durch die schweren Schmerzen des Unheils bei
-<note type="marginal">Σ 81</note> Seuchen, Hungersnöten, Kriegen, Bränden und Überschwemmungen und
+<milestone unit="altnumbering" n="81"/> Seuchen, Hungersnöten, Kriegen, Bränden und Überschwemmungen und
 wendete zu sich zurück diejenigen, die dessen bedürftig waren. Bald reinigte <lb n="15"/>
 er das ganze Leben (besserte er die Welt) durch Verlust des Wassers,
 bald aber strafte er die Gottlosen strichweise durch (zu) reichliche Regenfälle,
@@ -3403,7 +4015,7 @@ Ferne und verkündete hierdurch völlig eben durch Taten in die Ohren
 jedermanns, indem er rief: Schweigt (still) von dem Irrtum der Dämonen <lb n="35"/>
 und des Polytheismus und bekennt (vielmehr) den Herrn Himmels
 und der Erden, der der Gott der ganzen Welt ist, (und) den Erlöser,
-<note type="footnote">1 „übt“ („belehrt“) Σ = μελετάω c. Acc. Eusebius schrieb vermutlich den Gen.
+<note type="footnote">1 „übt“ ( „belehrt“) Σ = μελετάω c. Acc. Eusebius schrieb vermutlich den Gen.
 4 „und in jener Zeit“ Σ, streiche ABBREV 9 „bestrafte“ Σ (sachlich richtig) = μετέρχομαι
 13 man eiwartet <foreign xml:lang="abbr">ABBREV</foreign></note> 20 „und“ Σ l ABBREV 27 beachte ABBREV vor ABBREV
 
@@ -3418,11 +4030,14 @@ auf das von ihm besorgte Gute nicht achteten; und nicht nur dies, sondern
 (wie) er auch durch häufige Blitze und Brände,
 (verhängt wurden), welche sie für Götter ihren Irrtum heilte,
 <lb n="10"/> sodaß auch durch die Hinterlist der Menschen die Tempel
-brannten mitsamt denen, welche sie zu Göttern machten, und (so) offenkunding <note type="marginal">Σ 82</note>
+brannten mitsamt denen, welche sie zu Göttern machten, und (so) offenkunding <milestone unit="altnumbering" n="82"/>
 eine Widerlegung dieses Irrtums den Zuschauern zeigten. Aber
 obwohl eben jene Götterverehrer die früheren
-für sie nichts anderes als die Aufrechterhaltung ihres
-<lb n="15"/> Da sie aber auch ferner an die Götter glaubten, die
+für sie nichts anderes als die Aufrechterhaltung ihres Frevels.</p>
+</div>
+  
+<div type="textpart" subtype="chapter" n="87">
+<p><lb n="15"/> Da sie aber auch ferner an die Götter glaubten, die
 bekannten, nichts tun zu können außer dem, was
 das Schicksal ist (nach ihrer Meinung) die Ursache des Alls — verstanden
 und erwogen sie nicht, daß, weil das Schicksal sie
@@ -3448,23 +4063,45 @@ Tempels zu Delphi (Rhein. Mus. Bd. 51 329 ff.)</note>
 ihres Frevels" 27 man erwartet <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.123"/>
-früher die Griechen verführte. LXXXYIII. Der Tempel der Artemis
+früher die Griechen verführte.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="88">
+<p>Der Tempel der Artemis
 in Ephesos ging dreimal zu Grunde, einmal als ihn die Amazonen in
 Brand steckten, das andere Mal durch *Herostratos, einen Einwohner
 zu Ephesos, zuletzt durch den allmächtigen Gott, sodaß
 nach der Erscheinung unseres Erlösers auch dort nichts weiter existiert <lb n="5"/>
-noch gesehen wird als das große Siegeszeichen der Zersörung. LXXXIX.
-<note type="marginal">Σ 83</note> Es wird aber auch berichtet, daß der Tempel der Hera in
+noch gesehen wird als das große Siegeszeichen der Zersörung.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="89">
+<p><milestone unit="altnumbering" n="83"/>Es wird aber auch berichtet, daß der Tempel der Hera in
 durch Feuer vernichtet wurde, ebenso auch der in A.bai, als die Thebaner
 kamen und ihn in Brand steckten. Sie verbrannten mit ihm fünfhundert
-Mann. XC. Man sagt aber auch, daß das Zeusbild in Olympia <lb n="10"/>
-einmal der Blitz getroffen habe. XCI. Die Geschichte der Römer
-lehrt, daß auch der Tempel der Hestia in Rom &lt;und&gt;
+Mann.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="90">
+<p>Man sagt aber auch, daß das Zeusbild in Olympia <lb n="10"/>
+einmal der Blitz getroffen habe.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="91">
+<p>Die Geschichte der Römer
+lehrt, daß auch der Tempel der Hestia in Rom <add>und</add>
 Pantheon, wo natürlich die Götter
-waren, wiederum durch den Blitz vernichtet wurde. XCII. Ferner
+waren, wiederum durch den Blitz vernichtet wurde.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="92">
+<p>Ferner
 aber fiel einmal in das bei ihnen (so)genannte Kapitol ein Donner von <lb n="15"/>
-oben vom Himmel und zerstörte das Allerheiligste. XCIII.
-diese Züchtigungen also machte die allmächtige
+oben vom Himmel und zerstörte das Allerheiligste.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="93">
+<p>diese Züchtigungen also machte die allmächtige
 Gottes, die dämonenverehrenden Menschen von aller Ewigkeit
 Und nicht nur dies, sondern er unterwies sie auch früher durch
 gottgeziemende Lehren, seinen Vater zu loben, und warf lebenspendende <lb n="20"/>
@@ -3472,7 +4109,7 @@ Belehrung, göttliche Gesetze Gesetze und gerechte Worte nach Art guter Kräuter
 und Heilmittel zur Erlösung der vernünftigen
 Geschlecht. So also rief er früher durch *(gewisse) Propheten
 Hebräern, die am göttlichen Geiste teil hatten,
-früher durch andere gottliebende &lt;Männer&gt; und ferner nach diesen durch <lb n="25"/>
+früher durch andere gottliebende <add>Männer</add> und ferner nach diesen durch <lb n="25"/>
 die späteren Gottbekleideten Gottbekleideten die dem Tode Preisgegebenen zu ihrer
 eigenen Heilung auf und säte durch göttliche
 <note type="footnote">11 ᾖ. vgl. Jordan, Topographie Roms 12 S. 421 Anm. 136; S. 29 Anm. 29
@@ -3497,7 +4134,7 @@ fortan wie aus einer Quelle auch durch alle Teile der Welt die vernünftigen
 <lb n="5"/> Samen und Sitten. Fortan sah man bei allen Völkern
 kannte man bei allen Menschen den Namen und die Vorzüglichkeit
 der Philosophie, und die Liebe zum Guten und die Bemühung um
-das Finden der Wahrheit war bei vielen erregt, sodab auch die Verirrung <note type="marginal">Σ 84</note>
+das Finden der Wahrheit war bei vielen erregt, sodab auch die Verirrung <milestone unit="altnumbering" n="84"/>
 irrung der Väter in geringster Nichtachtung war, vielmehr die Verehrung
 <lb n="10"/> der Gottesliebe von den Jüngern verkündet und die Wahrheit
 gesucht wurde. Groß aber war die Spaltung hierüber
@@ -3505,7 +4142,9 @@ die Kämpfe und die Differenzen derer, die über Lehren
 zeigten die (Dinge) der Vorsehung, die über die Menschen in Menge
 von aller Ewigkeit her (ergingen), einen jedermann geziemenden und
 <lb n="15"/> entsprechenden Fürsorger.</p>
-<p>XCIV. Weil also fortan der Wechsel zur Tugend in jedermann
+</div>
+<div type="textpart" subtype="chapter" n="94">
+<p>Weil also fortan der Wechsel zur Tugend in jedermann
 groß war, sodaß das Leben der Menschen zur Ruhe
 Lebensart beinahe in Annehmlichkeit von der früheren Wildheit
 her umgewandelt war, so veranstaltete der gemeinsame Erlöser aller,
@@ -3534,8 +4173,12 @@ anzuwenden, aber keineswegs die Speisen, die für die
 <pb n="v.3.pt.2.p.125"/>
 sondern solche, die den Kranken zuträglich sind, und erst
 gesund geworden sind, ihnen gesundende und kräftigende Speisen
-zuführen, XCV. so also auch unterwies der
-<note type="marginal">Σ 85</note> aller wie ein guter Hirt und Arzt seine vernünftigen
+zuführen,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="95">
+<p>so also auch unterwies der
+<milestone unit="altnumbering" n="85"/> aller wie ein guter Hirt und Arzt seine vernünftigen
 Erden, die *durch Wahnsinn Wahnsinn zu Myriaden vieler Götter gekommen <lb n="5"/>
 waren und in unseliger Geistesverblendung und Wildheit rasten,
 vor seiner letzten Theophanie durch bittere Strafen, durch Seuchen,
@@ -3545,7 +4188,11 @@ Blitzschläge jene schweren (Anstöße d. h. die Tempel) und <lb n="10"/>
 gab auch den Dämonenverehrern (Gelegenheit),
 der polytheistischen Verirrung (und) durch die Strafe der Blitzschläge
 ihre eigenen Götzenbilder zu sehen (und in ihrem wahren
-zu lernen). XCVI. Er aber unterwies ferner so wie ein guter Vater
+zu lernen).</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="96">
+<p>Er aber unterwies ferner so wie ein guter Vater
 die Toren und gab ihnen eben durch reiche Versorgung mit reichlichen <lb n="15"/>
 Gütern Geschenke von sich aus: Regen zu rechter Zeit,
 Früchte, Wechsel der (Jahres)zeiten, Fortpflanzung der Tiere
@@ -3555,13 +4202,17 @@ göttlichen Worte und der gottesfürchtigen Lehre, die Einführung. die <lb n="2
 (Grund) linien und Anfänge der göttlichen Gesetze,
 Menschen frommte, durch Propheten, die bei den Hebräern berühmt
 waren. Er gab ferner auch durch viele andere eine für
-Menschen passende Hilfe infolge seiner eigenen Vorsehung. XCVII.
-Weil also infolge dieser (Dinge) fortan das Leben der Menschen zur <lb n="25"/>
+Menschen passende Hilfe infolge seiner eigenen Vorsehung.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="97">
+<p>Weil also infolge dieser (Dinge) fortan das Leben der Menschen zur <lb n="25"/>
 Friedlichkeit und Ruhe sich änderte und bereit war, die vollkommene
 Lehre über Gott aufzunehmen, zeigte wiederum der gemeinsame Erlöser
 aller, das eingeborene Wort Gottes, der König des Alls,
 Zeit seine göttliche Offenbarung durch Taten. Aber nachdem
-vorgelegt ist, ist es Zeit, daß wir zum Folgenden weitergehen.</p> <lb n="30"/>
+vorgelegt ist, ist es Zeit, daß wir zum Folgenden weitergehen.</p>
+</div> <lb n="30"/>
 <note type="footnote">5 „die zu wahnsinnigen Myriaden vieler Götter gekommen waren“]. “ 1.
 11 Euseb. schrieb vielleicht: „die Widerlegung der polytheistischen Verirrung
 durch die Strafe der Blitzschläge in ihre eigenen Götzenbilder zu sehen“
@@ -3570,7 +4221,8 @@ von Eusebius</note></div>
 <div type="textpart" subtype="book" n="3">
 <pb n="v.3.pt.2.p.126"/>
 <head>Das dritte Buch des ’sareensers.</head>
-<p>Ι. Weil also infolge des Gesagten das Leben der Menschen sich <note type="marginal">Σ 86</note>
+<div type="textpart" subtype="chapter" n="1">
+<p>Weil also infolge des Gesagten das Leben der Menschen sich <milestone unit="altnumbering" n="86"/>
 fortan in Friedlichkeit und Ruhe änderte und bereit war, die vollkommene
 Lehre über Gott zu empfangen, so tat mit Recht wiederum
 <lb n="5"/> der gemeinsame Erlöser aller, der eingeborne Logos Gottes,
@@ -3590,7 +4242,7 @@ ward allen gepredigt und Ein Königreich
 und zerstört wurde völlig die von Ewigkeit her friedlose und unversöhnliche
 <lb n="20"/> Feindschaft der Völker. Als aber die Kenntnis Eines
 allen Menschen überliefert war und Eine Sitte der Gerechtigkeit und
-Frömmigkeit [der Gotteskenntnis] durch die Belehrung
+Frömmigkeit <del>der Gotteskenntnis</del> durch die Belehrung
 existierte demgemäß auch Ein König zu Einer und
 das ganze Königreich der Römer und tiefer
 <lb n="25"/> und zu Einer Zeit sproßten wie auf den Wink Eines
@@ -3605,7 +4257,7 @@ das ganze Königreich der Römer und tiefer
 Blüten des Guten unter den Menschen auf: die fromme Lehre und
 Reich der Römer. Denn *vor diesem knechtete
 die Völker schwer, und da alles in Myriaden
-<note type="marginal">Σ 87</note> war, *so herrschten die einen gesondert über Syrien, während andere
+<milestone unit="altnumbering" n="87"/> war, *so herrschten die einen gesondert über Syrien, während andere
 üher Asien regierten, andere aber über Makedonien. Ägypten teilten <lb n="5"/>
 andere und hatten (es) inne, andere wiederum ebenso das Land Arabien.
 Ferner beherrschte das Geschlecht der Juden Palästina und
@@ -3613,7 +4265,10 @@ Dörfern, allen Städten und an jedem Ort kümmerten sie sich um Kriege
 und Kämpfe, als ob sie infolge eines Wahnsinns gegen
 (Mord)gierige und in Wahrheit Dámonische (wären). Über das Frühere <lb n="10"/>
 ist genügend geredet.</p>
-<p>II. Aber freilich völlig wie aus Einer Schranke brachen
+</div>
+
+<div type="textpart" subtype="chapter" n="2">
+<p>Aber freilich völlig wie aus Einer Schranke brachen
 Mächte hervor, machten alles friedlich und führten
 indem das monarchische Reich der Römer seitdem
 die ihm helfende Kraft des Erlösers aller, indem sie zumal und auf eins <lb n="15"/>
@@ -3635,7 +4290,7 @@ der Völker aufgehoben. Ferner wurde zugleich Ein Gott und Ein <lb n="30"/>
 Wissen desselben durch die Belehrung unsers Erlösers allen
 zugleich auch Ein Königreich der Römer
 <note type="footnote">2 πρό γε μὴν ταύτης L] 1. <foreign xml:lang="abbr">ABBREV</foreign> mit HS 4 „und" vor <foreign xml:lang="abbr">ABBREV</foreign> ist zu
-streichen 10 ,,(Mord)gierige" Σ φονῶντες L 12 ὡσπερ ἀπὸ νύσσης μιᾶς L
+streichen 10 „(Mord)gierige" Σ φονῶντες L 12 ὡσπερ ἀπὸ νύσσης μιᾶς L
 14 ἧ τε Ῥωμαίων ἀρχὴ μόναρχος ἐξ ἐκείνου φανθεῖσα L 10 συνακμάσασαι L]
 1. <foreign xml:lang="abbr">ABBREV</foreign> Bernstein 17 τἀς τῶν δαιμόνων πολυαρχίας τε καὶ πολυθείας L
 19 ἧ δὲ Ῥωμαίων ἀρχή, ὡς ἂν προκαθῃρημένων τῶν τῆς πολυαρχίας αἰτιῶν, τὰς
@@ -3649,11 +4304,11 @@ und alle bekannten einander als Brüder und lernten die
 (keimen). Auf der Stelle aber, als ob sie von Einem Vater abstammten
 und Söhne Eines Gottes und Einer Mutter,
 <lb n="5"/> (seien), empfingen sie einander friedlich mit dem Gruße, sodaß die ganze
-Schöpfung seitdem nichts Geringeres war als Ein Haus(gesinde) und ein <note type="marginal">Σ 88</note>
+Schöpfung seitdem nichts Geringeres war als Ein Haus(gesinde) und ein <milestone unit="altnumbering" n="88"/>
 wohlgeordnetes Geschlecht und dem, der Lust hatte, μὁγλιψη
 reisen und zu gehen, wohin nur immer jemand wollte, mit vieler Leichtigkeit,
 sodaß jene ohne Unfall aus dem Westen nach dem Osten
-<lb n="10"/> und wiederum diese &lt;von&gt; hier nach dort wie in ihr
+<lb n="10"/> und wiederum diese <add>von</add> hier nach dort wie in ihr
 entsprechend den alten Weissagungsworten und den prophetischen
 *Verkündigungen, — (sowohl) Myriaden andere, die wir
 Muße haben aufzuzählen, indessen aber (auch)
@@ -3664,7 +4319,9 @@ und die *Fülle des Friedens“,
 Schwerter zerschmettern zu Pflugscharen und ihre Lanzen zu Sicheln,
 und nicht wird ein Volk wider das andere (mehr) das Schwert ergreifen
 <lb n="20"/> noch werden sie (fernerhin) den Krieg lernen“.</p>
-<p>III. Dies wurde vorausgesagt und durch die Worte der Hebräer
+</div>
+<div type="textpart" subtype="chapter" n="3">
+<p>Dies wurde vorausgesagt und durch die Worte der Hebräer
 seit langer Zeit (voraus) verkündigt. Indem dies jetzt zu
 in Taten gesehen wird, bestätigt es die Zeugnisse der
 Du aber, wenn du zum Überfluß andere Beweise der Wahrheit willst,
@@ -3685,8 +4342,12 @@ vor <foreign xml:lang="abbr">ABBREV</foreign> 6 μιᾶς εὐνομουμέν
 
 <pb n="v.3.pt.2.p.129"/>
 und als ob du einen andern (fragtest,) frage (und) so erforsche die Natur
-der Dinge. IV. Welcher sterbliche Mensch jemals von denen, die von Ewigkeit
-her (gelebt haben): König &lt;oder Fürst&gt; oder Philosoph
+der Dinge.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="4">
+<p>Welcher sterbliche Mensch jemals von denen, die von Ewigkeit
+her (gelebt haben): König <add>oder Fürst</add> oder Philosoph
 oder Prophet, Grieche oder Barbare, hat soviel Tugend (davon)getragen,
 nicht nach dem Tode, sondern noch lebend und atmend und <lb n="5"/>
 vieles vermögend, sodaß er auf der ganzen Erde verkündet wurde und
@@ -3697,12 +4358,20 @@ der seinen Jüngern ein Wort sagte und es durch die Tat
 er vorher sagte und vorher offenbarte, seine Botschaft Botschaft müsse in der
 ganzen Schöpfung verkündet werden zum Zeugnis für alle Völker,
 brachte er mit dem Worte (zugleich) auch die Tat. Denn auf der Stelle
-Σ 89 und nicht in (weiter Zeit)ferne wurde die ganze Schöpfung mit seinen
-Worten erfüllt. V. Was also giebt es dagegen zu sagen für den, der <lb n="15"/>
+<milestone unit="altnumbering" n="89"/>und nicht in (weiter Zeit)ferne wurde die ganze Schöpfung mit seinen
+Worten erfüllt.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="5">
+<p>Was also giebt es dagegen zu sagen für den, der <lb n="15"/>
 wider die Wahrheit (den Sinn) zu richten sich erdreistet, da ja besser
 als alle Worte das mit den Augen (sichtbare) Zeugnis ist? Aber, indem
 du vom ersten (Beweis) weitergehst, komme (auch) zum andern und
-überlege bei dir selbst: VI. Welche sterbliche Natur ist von aller Ewigkeit
+überlege bei dir selbst:</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="6">
+<p>Welche sterbliche Natur ist von aller Ewigkeit
 an erschienen wie diese, die fromme und keusche Gebote nur mit <lb n="20"/>
 dem Worte ohne (jede) Schrift auferlegte und diese durch seine Jünger
 von den Enden der Erde bis zum Anfang der Welt Gefestigte und
@@ -3712,7 +4381,11 @@ Tag die von ihm überlieferten frommen Lehren verkündet wurden? <lb n="25"/>
 Aber du würdest keinen anderen finden, wenn du suchtest.
 allein das Werk der Kraft des Erlösers unser aller. Aber
 dies überzeugt den, der nicht überzeugt werden will. Also möge
-uns sagen, die wir lernen wollen: VII. Wer jemals von denen, die bei
+uns sagen, die wir lernen wollen:</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="7">
+<p>Wer jemals von denen, die bei
 den Menschen wegen (ihrer) Weisheit gepriesen wurden, hat barbarische <lb n="30"/>
 <note type="footnote">2 ff. vgl. Euseb. Hist. eccles. X 4 17 10 = Matth 28 19 11 vgl. Matth
 24 14 19 ff. vgl. Euseb. Hist. eccles. X 417 29 ff. vgl. Euseb. Hist. eccles. X 418</note>
@@ -3732,21 +4405,32 @@ Jüngern gemacht waren, keine Menschenfresser mehr
 übergaben, noch andere diesen verwandte wilde und tierische (Dinge)
 bei anderen geschahen. Aber dies sind (nur) geringe Beweise der
 göttlichen Offenbarung des Erlösers unser aller. Sieh
-indem du bei dir überlegst: VIII. Welcher sterbliche Mensch jemals,
+indem du bei dir überlegst:</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="8">
+<p>Welcher sterbliche Mensch jemals,
 <lb n="10"/> mit dem in so viel Zeiten *alle Herrscher zumal und Könige, Heere
 und Bürger Mengen und Völker, füge aber hinzu: die bei
 vielen als Götter Geltenden, gekämpft haben und zu jeder Zeit
 kämpfen, *hat eine übermenschliche Tüchtigkeit
-Lehre von Tag zu Tag blühte und neu wurde in der
-<lb n="15"/> IX. Wer anders von Ewigkeit her, seit das Leben der Menschen <note type="marginal">Σ90</note>
+Lehre von Tag zu Tag blühte und neu wurde in der ganzen Welt?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="9">
+<p><lb n="15"/> Wer anders von Ewigkeit her, seit das Leben der Menschen <milestone unit="altnumbering" n="90"/>
 existiert, der ein Volk auf seinen Namen aufrichten wollte, was völlig
 unerhört ist, *hat dies nicht in einem Winkel irgendwo auf
-verborgen, sondern überall unter der Sonne wohnen lassen &lt;und&gt; kraft
+verborgen, sondern überall unter der Sonne wohnen lassen <add>und</add> kraft
 göttlicher Vollmacht seinem Willen *die Erfüllung
 <lb n="20"/> die Kenntnis des Einen Gottes, der jenseits des Himmels (ist), des
 Königs der ganzen Welt, und die Furcht vor ihm allen
 der Oberfläche der ganzen Erde, barbarischen und
-überliefert? X. Wer jemals, der sich vornahm zu lehren. *hat
+überliefert?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="10">
+<p>Wer jemals, der sich vornahm zu lehren. *hat
 (dann), nachdem er sich ein derartiges Ziel vorgenommen hatte, das
 <lb n="25"/> Werk in die Tat umgesetzt und fast durch seine Wirksamkeit sein
 Werk als gottgeliebt geoffenbart, was besonders jedes unverschämte
@@ -3755,7 +4439,7 @@ Euseb. Hist. eccles. X 4 19 26 vgl. Röm 319</note>
 <note type="footnote">2 τοὺς αὐτῷ μαθητευομένους L „von ihnen" Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 9 τίς πώποτε
 . . . . τοσούτοις δὴ χρόνοις ὑπὸ πάντων ἀνθρώπων, ἀρχόντων τε καὶ βασιλέων,
 πολιτῶν τε καὶ στρατοπέδων, δήμων τε καὶ ἐθνῶν, πολεμηθεὶς καὶ εἰς ἀεὶ πολεμούμενος
-L „von allen Herrschern" Σ streiche <foreign xml:lang="abbr">ABBREV</foreign> 13 ,,und hat" Σ streiche <foreign xml:lang="abbr">ABBREV</foreign>
+L „von allen Herrschern" Σ streiche <foreign xml:lang="abbr">ABBREV</foreign> 13 „und hat" Σ streiche <foreign xml:lang="abbr">ABBREV</foreign>
 vor <foreign xml:lang="abbr">ABBREV</foreign> 17 „und hat" Σ streiche <foreign xml:lang="abbr">ABBREV</foreign>, vor <foreign xml:lang="abbr">ABBREV</foreign> 18 Das <foreign xml:lang="abbr">ABBREV</foreign> steht
 besser vor <foreign xml:lang="abbr">ABBREV</foreign> als vor <foreign xml:lang="abbr">ABBREV</foreign> ] ἱδρύσατο, δυνάμει θεικῆς ἐξουσίας πέρας
 ἐπιθεὶς τῷ αὐτοῦ βουλήματι L 23 „und hat" Σ streiche <foreign xml:lang="abbr">ABBREV</foreign> vor <foreign xml:lang="abbr">ABBREV</foreign> 26 πᾶν
@@ -3768,22 +4452,33 @@ er das bei Gott Geliebte wollte, der Unterstützung des von
 und seiner Hilfe gewürdigt wurde.</p>
 <p>Sieh und überlege aber, welcher Art die Lehren sind, die mit dieser <lb n="5"/>
 Verkündigung überliefert und in die Ohren aller <lb n="10"/>
-und durch Taten bestätigt wurden. XI. Wer anders
-her, der die Seelen der Menschen mit seinem vernünftigen
-hat, *hat sie ausgerüstet, den dämonischen
-zu verlachen und fernerhin den Hölzern, den Steinen und
-Hyle den göttlichen Namen nicht (mehr) beizulegen?
-Ägypter aber, die mehr als alle Menschen in Dämonenfurcht (befangen)
+und durch Taten bestätigt wurden.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="11">
+<p>Wer anders von jemals
+her, der die Seelen der Menschen mit seinem vernünftigen Lichte erleuchtet
+hat, *hat sie ausgerüstet, den dämonischen Irrtum ihrer Väter
+zu verlachen und fernerhin den Hölzern, den Steinen und der seelenlosen
+Hyle den göttlichen Namen nicht (mehr) beizulegen?</p>
+</div>
+  
+<div type="textpart" subtype="chapter" n="12">
+<p>Ägypter aber, die mehr als alle Menschen in Dämonenfurcht (befangen)
 waren (und) von denen der Irrtum des Polytheismus auch zu den
-Griechen kam, — wer anders außer unser Erlöser hat
+Griechen kam, — wer anders außer unser Erlöser hat (sie) überredet
 nicht mehr verächtlich zu handeln und nicht mehr den Tieren, dem <lb n="15"/>
-Gewürm und den
-Namen zu geben, sondern nur den Einen höher
-(stehenden) Gott anzuerkennen und trotz aller Todesarten für
-zu kämpfen? XIII. Wer aber von Ewigkeit her hat
+Gewürm und den unansehnlichten unvernünftigen Tieren den verehrungswürdigen
+Namen zu geben, sondern nur den Einen höher als alle
+(stehenden) Gott anzuerkennen und trotz aller Todesarten für die Frömmigkeit
+zu kämpfen?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="13">
+<p>Wer aber von Ewigkeit her hat
 und verderblichen Stamm der Dämonen, der einst das ganze <lb n="20"/>
 Geschlecht der Menschen weidete (beherrschte) und durch die Bewegung
-<note type="marginal">Σ 91</note> (d. h. den Antrieb) der Götzenbilder viele Verirrungen unter
+<milestone unit="altnumbering" n="91"/> (d. h. den Antrieb) der Götzenbilder viele Verirrungen unter
 zeigte, unsichtbar und mit mächtiger Hand und durch
 der überral verkündigten wie böse Tiere
 Menschen fortgetrieben, sodaß fernerhin die Dämonen an deu Sprudeln <lb n="25"/>
@@ -3817,20 +4512,32 @@ sein, verließen ihre gewohnten Plätze,
 Fortwanderung auf sich, durch göttliche Kraft in die
 Alle Weissagungen wurden überall aufgehoben und nur der
 Christus Gottes und nur der Eine Gott, der durch ihn verkündigt
-ward, wurde bei jedermann gepriesen. XIV. Wer aber anders als
+ward, wurde bei jedermann gepriesen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="14">
+<p>Wer aber anders als
 <lb n="15"/> unser Erlöser hat, durch seine Anrufung und durch
 Gebete, die durch ihn zu dem über allem (stehenden) Gott geschickt
 werden, die Überbleibsel der bösen Dämonen
 Leibe zu vertreiben Vollmacht gegeben denen, die rein und ungeschminkt
 dem besseren Leben der von ihm überlieferten Weisheit
-<lb n="20"/> nachgehen? XV. Vernünftige (und)
+<lb n="20"/> nachgehen?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="15">
+<p>Vernünftige (und)
 die in Gebeten und geheimen göttlichen Worten
 anders überlieferte den ihm Nahestehenden, (sie) auszuüben,
 allein? Deswegen bestanden in der ganzen Menschen weit feuerlose
-äre *gottgeziemender (Gottes)dienste und Weihgeschenke der Kirchen <note type="marginal">Σ92</note>
+äre *gottgeziemender (Gottes)dienste und Weihgeschenke der Kirchen <milestone unit="altnumbering" n="92"/>
 <lb n="25"/> und geistige und vernünftige Opfer, die
 dem Einen Gotte allein, dem Allkönig, von
-gebracht werden. XVI. Die Opfer aber, die durch Blut, Unreinheit,
+gebracht werden.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="16">
+<p>Die Opfer aber, die durch Blut, Unreinheit,
 Rauch und Feuer vollendet werden, die grausamen und wahnsinnigen
 Menschenmorde und Menschenopfer — wer hat (sie) heimlich und mit
 <lb n="30"/> unsichtbarer Kraft öscht und bewirkt, daß sie fernerhin
@@ -3847,18 +4554,29 @@ Menschen nicht geopfert werden" Σ ἀνδροκτασίας τε καὶ ἀν
 da nicht vor. sondern nach der göttlichen Lehre
 der Zeit Hadrians alle Menschenopfer auf der ganzen Erde aufgehoben
 wurden?</p>
-<p>XVII. Da alle diese offenkundigen Beweise die göttliche
+</div>
+
+<div type="textpart" subtype="chapter" n="17">
+<p>Da alle diese offenkundigen Beweise die göttliche
 Erlösers unser aller bestätigen, wessen Seele wäre so eisern, nieht die <lb n="5"/>
 Wahrheit zu bezeugen und seine göttliche Kraft und
 Leben zu bekennen? Denn es sind die Werke Lebendiger und keineswegs
 Toter, und man sagt, daß das, was sichtbar ist, die
-sei, was fern (von jeder Gestalt und unsichtbar) ist. XV III. Auf der
+sei, was fern (von jeder Gestalt und unsichtbar) ist.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="18">
+<p>Auf der
 Stelle aber gestern und vorgestern (noch) verwirrte das mit Gott kämpfende <lb n="10"/>
 Geschlecht (der Dämmonen) das Leben der
 verführte es und vermochte viel. Als es aber aus den
 wurde, wurde es aufs Land geworfen, verächtlicher
 ohne Atem, ohne Bewegung, ohne Stimme, und nicht mehr gab es ihr
-Wort noch ihr Gedächtnis. XIX. Denn dies ist die Natur Toter,
+Wort noch ihr Gedächtnis.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="19">
+<p>Denn dies ist die Natur Toter,
 derjenige, der nicht mehr ist, ist nichts. Und wer nichts ist, tut auch
 nichts. Wer aber zu jeder Zeit handelt und in jeder Stunde wirkt und
 mehr als die Lebendigen vermag, wie sollte man den für nichtseiend
@@ -3869,7 +4587,7 @@ wir mit den Sinnen des Leibes, noch hat jemals jemand den Verstand
 des Menschen, geschweige denn Gott und die Kraft Gottes mit Augen
 gesehen, sondern (nur) aus den Werken können wir
 Deswegen ziemt es sich, auch bei dem Erlöser unser aller die verborgene <lb n="25"/>
-<note type="marginal">Σ 93</note> Kraft aus seinen Werken zu erkennen und zu beurteilen, mag
+<milestone unit="altnumbering" n="93"/> Kraft aus seinen Werken zu erkennen und zu beurteilen, mag
 es nun nötig sein zu gestehen, das. was bis jetzt von ihm
 sei (Sache) eines Lebendigen, oder mag man sagen, es sei (Sache) eines
 Nichtseienden. Oder ist die Frage töricht und ungereimt?
@@ -3889,7 +4607,11 @@ Diels 15 vgl. die Lehre des Xenophanes in Praep. I 84</note>
 Tagen und die lebendigen Werke des lebendigen Gottes zu betrachten.
 Dom solcherlei Großtaten sind die lebendigen Werke eines
 (zwar) eines solchen, der in Wahrheit Gottes Leben lebt. Dn fragst, welches
-<lb n="5"/> diese (Werke) seien? Lerne! XX. Einige mit Gott kämpfende
+<lb n="5"/> diese (Werke) seien? Lerne!</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="20">
+<p>Einige mit Gott kämpfende
 (Kaiser) zertörten vor kurzem die für die
 mit vieler Streitlust, mit gewaltiger Kraft und mächtiger Hand
 von Grund aus, indem sie sie ausgruben, machten seine Kirchen unsichtbar
@@ -3918,11 +4640,11 @@ wurde, des Namens des Herrn gewürdigt wurde, und nicht
 <note type="footnote">23 ff. vgl. Praep. V 1 7</note>
 <note type="footnote">3 ἧ γὰρ οὐ ζῶντος καὶ θεοῦ ζωὴν ὡς ἀληθῶς ζῶντος ἔργα ζῶντα τυγχάνει
 τὰ τοιαδὶ κατορθώματα; L Vom Σ in Aussage verwandelt: „Denn die lebendigen
-Werke Gottes sind Leben in Wahrheit dessen, der lebendig ist in seinen Werken" <note type="marginal">Σ94</note>
+Werke Gottes sind Leben in Wahrheit dessen, der lebendig ist in seinen Werken" <milestone unit="altnumbering" n="94"/>
 4 wörtlicher „indem du fragst, lerne" Σ τίνα δὴ ταῦτα, ἐρωτᾶς;
 15 ὅτε δὴ τὰ πρὸς τὸν ὕστερον Πολεμηθέντα φίλα τε ἦν αὐτοῖς καὶ εἰρηναῖα L
 „denn bevor sie mit dem Letzteren kämpften, war ihnen Friede
-24 ,,wie früher“ Σ ἐξ ὑπαρχῆς L 25 ναοῖς τε ἁγίοις καὶ
+24 „wie früher“ Σ ἐξ ὑπαρχῆς L 25 ναοῖς τε ἁγίοις καὶ
 ἀφιερώμασι L 30 οὐκ ἐξ ἀνθρώπων τυχόντα τῆς ἐπικλήσεως L] 1. <foreign xml:lang="abbr">ABBREV</foreign> PSm</note>
 
 <pb n="v.3.pt.2.p.135"/>
@@ -3935,23 +4657,34 @@ jede Hoffnung abgeschnitten war, einer *zweiten, viel besseren Erneuerung
 gewürdigt als früher? Das größte
 sie erneuerte keineswegs nach dem Tode der mit Gott kämpfenden
 (Kaiser), sondern während die noch am Leben waren, die
-&lt;sodaß&gt; sie durch ihren (eigenen) Mund und durch ihre <lb n="10"/>
+<add>sodaß</add> sie durch ihren (eigenen) Mund und durch ihre <lb n="10"/>
 Schrift den Widerruf ihrer Frechheit verkündeten. Dies taten
 während sie in Ergötzung
-Geist, wie jemand meinen möchte, sondern durch Gottes
-XXI. Er aber hat auch nach all diesen Wintern der Verfolgung
+Geist, wie jemand meinen möchte, sondern durch Gottes Hiebe angetrieben.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="21">
+<p>Er aber hat auch nach all diesen Wintern der Verfolgung
 und auf dem Gipfel des Unheils Myriaden Männer, die Liehber <lb n="15"/>
 (sind) eines Lebens der Weisheit, und weibliche Priesterinnen und
 Scharen von Jungfrauen, die in vollkommener Heiligkeit die ganze Zeit
 ihres Lebens *existieren, durch die Lehre der göttlichen
-und in der ganzen Welt zusammengebracht. XXII. Enthaltung
+und in der ganzen Welt zusammengebracht.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="22">
+<p>Enthaltung
 aber (zu üben) von Speisen und viele Tage (lang) ohne Essen und ohne <lb n="20"/>
 Wein und mit Lagern auf der Erde willig auszuhalten und die Ausdauer
 eines festen und kräftigen Lebens mit Besonnenheit
 wer überredete (dazu) die Weiber und Myriaden von Kindern und
 Mengen von Männern, sodaß er durch das
 (Schrift) bewirkte, daß sie den vernünftigen <lb n="25"/>
-Speisen gegen die leiblichen Speisen eintauschten? XXIII. Wer
+Speisen gegen die leiblichen Speisen eintauschten?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="23">
+<p>Wer
 lehrte die barbarischen und ändlichen änner, Weiber,
 <note type="footnote">1 παρὸ καὶ κυριακῶν ἠξίωνται τῶν ἐπωνυμιῶν L τῆς ἐπωνυμίας Valesius
 3 „oder" Σ  L. Zu streichen? 6 δευτέρας . . . . ἀνανεώσεως L] <lb n="1."/>
@@ -3967,7 +4700,7 @@ Wein" Σ 25 „daß sie ünftige Speisen anstatt der leiblichen Speisen vernünf
 Seelen einander “ Σ. Viellelicht <foreign xml:lang="abbr">ABBREV</foreign> zu lesen.</note>
 
 <pb n="v.3.pt.2.p.136"/>
-Myriaden Sklaven &lt;und&gt; *Mengen der Völker,
+Myriaden Sklaven <add>und</add> *Mengen der Völker,
 und überzeugt zu sein, daß die Seele unsterblich
 der Gerechtigkeit" offenbar ein Aufseher der gerechten und frevlen
 Taten der Menschen sei, und das Gericht Gottes zu erwarten, (und)
@@ -3976,23 +4709,38 @@ keusches Leben zu kümmern. Denn sonst, wenn sie
 sei es unmöglich, sich dem Joch
 wird von dem, der von uns allein Gott genannt wird, bis jetzt
 bewirkt.</p>
-<lb n="10"/> <p>XXIV. Aber dies wollen wir lassen uud vielmehr auf andere <note type="marginal">Σ95</note>
+</div>
+  
+<div type="textpart" subtype="chapter" n="24">
+<p><lb n="10"/> Aber dies wollen wir lassen uud vielmehr auf andere <milestone unit="altnumbering" n="95"/>
 Weise dem, dessen Verstand versteinert ist, auch von solchen Fragen
 aus nahen, indem wir ihn so fragen: Wohlan, du, laß los ein vernünftiges
 Wort, bringe eine Frucht hervor, nicht aus törichtem Herzen,
 sondern aus geistiger und vernünftiger Seele und sprich, indem
-<lb n="15"/> dir selbst nachsinnst! XXV. Wer anders jemals von denen, die seit
+<lb n="15"/> dir selbst nachsinnst!</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="25">
+<p>Wer anders jemals von denen, die seit
 Ewigkeit gepriesen wurden, wurde wie der, der von uns Gott genannt
 wird, durch Prophetenworte von oben her vor Myriaden Zeiten erkannt
-und *vorher verkündigt bei den vor
-der Hebräer, die auch den Ort seiner Offenbarung,
+und *vorher verkündigt bei den vor alters gottgeliebten Kindern
+der Hebräer, die auch den Ort seiner Offenbarung, die Zeit seines
 <lb n="20"/> Kommens, die Art seines Lebens, seine Kraft, seine Worte und Taten
-vorher in den göttlichen Schriften beschrieben
-wer ist so schnell als Rächer erschienen dessen, was
-sich erfrechte, sodaß er auf der Stelle diejenigen, die
+vorher in den göttlichen Schriften beschrieben haben?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="26">
+<p>Oder
+wer ist so schnell als Rächer erschienen dessen, was man gegen ihn
+sich erfrechte, sodaß er auf der Stelle diejenigen, die gegen ihn frevelten
 das ganze Volk der Juden mit geheimer Kraft bestrafte und ihren
-<lb n="25"/> könighlichen Ort völlig
-mit seinen Heiligtümen zu
+<lb n="25"/> könighlichen Ort völlig von Grund aus zerstörte und ihren Tempel zusammen
+mit seinen Heiligtümen zu Boden stürzte?</p>
+</div>
+  
+<div type="textpart" subtype="chapter" n="27">
+<p>Wer hat Vorherverkündigungen
 über eben *diese, die (erwähnten) gottlosen Männer
 <note type="footnote">2 vgl. Fragm. Trag. Adesp. 421; Praep. XIII 13 47 15—21 = 2. Bruchstüch
 der griech. Theoph.</note>
@@ -4011,29 +4759,43 @@ gr. „und bestand und wurde ündigt” Σ 1. <foreign xml:lang="abbr">ABBREV</f
 <pb n="v.3.pt.2.p.137"/>
 und über die von ihm in der ganzen Welt gegründete Kirche *eben
 den Werken entsprechend vorhergesagt und ihre Wahrheit durch seine
-Werke erwiesen wie unser Erlöser, der über den Tempel
-(Juden) sagte: „Siehe! Euer Haus wird öde gelassen werden“,
+Werke erwiesen wie unser Erlöser, der über den Tempel der gottlosen
+(Juden) sagte: „Siehe! Euer Haus wird öde gelassen werden“, und
 „Nicht soll ein Stein auf dem andern bleiben an diesem Orte, der nicht <lb n="5"/>
-aufgelöst würde“? Über seine Kirche
+aufgelöst würde“? Über seine Kirche aber sagte er: „Auf diesen Felsen
 will ich meine Kirche bauen und die Riegel des Scheol sollen sie nicht
-überwältigen.</p>
-<p>XXVIII. Dies aber, daß er arme
+überwältigen“.</p>
+</div>
+  
+<div type="textpart" subtype="chapter" n="28">
+<p>Dies aber, daß er arme
 zur Herrschaft änderte und eben diese zu Gesetzgebern und <lb n="10"/>
 Lehrern der ganzen Menschenwelt machte, wie scheint dir das? Daß
 er ihnen dann versprach, mit dem Worte sagte und durch die Tat sie
 zu Menschenfischern machte und so große
 gab, daß sie sogar Schriften verfaßten
 diese so bestätigte, daß sie in der ganzen Welt in alle Sprachen der <lb n="15"/>
-<note type="marginal">Σ 96</note> Griechen und Barbaren übersetzt und bei allen Völkern
-und (daß) man glaubte, die in ihnen geschriebenen Worte
-XXIX. Wie aber scheint dir, daß er die
+<milestone unit="altnumbering" n="96"/> Griechen und Barbaren übersetzt und bei allen Völkern
+und (daß) man glaubte, die in ihnen geschriebenen Worte seien göttlich?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="29">
+<p>Wie aber scheint dir, daß er die
 und seinen Jüngern vorher bezeugte, daß sie
 bekannten, vor Könige und vor ἡγεμόνες kommen und bestraft werden <lb n="20"/>
-und die schwersten Qualen ertragen sollten? XXX. Dies aber, daß
+und die schwersten Qualen ertragen sollten?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="30">
+<p>Dies aber, daß
 auch willig machte, dies zu ertragen, und mit den Waffen der Frömmigkeit so
 tcappnete, daß sie in bezug auf ihre Seelen fester als Diamant
 Kämpfen gegen ihre Widersacher erschienen, wie sollte (dies)
-Wort übersteigen? XXXI. Und daß er nicht nur denjenigen, die ihm an- <lb n="25"/>
+Wort übersteigen?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="31">
+<p>Und daß er nicht nur denjenigen, die ihm an- <lb n="25"/>
 sondern auch denjenigen, die von ihnen (die Lehre) empfingen und
 wiederum auch denjenigen, die (noch) später (Jünger) wurden und den-
 <note type="footnote">4 = Matth 2338 5 = Matth 242 6 = Matth 16 18 9 ff. vgl. Matth
@@ -4055,12 +4817,18 @@ Seele so befestigte, daß sie. obwohl sie nichts Todeswürdiges
 Strafen und alle Arten der Foltern gern um der Gerechtigkeit des oberhalb
 von allem (stehenden) Gottes willen ertrugen, wie sollte das nicht
 <lb n="5"/> jedes Wunder übersteigen?</p>
-<p>XXXII. Aber wer jemals von den Königen, der so lange Zeit
+</div>
+<div type="textpart" subtype="chapter" n="32">
+<p>Aber wer jemals von den Königen, der so lange Zeit
 seiner Herrschaft (war), vollendete (dies)? Wer siegte so nach seinem
 Tode und richtete das Siegeszeichen über sein Feinde auf und unterwarf
 alle Orter, Plätze und Städte der Griechen
 <lb n="10"/> mit verborgener Kraft *und mit unsichtbarer Rechte *seinen
-Widersacher? XXXIII. Die Hauptsache aber von all dem Gesagten,
+Widersacher?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="33">
+<p>Die Hauptsache aber von all dem Gesagten,
 der Friede, der durch seine Macht auf der ganzen Erde besorgt wurde,
 über den wir das Geziemende vorher gesagt haben, welches Lästermaul
 sollte er nicht stopfen, indem so in der Tat mit seiner Lehre die Liebe
@@ -4069,7 +4837,7 @@ durch die Propheten Gottes der Friede der Völker in
 Welt vorher verkündigt ward und das von ihm in alle Völker
 Wort.</p>
 <p>Aber (zu) klein wäre Ein Tag, um zu versuchen,
-<lb n="20"/> Beweise der göttlichen Kraft des Logos Gottes, des Erlösers aller, die <note type="marginal">Σ97</note>
+<lb n="20"/> Beweise der göttlichen Kraft des Logos Gottes, des Erlösers aller, die <milestone unit="altnumbering" n="97"/>
 bis jetzt *gesehen werden, zu sammeln und zu zeigen, das niemals
 und von Ewigkeit her keiner, weder bei Griechen *noch bei Barbaren,
 eine derartige vorzügliche und göttliche Kraft
@@ -4080,7 +4848,7 @@ genannt werden, eine Natur wie diese auf Erden erschienen ist! Oder
 wer will, möge es zeigen. Es möge
 <note type="footnote">6 ff. vgl. Euseb. Hist, eccles. X 4 20 12 vgl. ο. S. 127 Z. 12 ff. 13 vgl. Röm 319</note>
 <note type="footnote">6 ἀλλὰ βασιλέων εἰς τοσοῦτον αἰῶνα τίς πώποτε κρατῶν διετέλεσεν; 10 ἀοράτῳ
-&lt;δυνάμει&gt; &lt;δυνάμει + Σ&gt; καὶ ἀφανεῖ δεξιᾷ L „mit
+<add>δυνάμει</add> <add>δυνάμει + Σ</add> καὶ ἀφανεῖ δεξιᾷ L „mit
 Rechten“ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 11 l. <foreign xml:lang="abbr">ABBREV</foreign> mit HS 14 „Lehre" †
 τῷ καταβληθέντι ὐπ’ αὐτοῦ τῴ παντὶ κόσμῳ κηρύγματι L. Vielleicht in Σ ausgefallen
 <lb n="21"/> ἐπιλείψει με . . . . τὰς ἐναργεῖς ἀποδείξεις . . . . τὰς ἐκ τῶν
@@ -4092,16 +4860,23 @@ gezeigt “ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 22 „noch bei Barba
 es gibt, und uns sagen, von welchem Gott oder Heros von aller Ewigkeit
 her *jenials gehört wurde, daß er die Lehren, die ein ewiges Lehen
 und ein himmlisches Reich verursachen, den Menschen überliefert habe
-wie unser Erlöser, der bewirkte, daß Myriaden
+wie unser Erlöser, der bewirkte, daß Myriaden Mengen in der ganzen
 Welt durch seine weisen Lehren geübt (erzogen) wurden, und <lb n="5"/>
 sie überredete, tiberredete, einem himmlischen Leben nachzujagen, dies zetiliche
-Leben aber zu verachten und die himmlischen Wohnplätze
-die für die gottliebenden Seelen aufbewahrt sind.
-Gott oder Heros hat völlig von Sonnenaufgang *bis zu
+Leben aber zu verachten und die himmlischen Wohnplätze zu erhoffen
+die für die gottliebenden Seelen aufbewahrt sind.</p>
+</div>
+  
+<div type="textpart" subtype="chapter" n="34">
+<p>Welcher Gott oder Heros hat völlig von Sonnenaufgang *bis zu
 bald so schnell wie der Lauf der Sonne, mit den glänzenden <lb n="10"/>
 Strahlen seiner Lehre die Erde erhellt und erleuchtet, sodaß
 auf der ganzen Erde dem Einen Gott Einen und denselben Gottesdienst
-vollendeten? XXXV. Welcher Gott oder Heros hat jemals alle Götter
+vollendeten?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="35">
+<p>Welcher Gott oder Heros hat jemals alle Götter
 und Heroen der Griechen und Barbaren verdrängt und ein
 daß keiner von jenen für einen Gott gehalten werde und, mach- <lb n="15"/>
 er das Gesetz gegeben hatte, sie überzeugt? Als dann aber alle
@@ -4109,13 +4884,21 @@ mit ihm kämpften, hat er, obwohl er (nur) Einer war, das
 entgegenstehende Heer vernichtet und ist besser erschienen als
 alle Götter und Heroen von Ewigkeit her, sodaß
 Menschenwelt der eingeborne Logos Gottes von allen Menschen genannt <lb n="20"/>
-wurde. XXXVI. Welcher Gott oder Heros hat jemals völlig allen
+wurde.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="36">
+<p>Welcher Gott oder Heros hat jemals völlig allen
 Völkern, die auf dem großen στοιχεῖον der
 auf Erden und denen im Meere, überliefert, in jeder Woche an dem
 Tage, der bei den Griechen der Sonntag heißt, ein Fest zu
 Heiligkeit der Seele und des Leibes und sich zusammen zu vereinigen, <lb n="25"/>
-<note type="marginal">Σ98</note> und hat sie zubereitet, nicht die Leiber zu *mästen, sondern
-durch die göttliche Lehre zu beleben? XXXVII. Welcher
+<milestone unit="altnumbering" n="98"/> und hat sie zubereitet, nicht die Leiber zu *mästen, sondern
+durch die göttliche Lehre zu beleben?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="37">
+<p>Welcher
 Heros hat wie der unsrige, als man so mit ihm kämpfte,
 wider seine Feinde aufgerichtet? Denn sie hörten
 von Anfang bis zu Ende mit seiner Lehre und mit seinem Volke zu <lb n="30"/>
@@ -4135,7 +4918,11 @@ Seinen mit den *göttlichen Häusern zu großem
 ist es nötig, durch Worte die göttlichen
 die besser sind als jedes Wort, sammeln zu wollen, da ja auch, wenn
 <lb n="5"/> wir schwiegen, die Dinge schreien würden zu denen, die
-Seele besitzen, XXXVIII. (daß) dies seltsam ist in Wahrheit und
+Seele besitzen,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="38">
+<p>(daß) dies seltsam ist in Wahrheit und
 das nicht wahrscheinlich ist, und (daß) von Ewigkeit her die Welt
 Menschen dies Eine Ding (hervor)brachte und einst der in Wahrheit
 einzige Sohn Gottes denen auf Erden erschien, durch den das ganze
@@ -4152,25 +4939,28 @@ und Segnungen und die gebührenden Bekenntnisse darbrachten,
 <lb n="20"/> fortan fromme Hymnen und Bekenntnisse, die zu denen der Engelscharen
 im Himmel stimmen, auch von den Bewohnern des στοιχεῖον
 der Erde jeden Tag und jede Nacht *geschickt wurden.</p>
-<p>XXXIX. Die erlösenden und der Welt helfenden Taten
+</div>
+
+<div type="textpart" subtype="chapter" n="39">
+<p>Die erlösenden und der Welt helfenden Taten
 des göttlichen Logos unter den Menschen (waren) also
 <lb n="25"/> Myriaden andere (Dinge) wie sie, um derentwillen er, (als) er in die
 Welt der Menschen kam, keineswegs das tat, was seiner Gewohnheit
 entsprach, er der unkörperlich (ist) und verborgen durch die
 *geht, der eben in Werken, denen im Himmel und denen auf Erden,
 <note type="footnote">25—S 141. 6 — 2418—15</note>
-<note type="footnote">1 ὁ δ’ ἀφανὴς ἀφανῶς L 2 τοὺς οἰκείοις αὐτοῖς ἱεροῖς οἴκοις („eben durch
+<note type="footnote">1 ὁ δ’ ἀφανὴς ἀφανῶς L 2 τοὺς οἰκείοις αὐτοῖς ἱεροῖς οἴκοις ( „eben durch
 die heiligen Häuser“) ἐπὶ μέγα δόξης προῆγεν L] 1. <foreign xml:lang="abbr">ABBREV</foreign> 6 Hauptsatz Σ]
 ξένον ἀληθῶς καὶ παράδοξον καὶ ἒν μόνον τὸν βροτὸν ἀνθρώπων ἐνηνοχέναι καὶ
 τὸ τοῦ Var.) ἀληθῶς παῖδα θεοῦ μόνον ἐξ αἰῶνος ἐπὶ γῆς ὦψαι L . . . καὶ ἒν
 μόνον ἐξ αἰῶνος τὸν κόσμον ἀνθρώπων ἐνηνοχέναι τὸ ἀληθῶς παῖδα θεοῦ [ ]
-τοῖς ἐπὶ γῆς ὦφθαι Hkl καὶ ἔν χρῆμα &lt;ἐξ αἰῶνος&gt; τὸν βίον τῶν ἀνθρώπων ἐνηνοχέναι
-καί &lt;ποτε&gt; τὸν &lt;μόνον&gt; ἀληθῶς παῖδα θεοῦ [ ]
+τοῖς ἐπὶ γῆς ὦφθαι Hkl καὶ ἔν χρῆμα <add>ἐξ αἰῶνος</add> τὸν βίον τῶν ἀνθρώπων ἐνηνοχέναι
+καί <add>ποτε</add> τὸν <add>μόνον</add> ἀληθῶς παῖδα θεοῦ [ ]
 nach Σ 16 1. <foreign xml:lang="abbr">ABBREV</foreign> mit HS (Druckfehler) 22 1. <foreign xml:lang="abbr">ABBREV</foreign> mit HS 28 τὸν
 ἅπαντα κόσμον ἀφανῶς ἐπιπορευομένῳ L „macht" Σ 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.141"/>
-<note type="marginal">Σ 99</note> seine gewaltigen Taten zeigt, sondern in neuer und in einer seiner
+<milestone unit="altnumbering" n="99"/> seine gewaltigen Taten zeigt, sondern in neuer und in einer seiner
 Gewohnheit fremden Weise. Denn durch ein sterbliches Instrument
 (d. h. den Leib) hielt er, wie der König durch einen
 seine Reden (zu) und seinen Umgang mit den Menschen, indem
@@ -4219,7 +5009,7 @@ dessen, was man sieht, freuen und in Bildern und Schnitzarbeiten
 in ὕλη und in Körpern und (die) um ihrer Schwäche
 Wahnsinns willen sterbliche Menschen von Natur Götter
 (ihnen) zeigte sich gerade so auch der (menschen)freundliche Logos
-Gottes. Deswegen machte er sich als allerheiligsten Tempel *ein körpernliches <note type="marginal">Σ 100</note>
+Gottes. Deswegen machte er sich als allerheiligsten Tempel *ein körpernliches <milestone unit="altnumbering" n="100"/>
 <lb n="10"/> Instrument, *eine sinnlich wahrnehmbare Wohnung für
 Kraft, *ein reines und ganz vorzügliches
 alle seelenlosen Götzen. Denn das aus seelenloser ὕλη (bestehende)
@@ -4266,9 +5056,9 @@ und Eichen umänderte das, was der Musik ähnlich
 der allweise und ganz vorzügliche Logos Gottes den Seelen
 die in mannigfaches Lnheil verstrickt waren, allerlei Heilungen, ergriff
 das musikalische Instrument, das Werk seiner Weisheit, *den Menschen
-mit Händen &lt;und&gt; stimmte durch ihn Gesünge und Besehwürungen für <lb n="15"/>
+mit Händen <add>und</add> stimmte durch ihn Gesünge und Besehwürungen für <lb n="15"/>
 die vernünftigen, aber nicht für
-<note type="marginal">Σ101</note> heilte jede wilde Sitte der Griechen und der Barbaren und die rohen
+<milestone unit="altnumbering" n="101"/> heilte jede wilde Sitte der Griechen und der Barbaren und die rohen
 und tierischen Leidenschaften der Seelen mit den Heilmitteln göttlicher
 Lehre und zeigte den kranken Seelen, die Gott im Werden und in den
 Körpern suchen, wie ein vorzüglicher Arzt durch ein  ihnen verwandtes <lb n="20"/>
@@ -4311,9 +5101,9 @@ weil nicht einmal, wenn es so (sichträfe), sobald eine Leier zerborchen
 schlägt, noch würden würdern wir mit Recht sagen,
 Mannes bestraft wird, daß die Weisheit des Weisen oder die
 Leibe geschlagen oder verbrannt wird. So ist es noch viel weniger
-richtig zu sagen, daß die Kraft des göttlichen g"ottlichen <note type="marginal">Σ102</note>
+richtig zu sagen, daß die Kraft des göttlichen g"ottlichen <milestone unit="altnumbering" n="102"/>
 <lb n="20"/> Schaden an den Leiden des Körpers nahm, weil nicht einmal das
-des Lichtes gestattete&gt;, daß die Strahlen
+des Lichtes <add>gestattete</add>, daß die Strahlen
 vom Himmel auf die Erde gesandt werden und Schmutz und Lehm
 und Befleckung jeder Art berühen, etwas befleckt werden.
 freilich hindern zu sagen, daß auch sie vom Glanz des
@@ -4352,10 +5142,13 @@ leicht und ungehindert vollziehen könnten und
 das ewige Leben bei Gott, dem Königh des Alls,
 Licht und das Königreich des Himmels mit den Scharen der heiligen <lb n="15"/>
 Engel zu empfangen.</p>
-<p>XL. So verrichtete also der eingeborene Logos Gottes, der sich
+</div>
+
+<div type="textpart" subtype="chapter" n="40">
+<p>So verrichtete also der eingeborene Logos Gottes, der sich
 eines menschlichen Instrumentes bediente und einen Dolmetscher seiner
 selbst aufstellte, alles für die Heilung der Menschen nach
-<note type="marginal">Σ 103</note> seines Vaters, indem er ohne ὕλη und ohne Körper blieb, wie er vor- <lb n="20"/>
+<milestone unit="altnumbering" n="103"/> seines Vaters, indem er ohne ὕλη und ohne Körper blieb, wie er vor- <lb n="20"/>
 bei dem Vater war und durch einen Menschen Gott den Menschen
 zeigte in gewaltigen Taten und staunenswerten Werken mit göttlicher
 Kraft, und durch wahre Weisheit säte er die Lehre und lehrte
@@ -4377,41 +5170,41 @@ teilzuhaben, so (ist) reichlich (Gelegenheit), dich dem Hören der
 προαγούσαις L</note>
 
 <pb n="v.3.pt.2.p.146"/>
-seiner Jünger zuzuwenden und die Schrift nach allen
-zu lernen über seine Taten und über seine Worte, sodaß du
-Gott siehst und den göttlichen Logos, wie er durch einen
+seiner Jünger zuzuwenden und die Schrift nach allen Seiten kennen
+zu lernen über seine Taten und über seine Worte, sodaß du du in Wahrheit
+Gott siehst und den göttlichen Logos, wie er durch einen Dolmetscher mit
 den Menschen, (uns) ähnlich an Leiden (zusammen) war, und wie der
-<lb n="5"/> Unsterbliche mit den Sterblichen redete, und wie Unkörperliche
+<lb n="5"/> Unsterbliche mit den Sterblichen redete, und wie Unkörperliche ein
 Bild aus menschlicher Natur anzog, und wie der Gott in ihm sein Bild
-antrieb, und wie der Erlöser aller (göttliche)
+antrieb, und wie der Erlöser aller (göttliche) Reden losieß und göttliche
 Lehre vortrug und alle Krankheiten und Schmerzen heilte, und wie der,
 in dem kein Falsch war, zu guten Werken bereit war, und wie er das,
 <lb n="10"/> was kein Auge je gesehen und in keines Menschen Ohr gekommen
 ist, in gewaltigen Taten vollendete. So brachte er seinen Jüngern den
-Anfang der Vorzüglicheit bei Gott nahe und machte sie weise
+Anfang der Vorzüglicheit bei Gott nahe und machte sie weise mit unaussprechlicher
 Kraft und bereitete sie zu wahren Herolden seiner Gottheit.
 So heilte er ferner diejenigen, deren Seelen durch allerleiSüdnen Südnen
-<lb n="15"/> verderbt waren, indem er bald für die Leiden die
-(Arznei) gewährte, bald aber die mystische Theorie
-denen überlieferte, die sie aufnehmen können. Was aber
+<lb n="15"/> verderbt waren, indem er bald für die Leiden die entsprechende Hilfe <milestone unit="altnumbering" n="104"/>
+(Arznei) gewährte, bald aber die mystische Theorie der göttlichen Lehre
+denen überlieferte, die sie aufnehmen können. Was aber habe ich nötig
 zu sagen, wie er die Feinde der Wahrheit mit gebührender Widerlegung
-schön und freundlich aufnahm, indem er auch sie zumal
+schön und freundlich aufnahm, indem er auch sie zumal heilte und
 <lb n="20"/> durch die Freimut seiner Worte unterwies, und wie er sich jedermann
-demütig darbot als ein hilfreicher, langmütiger
+demütig darbot als ein hilfreicher, langmütiger und gefühlvoller Arzt aller
 nur der Seelen, sondern auch der Leiber? Deswegen hatte das hebräische
 (Propheten)wort die Bezeichnung mit dem Namen Jesus vorher
-für unsern Erlöser geprägt, indem es
-<lb n="25"/> auffaßte. Die Bezeichnung aber mit (dem Begriff) der
-bewährte er durch Taten, indem er die Seelen der Menschen in
+für unsern Erlöser geprägt, indem es (das Wort) Jesus als Arzt aller
+<lb n="25"/> auffaßte. Die Bezeichnung aber mit (dem Begriff) der Heilung für Jesus
+bewährte er durch Taten, indem er die Seelen der Menschen in der
 himmlischen Lehre unterwies und alle Leiden, Schmerzen und Krankheiten
 der Leiber mit der Kraft des heilenden Wortes heilte. Bald
-reinigte er die, die aussätzig waren, an ihrem Leibe, bald trieb
-<lb n="30"/> einen Befehl die Dämonen in den Menschen aus,
-er reichliche Heilung denen, die durch Krankheit gequält
+reinigte er die, die aussätzig waren, an ihrem Leibe, bald trieb er durch
+<lb n="30"/> einen Befehl die Dämonen in den Menschen aus, bald wieder gewährte
+er reichliche Heilung denen, die durch Krankheit gequält wurden, bald
 sagte er dem, dessen Leib schlaff und dessen Glieder insgesamt gelähmt
 waren, nur mit einem Worte: „Stehe auf, nimm dein Bett und wandle“,
 der aber tat, was er ihm auftrug. Den Blinden wiederum zu (anderer)
-<lb n="35"/> Zeit verschaffte er den Anblick des Lichtes. So entschloß
+<lb n="35"/> Zeit verschaffte er den Anblick des Lichtes. So entschloß sich ferner
 <note type="footnote">10 vgl. I Kor 29 24 vgl. Dem. IV 10 18. 19 28—S. 147, 25 = Dem. III 421—26
 33 = Matth 96 35 vgl. Matth 9 20 ff.</note>
 <note type="footnote">21 wörtlich: „und als ein langmütiger und
@@ -4431,7 +5224,7 @@ wiederum seine Tochter — es war ein Synagogenvorsteher der Juden — <lb n="10
 aber dieser (empfing sie gesund), nachdem sie (bereits) gestorben war.
 Was habe ich nötig zu sagen, wie ein anderer Toter nach
 durch die Kraft des Erlösers aller auferstand, als er nur
-<note type="marginal">Σ 105</note> mit dem ihn der alles lebendigmachende Logos rief? Oder wie er auf dem
+<milestone unit="altnumbering" n="105"/> mit dem ihn der alles lebendigmachende Logos rief? Oder wie er auf dem
 Meere gleichwie auf der trockenen Erde seinen Weg nahm und oben <lb n="15"/>
 auf dem Rücken der W asser sein Instrument
 ließ? Oder wie er, als seine Jünger segelten und
@@ -4442,17 +5235,22 @@ Schar von Myriaden Weibern und Kindern mit ihnen war, von Broten
 an der Zahl fünf vollständig sättigte, daß
 empfingen als ausreichend war, um zwölf Körbe zu füllen,—wer sollte
 (darüber) nicht staunen und (wen sollte das nicht) mit
-zur Erforschung seiner verborgenen Kraft? XLI. Aus (diesen und) vielen <lb n="25"/>
+zur Erforschung seiner verborgenen Kraft?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="41">
+<p>Aus (diesen und) vielen <lb n="25"/>
 andern gewaltigen Wundern also empfängt, wer will, den
 und offenkundigen Beweis für
 noch mehr aber daraus, wenn er aucb bedenkt, daß
-vorauswußte &lt;und&gt; vorausverkündigte, daß die
+vorauswußte <add>und</add> vorausverkündigte, daß die
 göttliche Kraft *in gewaltigem Wechsel zur Vorzüglichkeit kommen <lb n="30"/>
 werde, und daß er sich als den Täter dieses
 durch Werke seine Verheißung bewahrheitete.
 Dinge demgemäß wird jemand im Überflusse finden, wenn er
 aus den Prophezeiungen und Erfüllungen die
-seiner Gottheit prüft, die auch wir zu passender Zeit erwägen werden.</p> <lb n="35"/>
+seiner Gottheit prüft, die auch wir zu passender Zeit erwägen werden.</p>
+<lb n="35"/>
 <note type="footnote">7 vgl. Matth 8 5ff. 9 vgl. Mark 5 22ff. 12 vgl. Job11 1 ff. 14 vgl. Matth
 1425ff. 17 vgl. Matth 8 24 ff. 20 vgl. Matth 14 19 ff.</note>
 <note type="footnote">15 ola ἐπὶ λεωφόρου γῆς D 29 „daß er die Zukunft mit göttlicher Kraft
@@ -4462,7 +5260,11 @@ vorauswußte“ Σ. Aber das <foreign xml:lang="abbr">ABBREV</foreign> steht bes
 <p>Aber für jetzt möge, damit sich *uns nicht
 Ferne über alle seinegroßen Werke erstrecke, *sein Tod vor Augen
 *bleiben, den der Dolmetscher, das Gewand des Logos Gottes und das
-Bild, das geoffenbart wurde, ertrug, wie jedermann bekennt. XLII. Er
+Bild, das geoffenbart wurde, ertrug, wie jedermann bekennt.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="42">
+<p>Er
 <lb n="5"/> sein Tod also, der verkündet wurde, hatte am Wunder teil, da
 den übrigen Menschen gleich geschah. Denn er wurde weder
 durch eine Krankheit vernichtet, noch durch Erdrosselung, noch durch
@@ -4471,7 +5273,11 @@ gleich mit dem Eisen geschnitten, noch litt er das geringste Etwas
 <lb n="10"/> von einem der Menschen, die zu töten gewohnt sind, und
 einen gewaltsamen Tod, sondern freiwillig übergab er es allein, sein
 Instrument, den Verleumdern. Das aber wurde sogleich von der Erde
-erhöth. XLIII. Er aber rief laut und sagte, daß er seinem Vater seinen <note type="marginal">Σ 106</note>
+erhöth.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="43">
+<p>Er aber rief laut und sagte, daß er seinem Vater seinen <milestone unit="altnumbering" n="106"/>
 Geist übergebe, wurde frei von sich selbst und vollzog die Auswanderung
 <lb n="15"/> aus dem Leibe. Deswegen überlieferte er seinen Jüngern
 Tode eben dies (Wort), lehrte und sagte: „Niemand nimmt meine Seele
@@ -4481,7 +5287,11 @@ der gute Hirte und kenne die Meinen und die Meinen kennen mich“,
 <lb n="20"/> und „ich lasse mein Leben für meine Schafe“.
 Todes aber stellt er in kurzem hin, indem er sagt: „Wenn das Weizenkorn
 nicht in die Erde fällt und stirbt, bleibt es nur
-es aber stirbt, bringt es viele Früchte.“ XLIV. Indem er
+es aber stirbt, bringt es viele Früchte.“</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="44">
+<p>Indem er
 derart bei seinem Tode überlieferte, wurde er von sich selbst frei
 <lb n="25"/> und vollzog seine Auswanderung aus dem Leibe. Dann aber wurde
 sein Leib von seinen Jüngern herabgenommen
@@ -4504,8 +5314,11 @@ seinen Jüngern, mit denen er etwas redete und kurze
 war. (Dann) stieg er auf dorthin, wo(her) er war, und vollzog vor ihren
 Augen seinen Lauf und seinen Aufstieg zum Himmel , (vor seinen
 Jüngern), denen er auch Lehren für ihr Tun überlieferte
-Lehrern der Gottesfurcht Gottesfurcht für alle Völker unachte.</p> <lb n="5"/>
-<p>XLV. Was also bleibt nach diesen (Ausführungen) übrig als eben
+Lehrern der Gottesfurcht Gottesfurcht für alle Völker unachte.</p>
+</div>
+  
+<div type="textpart" subtype="chapter" n="45">
+<lb n="5"/><p>Was also bleibt nach diesen (Ausführungen) übrig als eben
 die Hauptsache zu sagen, welchen Grund er hatte, ich meine aber das
 von jedermann besprochene Ende seines Lebens und die Art seines
 Leidens und das große Wunder seiner Auferstehung nach
@@ -4514,22 +5327,45 @@ kommen und eben diese durch offenkundige Zeugnisse bestätigen. Indem
 er also ein sterbliches Instrument wegen der vorher genannten
 Gründe gleichsam als gottgeziemendes Bild gebrauchte und
 seiner (Hilfe) wie ein Großkönig vermittelst des Dolmetschers in
-der Menschen einzog, tat er alles würdig der göttlichen Kraft. XLVI. <lb n="15"/>
-Wenn er also in anderer Weise nach seiner Lebensführung
-<note type="marginal">Σ107</note> Menschen unsichtbar *geworden worden und plötzlich davongeflogen wäre
+der Menschen einzog, tat er alles würdig der göttlichen Kraft.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="46">
+<lb n="15"/><p>Wenn er also in anderer Weise nach seiner Lebensführung
+<milestone unit="altnumbering" n="107"/> Menschen unsichtbar *geworden worden und plötzlich davongeflogen wäre
 heimlich seinen Dolmetscher gestohlen und sich bemüht hätte, sein
 Bild durch die Flucht dem Tode zu entziehen, *und dann von sich aus
 das Sterbliche Verderben und Untergang hätte berühren lassen, so wäre <lb n="20"/>
-er den meisten einer Halluzination gleich geworden. XL VII. Weder
+er den meisten einer Halluzination gleich geworden.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="47">
+<p>Weder
 hätte er sich (dann) etwas Würdiges getan, da er
 Gottes und die Kraft Gottes ist, (trotzdem) aber seinen eigenen Dolmetscher
-dem Untergang und Verderben überlieferte, XLVIII. noch
+dem Untergang und Verderben überlieferte,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="48">
+<p>noch
 wäre das, was er gegen die Dämonen tat, durch den Kampf mit dem <lb n="25"/>
-Tode der Vollendung gewürdigt, IXL. noch wäre
-nach seinem Fortgange war. L. noch wäre ihm geglaubt worden
-denen er nicht überliefert hat, noch wäre er besser erschienen
-Natur als der Tod, LI. noch hätte er das Sterbliche von
-Natur befreit, &lt;noch wäre er in der ganzen Menschenwelt gehört (und <lb n="30"/>
+Tode der Vollendung gewürdigt,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="49">
+<p>noch wäre erkannt worden, wo er
+nach seinem Fortgange war.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="50">
+<p>noch wäre ihm geglaubt worden von denen,
+denen er nicht überliefert hat, noch wäre er besser erschienen in seiner
+Natur als der Tod,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="51">
+<p>noch hätte er das Sterbliche von seiner eigenen
+Natur befreit, <add>noch wäre er in der ganzen Menschenwelt gehört (und <lb n="30"/>
 <note type="footnote">6—8. 151, 9 — Laus 24412—2464</note>
 <note type="footnote">2 ἄνεισιν ὅθεν καὶ παρῆν Th. gr. 4 ὑποθήκας] „Pfänder“ Σ 8 „das
 von jedermann besprochene Ende"j τὸ πολυθρύλλητον . . . . τέλος Th. gr. 17 ἀφανὴς
@@ -4539,29 +5375,44 @@ dann" Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 27 „fortgehend“ Σ χ�
 ἠκούσθη Th. gr. &lt; Σ wohl mit unrecht, l. <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.150"/>
-bekannt) geworden&gt; LH. noch hätte
-zu verachten, LIII. noch hätte er die Hoffnung auf ein Leben
-nach dem Tode für diejenigen hingestellt, die seiner
-LIV. noch hätte er die *Verheißungen seiner
+bekannt) geworden</add></p>
+</div>
+  
+<div type="textpart" subtype="chapter" n="52">
+<p>noch hätte er seine *Jünger überredet, den Tod
+zu verachten,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="53">
+<p>noch hätte er die Hoffnung auf ein Leben bei Gott
+nach dem Tode für diejenigen hingestellt, die seiner Lehre nachfolgen,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="54">
+<p>noch hätte er die *Verheißungen seiner Worte erfüllt, noch hätte
 <lb n="5"/> er den Prophezeiungen, die über ihn vorhergesagt waren, die entsprechende
-Erfüllung geboten, LV. noch hätte
+Erfüllung geboten,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="55">
+<p>noch hätte er in dem allerletzsten
 Kampf gesiegt. Dieser war gegen den Tod.</p>
 <p>Wegen aller dieser Dinge, da vor allem dem sterblichen Instrument,
 nachdem es den Dienst vollendet hatte, den es dem Logos Gottes leistete,
 <lb n="10"/> ein gottgeziemendes Ennde zustoßen mußte, wurde es in dieser (Weise)
 dem Tode eingereiht. Denn zwei (Dinge) blieben übrig beim Ende:
 entweder das Ganze dem Verderben und dem Untergange preiszugeben
-und den schimpflichsten [Lebens]ausgang des ganzen Kampfes zu veranstalten,
+und den schimpflichsten <del>Lebens</del>ausgang des ganzen Kampfes zu veranstalten,
 oder sich besser als den Tod zu zeigen und mit göttlicher
 <lb n="15"/> Kraft das Sterbliche unsterblich hinzustellen. Das erste aber war nicht
 der *Verheißung entsprechend. Denn nicht ist es Sache
-kalt zu machen, noch des Lichtes, finster zu machen. So ist es auch <note type="marginal">Σ108</note>
+kalt zu machen, noch des Lichtes, finster zu machen. So ist es auch <milestone unit="altnumbering" n="108"/>
 nicht Sache des Lebens zu töten, noch des Logos
 zu handeln. Welchen Grund also hatte der, der anderen das Leben
 <lb n="20"/> verhieß, die Vernichtung seines (eigenen) Instrumentes
 sein Bild dem Untergange preiszugeben und den Dolmetscher seiner
 Gottheit dem Verderben des Todes darzubieten, er, der denen, die zu
-ihm ihre Zuflucht nahmen, das ewige Leben [vorher] anriet? Also war
+ihm ihre Zuflucht nahmen, das ewige Leben <del>vorher</del> anriet? Also war
 das Zweite notwendig, ich meine aber dies, daß er sich
 <lb n="25"/> als den Tod. Wie also sollte er dies machen? Heimlich und durch
 Diebstahl oder jedermann offenkundig und klar? Wenn aber das Werk
@@ -4604,7 +5455,7 @@ Zeugnisse aber lehren (es), mit denen die Erfüllung der
 wurde vom heiligen Geist in die Wüste
 zu werden, und er war dort vierzig Tage und vierzig Nächte
 und war mit den Tieren zusammen." Was waren diese Tiere anders) <lb n="25"/>
-<note type="marginal">Σ109</note> als die Häupter der Dämonen, die der
+<milestone unit="altnumbering" n="109"/> als die Häupter der Dämonen, die der
 Weise: „Schlange“, „Natter“, „Löwe" und „Drache“ wegen der Ähnlichkeit
 ihrer Bosheit mit Bezug auf ihn so nannte und sprach: „Auf
 die Schlange und die Natter wirst du treten und den Löwen
@@ -4624,7 +5475,11 @@ mit Pes</note>
 schoß, das am Tage fliegt, vor dem Dinge, das in
 wandelt, und vor dem Geiste des Dämons am Mittag. An
 werden Tausende fallen und Myriaden zu deiner Rechten und dir werden
-sie nicht nahen.“ LVI. Dies wurde im Gleichnis und im
+sie nicht nahen.“</p> 
+</div>
+
+<div type="textpart" subtype="chapter" n="56">
+<p>Dies wurde im Gleichnis und im
 <lb n="5"/> gesagt über den Kampf in der Wüste,
 mit den unsichtbaren Geistern stattfand. Alle diese Nächte
 Tage hindurch also, kämpfte der Logos Gottes
@@ -4639,8 +5494,11 @@ besiegt and den Feinden nicht mit Recht Untertan war, nicht
 machen und zu zeigen, daß besser als
 Götter gehalten wurden, wegen der Gemeinschaft mit
 sein Geliebter sei, den er nach seinem Bilde und Gleichnis gemacht
-hatte, wie in den Worten (der Schrift) mystisch geschrieben ist. LVII.
-<lb n="20"/> Als also der Kampf gegen diese ein Ende fand, da stieg fortan siegbekleidet
+hatte, wie in den Worten (der Schrift) mystisch geschrieben ist.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="57">
+<p><lb n="20"/>Als also der Kampf gegen diese ein Ende fand, da stieg fortan siegbekleidet
 der Erlöser von uns allen (aus der Wüste)
 Leben unter den Menschen und befreite ihre Seelen, indem er sie aus
 den Fesseln der Dämonen löste und
@@ -4648,7 +5506,7 @@ Verborgene offenbarte, vor allem das, was er gegen die unsichtbaren
 <lb n="25"/> Feinde tat. Er sagt aber so und stellt (folgende Worte) hin: „Fasset
 Mut! Ich habe die Welt besiegt“, und (auch) die Art seines
 lehrte er durch das, was er seinen Jüngern im Gleichnis
-mand kann eintreten in das Haus des Starken und seine Gefäße rauben, <note type="marginal">Σ110</note>
+mand kann eintreten in das Haus des Starken und seine Gefäße rauben, <milestone unit="altnumbering" n="110"/>
 wenn er nicht zuvor den Starken fesselt, dann aber wird er auch sein
 <lb n="30"/> Haus plündern.“ Er hat also den Starken gefesselt und das
 der Dämonen vertrieben und sogleich die Seelen
@@ -4702,34 +5560,39 @@ der Logos die nützliche Einrichtung vor") Th. gr. 26 εἰς
 Σ. aber vgl. S. 154 1 εἰς παράστασιν</note>
 
 <pb n="v.3.pt.2.p.154"/>
-zum Beweise der göttlichen Kraft, durch die er das von ihm
+zum Beweise der göttlichen Kraft, durch die er das von ihm verkündigte <milestone unit="altnumbering" n="111"/>
 ewige Leben besser als jeden Tod zeigte.</p>
-<p>LVIII. Die erste Ursache also war diese, die zweite aber war der
-Beweis der im Leibe wohnenden göttlichen Kraft. Denn
-<lb n="5"/> Menschen früher diejenigen, die vom Tode besiegt
-Männer in Wahrheit, die das gemeinsame Ende empfangen
-Göttern machten und Heroen und Götter
+</div>
+
+<div type="textpart" subtype="chapter" n="58">
+<p>Die erste Ursache also war diese, die zweite aber war der
+Beweis der im Leibe wohnenden göttlichen Kraft. Denn weil die
+<lb n="5"/> Menschen früher diejenigen, die vom Tode besiegt waren — sterbliche
+Männer in Wahrheit, die das gemeinsame Ende empfangen hatten — zu
+Göttern machten und Heroen und Götter diejenigen nannten, die vom
 Tode beherrscht waren, so zeigte sich auch in diesem (Punkte) mit
 Recht *wegen dieser Ursache der freundliche Logos Gottes (und) zeigte
 <lb n="10"/> den Menschen eine Natur, die besser (ist) als der Tod, und führte das
-Sterbliche nach seiner Auflösung zu einem zweiten
+Sterbliche nach seiner Auflösung zu einem zweiten Leben und ließ
 jedermann das Siegeszeichen der Unsterblichkeit wider den Tod sehen
 und lehrte allein den bekennen, der im Tode wahrhaftiger Gott ist, der
 den Siegeskranz wider den Tod auf sein Haupt gebunden hat.</p>
-<lb n="15"/> <p>LIX. Eine dritte Ursache des *erlösenden Todes ist
+</div>
+<lb n="15"/> <div type="textpart" subtype="chapter" n="59">
+<p>Eine dritte Ursache des *erlösenden Todes ist diejenige, welche
 die geheimen Worte (der Schrift) enthalten. Welche sind das? Er war
-ein Opfer, das (als Ersatz) für die Seelen des ganzen
-wurde, ein Opfer, das für die *Herde
-wTurde, ein Abwehropfer der dämonischen Verirrung. Ein
-<lb n="20"/> und eine große Opfergabe, der hochheilige Leih
-ähnlich einem Schafe für das ganze Geschlecht
-und (als Ersatz) für die Seelen aller Völker,
-Verirrung ihrer *Väter befangen waren, geweiht. (Daher) war
-ganze unreine und unheilige Kraft der Dämonen vernichtet,
-<lb n="25"/> und zerstört war auf der Stelle mit besserer Kraft der
-und irdische Irrtum. Das erlösende Opfer also aus den
-leibliche Instrument des göttlichen Logos, wurde für
-Menschen geschlachtet. Dies aber war das Opfer, das durch die Ver-
+ein Opfer, das (als Ersatz) für die Seelen des ganzen Geschlechts dargebracht
+wurde, ein Opfer, das für die *Herde aller Menschen getötet
+wTurde, ein Abwehropfer der dämonischen Verirrung. Ein Opfer also
+<lb n="20"/> und eine große Opfergabe, der hochheilige Leih unsers Erlösers, wurde
+ähnlich einem Schafe für das ganze Geschlecht der Menschen geschlachtet
+und (als Ersatz) für die Seelen aller Völker, die im Frevel dämonischer
+Verirrung ihrer *Väter befangen waren, geweiht. (Daher) war fortan die
+ganze unreine und unheilige Kraft der Dämonen vernichtet, und aufgelöst
+<lb n="25"/> und zerstört war auf der Stelle mit besserer Kraft der ganze eitle
+und irdische Irrtum. Das erlösende Opfer also aus den Menschen, das
+leibliche Instrument des göttlichen Logos, wurde für die *Herde aller
+Menschen geschlachtet. Dies aber war das Opfer, das durch die Verleumdung
 <note type="footnote">3—S. 155, 22 = Laus 247 15—248 23 15 ff. vgl. Dem. IV 12 7 21 vgl.
 Jes 53 7</note>
 <note type="footnote">6 ἄνδρας θνητοὺς . . . . . κοινὸν τέλος ὑποδεδεγμένους] μένους] „an denen . . . . erschienen
@@ -4743,10 +5606,10 @@ besser ist als alle Opfer πανιέρου als πανιερείου verstanden
 δύναμις L 27 ἀγέλης] 1. <foreign xml:lang="abbr">ABBREV</foreign> Lee</note>
 
 <pb n="v.3.pt.2.p.155"/>
-leumdung der Menschen dem Tode überliefert wurde, über das die
+der Menschen dem Tode überliefert wurde, über das die
 Worte der heiligen Schrift ausrufen, indem sie bald so sagen: „Siehe
-das Schaf Gottes, siehe, was da trägt die Sünde
-<note type="marginal">Σ112</note> aber bald so vorausverkündigen: „Wie ein Schaf wurde er
+das Schaf Gottes, siehe, was da trägt die Sünde der Welt“, indem sie
+<milestone unit="altnumbering" n="112"/> aber bald so vorausverkündigen: „Wie ein Schaf wurde er
 geführt und wie ein Lamm verstummte er vor dem Scherer“. Die <lb n="5"/>
 Ursache lehrt sie, indem sie sagt: „Wahrhaftig, unsere Sünden
 ertragen und unsere Schmerzen hat er erduldet. Wir aber achteten ihn
@@ -4770,7 +5633,9 @@ des Hohenpriesters hat. Beide Namen also empfing er: den des Erlösungsopfers
 zeigt der Name Jesus an und den des Hohenpriesters, des <lb n="25"/>
 Wortes Gottes, der für alle zum Priester geweiht ist, tut die Sitte der
 Hebräer betreffs des kund.</p>
-<p>LX. Außer dem, was gesagt ist, gibt es noch
+</div>
+<div type="textpart" subtype="chapter" n="60">
+<p>Außer dem, was gesagt ist, gibt es noch
 Grund für den *erlösenden Tod, der (im
 Denn da es für seine Jünger notwendig war, mit
 Wiedergeburt *des Lebens nach dem Tode offenkundig zu sehen, auf
@@ -4791,7 +5656,7 @@ frommen Leben nachgehen sollten, mußten vor
 Lehre durch deutliches Schauen (in sich) aufnehmen, und noch viel mehr
 <lb n="5"/> jene, die ihn bald in der ganzen Welt verkündigen und
 allen Völkern dargebotene Gotteserkenntnis
-lassen sollten. Es war notwendig, daß gerade sie eine gewaltige Überzeugung <note type="marginal">Σ113</note>
+lassen sollten. Es war notwendig, daß gerade sie eine gewaltige Überzeugung <milestone unit="altnumbering" n="113"/>
 des Lebens nach dem Tode empfingen, damit sie ohne Furcht
 und Zagen vor dem Tode den ἀγών wider die polytheistische Verirrung
 <lb n="10"/> *willig unternähmen. Denn wenn
@@ -4801,8 +5666,11 @@ Herrschaft des Todes, indem er nicht mit Reden und Worten ihnen die
 Lehre übergab, noch überzeugend und aus Wahrscheinlichkeitsgründen
 <lb n="15"/> mit Worten, den Menschen gleich, (einen Befehl) über die Unsterblichkeit
 der Seele anordnete, sondern indem er ihnen eben durch die Tat
-die Siegeszeichen wider den Tod zeigte.
-LXI. Denn früher war der Tod allen Menschen furchtbar,
+die Siegeszeichen wider den Tod zeigte.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="61">
+<p>Denn früher war der Tod allen Menschen furchtbar,
 ganzes sterbliches Geschlecht verderbte, und seine Herrschaft wurde für
 <lb n="20"/> eine Auflösung der ganzen menschlichen Natur, der
 des Leibes, gehalten und niemand hat jemals vermocht, dies Furchtbare
@@ -4816,10 +5684,10 @@ und keine Offenbarungen der Engel. Besser als alle und höher als alle war (der 
 <lb n="30"/> ruhmredige, übermütige Tod, durch den das ganze sterbliche Geschlect
 geknechtet war und in allerlei Freveln sich wälzte, in Besudelungen
 mit Blut, in unrechten *Taten und im Irrtum jeder Art der bösen, gott-
-<note type="footnote">6 „leuchten lassen“ Σ καταγγέλλειν Th. gr. 10 προθύμως] „in ihrem lrrtum“Σ (Schreibfehler) l. <foreign xml:lang="abbr">ABBREV</foreign> 12 „notwedig“] genauer„besonders“
+<note type="footnote">6 „leuchten lassen“ Σ καταγγέλλειν Th. gr. 10 προθύμως] „in ihrem lrrtum“Σ (Schreibfehler) l. <foreign xml:lang="abbr">ABBREV</foreign> 12 „notwedig“] genauer „besonders“
 Σ ἀναγκαίως Th. gr. 15 οὐδὲ λόγοις. . . . τὸν περὶ ψυχῆς ἀθανασίας . . .
 συντάττων Th. gr. 24 „alle Scharen der Völker, und Familien“ Σ l. <foreign xml:lang="abbr">ABBREV</foreign>
-<foreign xml:lang="abbr">ABBREV</foreign> 29 τὴν κατὰ πάντων νίκην ἐπεῖχεν] „den Sieg höher als alle“ („oder
+<foreign xml:lang="abbr">ABBREV</foreign> 29 τὴν κατὰ πάντων νίκην ἐπεῖχεν] „den Sieg höher als alle“ ( „oder
 oberhalb von allen“) Σ (=τὴν πάντων ν. ἐπ-εῖχεν?) | ὑψηλός] l. <foreign xml:lang="abbr">ABBREV</foreign> mit HS
 321. <foreign xml:lang="abbr">ABBREV</foreign> mit HS</note>
 
@@ -4831,9 +5699,9 @@ einer Rechenschaft nicht unterwarfen, so lebten sie wegen der Auflösung
 infolge des Todes ein Leben, das kein Leben war, nahmen weder Gott <lb n="5"/>
 in ihr Denken auf, das gerechte Gericht Gottes,
 noch belebten sie die Erinnerung an die ändige οὐσία ihrer
-sondern hatten den Tod als den Einen harten Herrscher [im Gebrauch]
+sondern hatten den Tod als den Einen harten Herrscher <del>im Gebrauch</del>
 und redeten sich selbst ein, ß das aus ihm (stammende)
-<note type="marginal">Σ114</note> &lt;der Leiber&gt; eine ösung des ganzen (Menschen) sei, und nannten <lb n="10"/>
+<milestone unit="altnumbering" n="114"/> <add>der Leiber</add> eine ösung des ganzen (Menschen) sei, und nannten <lb n="10"/>
 den Tod den reichen Gott, daher (der Name) Pluton. Und nicht nur
 der Tod war ihnen ein Gott, sondern auch die kostbaren (Dinge) vor
 ihm, die ihnen passen zu einem Leben der Lust. Ein Gott also war
@@ -4845,13 +5713,13 @@ der Demeter und der Persephone und der Raub der Kore zur Unterwelt
 und wiederum ihre Rückgabe! Daher die Feste des
 Herakles, vom Rausch wie von einem stärkeren Gott besiegt, daher die <lb n="20"/>
 ehebrecherischen Mysterien des Eros und der Aphrodite! Daher Zeus,
-der hinter den Weibern herrast und den Ganymedes liebt, &lt;und&gt; das
+der hinter den Weibern herrast und den Ganymedes liebt, <add>und</add> das
 Mythengefasel von den Göttern, die die Lust lieben
 Leidenschaften! Aller dieser (Dinge) Ursache aber war der Tod. Denn
 sie glaubten, daß der Tod das Ende und die Vollendung des Alls, die Auflösung <lb n="25"/>
 und die Vernichtung der Seelen zumal und der Leiber sei, und
 daß es kein anderes Leben gebe als das des Leibes
-&lt;und&gt; führten (daher) ein Leben schlechter als
+<add>und</add> führten (daher) ein Leben schlechter als
 Tiere.</p>
 <p>Mit ihnen hatte Mitleid der König des Alls, der Logos Gottes, <lb n="30"/>
 <note type="footnote">1—5 vgl. Laus 212 32—213 2 5—24 = Laus 213 2—18</note>
@@ -4863,22 +5731,22 @@ nach <foreign xml:lang="abbr">ABBREV</foreign> 22 „und" &lt; Σ 1. <foreign xm
 ἀσελγῆ μύθων ἀναπλάσματα L 28 „und" &lt; Σ l. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.158"/>
-&lt;und&gt; auf den freundlichen Wink seines Vaters eilte er, *um ihnen zu
-helfen, &lt;und&gt; ersann wie ein sehr freundlicher König *die
+<add>und</add> auf den freundlichen Wink seines Vaters eilte er, *um ihnen zu
+helfen, <add>und</add> ersann wie ein sehr freundlicher König *die
 des Todes durch eine menschliche Natur. Obwohl er selbst das Leben
-und der Logos Gottes und die Kraft Gottes war, so beschloβ er dennoch,
+und der Logos Gottes und die Kraft Gottes war, so beschloß er dennoch,
 <lb n="5"/> nicht ohne den (Menschen), dem geholfen wurde, das zu widerlegen, was
 den Menschen furchtbar war. Deshalb benutzte er eine menschliche
 Waffe und einen sterblichen Leib, er der unkörperlich war, und besiegte
 den Tod durch das Sterbliche. Daher wurde eben sein erstes Mysterium
-des Leibes gemacht, daher das Siegeszeichen des Kreuzes, daher hieβ die
+des Leibes gemacht, daher das Siegeszeichen des Kreuzes, daher hieß die
 <lb n="10"/> Erinnerung an das ewige unsterbliche Leben „sein ächtnis“. Er
 gebrauchte also eine sterbliche Waffe und zeigte jedermann ein großes
 Wunder, indem er ein Siegeszeichen der Unsterblichkeit wider den Tod
 aufstellte. Denn er überließ das Sterbliche dem Fraß des Tieres
 dem Tode), das aber wurde sogleich ans Holz des Kreuzes geheftet.
 <lb n="15"/> damit die sterbliche Natur von jedermann erkannt würde und niemandem
-weder von den Menschen noch von den Dämonen noch von <note type="marginal">Σ11</note>
+weder von den Menschen noch von den Dämonen noch von <milestone unit="altnumbering" n="115"/>
 den besseren Kräften verborgen sei, was geschah.
 genau das Sterbliche sehen, wie es gleichsam in einem großen Theater
 die eigene Natur bekannte, damit hinterher der Tod komme wie ein
@@ -4887,7 +5755,7 @@ nach dem Tode die Kraft des Lebens komme und wiederum jedermann
 den Sieg wider den Tod hinstelle, indem sie das Sterbliche unsterblich
 zeigt. Es verließ also auf kurze Zeit den Leib die Kraft
 Gottes, die ihn beherrschte. Der (Leib) aber wurde ans Holz gehängt
-<lb n="25"/> und war &lt;nach&gt; kurzer Zeit tot. Aber keineswegs war der Logos, der
+<lb n="25"/> und war <add>nach</add> kurzer Zeit tot. Aber keineswegs war der Logos, der
 Lebendigmacher aller, das Tote, sondern das Sterbliche bekannte seine
 eigene Natur. Und darauf wurde das Tote, das jetzt vom Tode beherrscht
 ward, von den Menschen herahgenommen und der gebräuchlichen
@@ -4919,10 +5787,13 @@ auferstanden wäre, so wäre er
 nachdem er wahrhaftig (ans Kreuz) erhöht und
 war Τι· in (kurzer) Zeit den Tod wahrhaftig erduldet hatte, dann erst
 zeigte der Logos Gottes, der Lebendigmacher aller, die allen Menschen <lb n="15"/>
-aufbewahrte Hoffnung durch die Wiedergeburt des Sterblichen.
-LXII. Was also geschah nachdem? Ich möchte dir
+aufbewahrte Hoffnung durch die Wiedergeburt des Sterblichen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="62">
+<p>Was also geschah nachdem? Ich möchte dir
 mehr sein für das, was geschah. *Diejenigen aber, die
-<note type="marginal">Σ116</note> sahen, sie möchten bessere, glaubwürdigere Zeugen sein,
+<milestone unit="altnumbering" n="116"/> sahen, sie möchten bessere, glaubwürdigere Zeugen sein,
 ihr Blut und durch ihr Leben, durch den Anblick der Taten die Wahrheit <lb n="20"/>
 bestätigten und die ganze Welt durch die Kraft
 sie Zeugnis ablegten, mit der von ihnen verkündigten Frömmigkeit erfüllten.
@@ -4956,9 +5827,13 @@ brachten.</p>
 <p>Fernerhin fürchteten sie sich nicht mehr wie früher
 <lb n="10"/> sondern lachten viel und kräftig im Spiel mit dem Schreckmittel (des
 sodaß sie sogar dem Tode nachjagten aus der Liebe
-Leben. LXIII. Daher entstand fortan den Menschen Fürsorge
+Leben.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="63">
+<p>Daher entstand fortan den Menschen Fürsorge
 für ein heiliges und keusches Leben und Eifer für
-an Gott und den Logos &lt;und&gt; viele &lt;Bemühung&gt;
+an Gott und den Logos <add>und</add> viele <add>Bemühung</add>
 <lb n="15"/> Frömmigkeit und Abkehr vom Bösen und Gottlosen.
 dies, sondern auch über das Leben nach dem Tode wurden fortan bei
 jedermann wahre Gedanken erregt und richtiges und wahres Denken
@@ -4966,7 +5841,11 @@ jedermann wahre Gedanken erregt und richtiges und wahres Denken
 änderte sich seitdem das ganze Geschlecht der Menschen durch unaussprechliche
 <lb n="20"/> Worte zur Vorzüglichkeit, spuckte
 zertrat die unwürdigen Gesetze der Dámonen und
-den Vätern Vátern her überlieferte Verirrung. LXIV. Daben wurden die <note type="marginal">Σ117</note>
+den Vätern Vátern her überlieferte Verirrung.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="64">
+<p>Daben wurden die <milestone unit="altnumbering" n="117"/>
 Menschen fortan in der himmlischen Lehre und in den Worten der
 Gotteserkenntnis unterrichtet, sodaß sie die mit den leiblichen
 <lb n="25"/> sichtbare Welt nicht mehr anstaunten (und verehrten), noch, indem sie
@@ -4974,12 +5853,20 @@ nach oben blickten und Sonne, Mond und Sterne sahen, bis zu ihnen
 ihre Bewunderung erhoben (und sie darauf beschräkten),
 wurden belehrt, den jenseits von diesen (Waltenden), den Verborgenen
 und Unsichtbaren, den Schöpfer alles dessen, was existiert,
-<lb n="30"/> des Alls, zu bekennen und ihn allein zu fürchten. LXV. Fernerhin
+<lb n="30"/> des Alls, zu bekennen und ihn allein zu fürchten.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="65">
+<p>Fernerhin
 glaubte, wer in der neuen Lehre erzogen war, nicht mehr wie früher,
 ß die üssige, ängliche, seelen- und vernunftlose
 noch die στοιχεῖα: Erde, Wasser, Luft und Feuer ötter seien, da
 ihm gelehrt war, daß die Vörzüglichkeit seiner
-<lb n="35"/> ist als sie. LXVI. Fernerhin war er nicht mehr wie früher
+<lb n="35"/> ist als sie.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="66">
+<p>Fernerhin war er nicht mehr wie früher
 <note type="footnote">18—30 = 222 11—19 20 ff. vgl. Euseb. Hist. eccles. X 4 16</note>
 <note type="footnote">10 „im Spiel“ vgl. u. S. 162 17 13 „und Erinnerung an Gott und viele
 (l.Sing.) Rede πολυλογία?) über die wahre ömmigkeit“ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign>
@@ -4992,32 +5879,52 @@ besiegt — damals aber war er besiegt worden, ohne zu siegen
 — noch machte er (sie) sich ferner zu Göttern, da ihm
 das Böse und alle böse Lust und Torheit mit
 Denken und aus seiner Seele auszurotten, sodaß er nicht einmal wagte, <note type="marginal">5</note>
-ein Weib in schändlicher Lust anzublicken. LXVII.
-er nicht mehr wie früher über den Dolmetscher seiner Seele (d.
-Körper), noch wagte er ihn Gott zu nennen, noch nannte er
+ein Weib in schändlicher Lust anzublicken.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="67">
+<p>Fenerhin staunte
+er nicht mehr wie früher über den Dolmetscher seiner Seele (d. h. den
+Körper), noch wagte er ihn Gott zu nennen, noch nannte er jetzt seinen
 Geist Athene, noch andere (Dinge) dem entsprechend, sondern er erkannte
 an und segnete (pries) allein den, der jenseits von allem ist, den <lb n="10"/>
-göttlichen Logos, den Künstler des Alls, die
-seinen Erlöser. LXVIII. Fernerhin nannte er nicht mehr, noch
-an wie früher als Heroen und Götter
+göttlichen Logos, den Künstler des Alls, die Weisheit des Allgottes als
+seinen Erlöser.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="68">
+<p>Fernerhin nannte er nicht mehr, noch rief er
+an wie früher als Heroen und Götter sterbliche Menschen, die in
 schimpflichem Ausgang aus dem Leben schieden und dem Tode Macht
 über ihr Leben gewährten, sondern er bekannte ihn allein, der besser ist <note type="marginal">15</note>
 als der Tod, *den Sieger, der das Siegeszeichen wider die Macht des
-Todes (in den Händen) hält,
-er nicht mehr wie früher die seelenlosen Götzen
-die unvernünftige Natur *der Tiere
-Σ 118 sondern er lachte über den Irrtum seiner Vorfahren und wandte sein <lb n="20"/>
+Todes (in den Händen) hält, aks seinen Erlöser.</p>
+</div>
+  
+<div type="textpart" subtype="chapter" n="69">
+<p>Fernerhin staunte
+er nicht mehr wie früher die seelenlosen Götzen an, noch verehrte er
+die unvernünftige Natur *der Tiere in widernatürlicher Dämonenfurcht,
+<milestone unit="altnumbering" n="118"/>sondern er lachte über den Irrtum seiner Vorfahren und wandte sein <lb n="20"/>
 Angesicht ab von ihrer Art (der Verehrung), die ohne Gotteserkenntnis
-und ohne (Gottes)lehre (war). LXX. Fernerhin staunte er nicht mehr
-wie früher das Bild böser Dämonen
-irdischer Geister, (den Satan), der durch die mächtige Macht
+und ohne (Gottes)lehre (war).</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="70">
+<p>Fernerhin staunte er nicht mehr
+wie früher das Bild böser Dämonen an, noch die irrige Halluzination
+irdischer Geister, (den Satan), der durch die mächtige Macht des Einen
 Logos, des önigs, gebunden ist, *da ihm gelehrt ist, durch sie das <note type="marginal">25</note>
 ganze Geschlecht der den Menschen nachstellenden (Dämonen) aufzulösen
 und zu vernichten und aus den Leibern und Seelen eben jene
-Schäden zu vertreiben. LXXI. Fernerhin verunreinigte er
-mehr wie früher durch durch Libationen und Fett, noch durch
-noch durch Opfer unvernünftiger Tiere, wieviel
-sich an Menschenmorden und Menschenopfern, da er<note type="marginal">30</note> belehrt ist, daß
+Schäden zu vertreiben.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="71">
+<p>Fernerhin verunreinigte er sich nicht
+mehr wie früher durch durch Libationen und Fett, noch durch Blut und Opfer
+noch durch Opfer unvernünftiger Tiere, wieviel weniger ergötzte er
+sich an Menschenmorden und Menschenopfern, da er belehrt ist, daß <note type="marginal">30</note>
 Gott nichts bedarf, noch sich freut über die ὕλη des Leibes, noch über
 den Rauch des irdischen Opfers, sondern nur an einem erleuchteten
 <note type="footnote">6 vgl. Matth 528 24 vgl. Matth 12 29</note>
@@ -5031,27 +5938,41 @@ Eusebius III*.</note>
 Verstande, an Reinheit der Seele und Heiligkeit des Lebenswandels,
 *an rauchlosen, unblutigen Opfern, deren Darbringung der Erlöser
 in der ganzen Menschenwelt zu seinem Gedächtnis durch
-Worte angeordnet hat. LXXII. Fernerhin erdreistete er sich nicht mehr
-<lb n="5"/> wie früher, die Speisen des Leibes und die Trunkenheit, noch
-und seine Leidenschaften Götter zu nennen, da ihm durch
-seines Erlösers gelehrt ist, seine Glieder auf Erden
-Fernerhin wurde er nicht mehr erregt, wenn er vom Tode hörte, noch
-fürchtete er die Auflösung seiner Seele
+Worte angeordnet hat.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="72">
+<p>Fernerhin erdreistete er sich nicht mehr
+<lb n="5"/> wie früher, die Speisen des Leibes und die Trunkenheit, noch die Lust
+und seine Leidenschaften Götter zu nennen, da ihm durch die Worte
+seines Erlösers gelehrt ist, seine Glieder auf Erden zu töten.</p>
+</div>
+  
+<div type="textpart" subtype="chapter" n="73">
+<p>Fernerhin wurde er nicht mehr erregt, wenn er vom Tode hörte, noch
+fürchtete er die Auflösung seiner Seele mitsamt dem Leibe, noch
 <lb n="10"/> nannte er den Tod Gott, sondern er bekannte nur den Einen, der oberhalb
 von allem (ist), den lebendig machenden Logos Gottes als seinen
 öser und als den Besieger des Todes.</p>
-<p>LXXIV. Mit so viel frommen Lehren also ist der bewaffnet, der in
+</div>
+
+<div type="textpart" subtype="chapter" n="74">
+<p>Mit so viel frommen Lehren also ist der bewaffnet, der in
 der neuen Lehre erzogen ist, die er nicht einmal denen preisgibt, die
-<lb n="15"/> mit Gott wider die Wahrheit zu kämpfen wagen, sondern er
+<lb n="15"/> mit Gott wider die Wahrheit zu kämpfen wagen, sondern er steht fest
 im Geist gegen Feuer und Eisen, ist standhaft gegen wilde Tiere, gegen
 die Tiefen des Meeres und gegen die übrigen Schrecken des Todes. Es
-spielen mit dem Tode, der früher furchtbar war und von dem
-man sich scheute, (solche, die) Kinder und Weiber ihrer Natur nach <note type="marginal">Σ119</note>
+spielen mit dem Tode, der früher furchtbar war und von dem zu hören
+man sich scheute, (solche, die) Kinder und Weiber ihrer Natur nach <milestone unit="altnumbering" n="119"/>
 <lb n="20"/> (sind). Barbaren aber und Griechen zumal, die inbetreff des unsterblichen
 Lebens volle Überzeugung durch die Auferstehung unsers Erlösers
-gewonnen haben, jagen einem Leben vorzüglicher
+gewonnen haben, jagen einem Leben vorzüglicher Weisheit und
 Gottesfurcht nach, indem sie das Siegeszeichen wider den Tod und das
-ewige, künftige Leben ihrem Erlöser
+ewige, künftige Leben ihrem Erlöser zuschreiben.</p>
+</div>
+  
+<div type="textpart" subtype="chapter" n="75">
+<p>Deswegen
 <lb n="25"/> handelt fortan eben dasselbe Geschlecht der vernünftigen Menschen
 — dem ja deswegen zu teil geworden ist, auf Erden zu wohnen —
 (handelt) eben dasselbe seiner Natur gemäß, *da es gelehrt ist,
@@ -5060,7 +5981,11 @@ pheten *zu entsprechen, die früher vor Myriaden Jahren
 <lb n="30"/> „Es sollen sich erinnern und umkehren zum Herrn, ihrem
 Gott, alle Enden der Erde und vor ihm niederfallen alle Familien der
 Völker; denn dem Herrn gehört das Reich und
-der Völker.“ LXXVI. Daher bestehen in der
+der Völker.“</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="76">
+<p>Daher bestehen in der
 (Lehr)orte und Schulen und (daher) werden die Worte Gottes und die
 <note type="footnote">3 vgl. Luk 22 19 I Kor 11 25 7 vgl. Kol 35 30 = Ps 22 (LXX 21)28 f.
 33 ᾖ. vgl. Laus 22428 222 22</note>
@@ -5071,9 +5996,17 @@ der Völker.“ LXXVI. Daher bestehen in der
 
 <pb n="v.3.pt.2.p.163"/>
 Lehren eines keuschen und gottestürchtigen Lebenswandels in die Ohen
-aller Völker verkündigt. LXXVII. Daher ehren in jeder stadt und an
+aller Völker verkündigt.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="77">
+<p>Daher ehren in jeder stadt und an
 jedem Orte Scharen von (über)all (her) den Logos Gottes, den lebendigmacher
-aller, mit Siegeshymnen. LXXV III. Daher bringt auch das
+aller, mit Siegeshymnen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="78">
+<p>Daher bringt auch das
 Menschengeschlecht dem Allkönig Gott Gesänge dar, die mit denen der <lb n="5"/>
 Engelscharen im Himmel übereinstimmen. Fortan senden zumal mit
 denen, die um den allerhöchsten Gott kreisen: den Geistern verständigen,
@@ -5086,7 +6019,9 @@ Guten. Was (früher) niemals stattfand — jetzt läßt das ganze Geschlecht
 der Menschen in der ganzen Menschenwelt die Gott, dem König es
 Alls, schuldige Frucht an jedem Tage zu denselben Stunden und in den <lb n="15"/>
 gleichen Zeiten wie auf Eine Verabredung *sprießen.</p>
-<note type="marginal">Σ120</note> <p>LXXIX. Jetzt sind die Familien der Dämonen und die Mythen der
+</div>
+<milestone unit="altnumbering" n="120"/> <div type="textpart" subtype="chapter" n="79">
+<p>Jetzt sind die Familien der Dämonen und die Mythen der
 Götter, die längst vernichtet sind, bald vergessen, erneut aber ist bei
 jedermann und verjüngt das Wort Christi. Jetzt werden die göttlichen
 Gesetze und Lektionen auf der ganzen Erde verkündigt und machen alle <lb n="20"/>
@@ -5119,15 +6054,19 @@ Christi, sind in denselben (Dingen) weise und allzumal übt, den Tod zu
 Hoffnung durch die ßung des Logos, unsers ösers, dar. Aber sie
 haben auch gelernt, ß sie das unsterbliche Leben der Seele in der Wohnung
 des ölbes und das Reich Gottes empfangen üden, das er als
-ein Pfand denen ß, die von hier (dieser Erde) Lebewohl
+ein Pfand denen ß, die von hier (dieser Erde) Lebewohl gesagt
 <lb n="10"/> haben. Eben durch Werke ätigte ihr öser die Verheißung:
-durch den Kampf mit dem Tode, wodurch er seinen üngern die
+durch den Kampf mit dem Tode, wodurch er seinen üngern die Nichtigkeit
 des bei jedermann ürchteten Todes zeigte und das von ihm
 ihnen versprochene Leben ihren Augen durch offenkundigen Anblick
 hinstellte, damit sie es ähen, und sein Bild zum Erstling unserer Hoffnung
-<lb n="15"/> sowohl auf ein Leben in änglichem Leibe als auf die Unsterblichkeit Σ <lb n="121"/>
+<lb n="15"/> sowohl auf ein Leben in änglichem Leibe als auf die Unsterblichkeit <milestone unit="altnumbering" n="121"/>
 Sterblichkeit der Seele und auf die engelgleiche ät durch die
-Auferweckung machte. LXXX. Die ösenden und der Welt helfenden
+Auferweckung machte.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="80">
+<p>Die ösenden und der Welt helfenden
 Taten der Offenbarung des öttlichen Logos unter den Menschen sind
 also diese.</p>
 <lb n="20"/> <p>Wenn aber jemand will, ß zum Überfluß auch Myriaden andere
@@ -5137,16 +6076,18 @@ Von diesen will ich wenige voraussagende Worte über die Taten, die
 von ihm geschehen sollten, die er zum Beweise seiner Gottheit vorher
 <lb n="25"/> ündigte, aus den Schriften seiner ünger ählen und als Schluß
 jenen vorlegen, die den Anfang meines Sermons nicht anerkennen.</p>
-<p>Zu Ende ist das dritte Buch des äsareensers.</p>
+<note>Zu Ende ist das dritte Buch des äsareensers.</note>
 <note type="footnote">1 vgl. Gal 328 Kol 3 11</note>
 <note type="footnote">9 „Lebewohl gesagt haben"] <foreign xml:lang="abbr">ABBREV</foreign> vermutlich = συντάττεσαι 27 Die
 Unterschrift stammt nicht von Eusebius her</note>
+</div>
 </div>
 
  <div type="textpart" subtype="book" n="4">
 <pb n="v.3.pt.2.p.165"/>
 <head>Das vierte Buch des äsareensers.</head>
-<note type="marginal">Σ122</note> <p>I. ön ist es, fortan von dem gemeinsamen öser aller (selbst)
+<milestone unit="altnumbering" n="122"/> <div type="textpart" subtype="chapter" n="1">
+<p>Schön ist es, fortan von dem gemeinsamen öser aller (selbst)
 zu ören, der mit den Menschen redete und nach Art eines guten Vaters
 mit seinen öhnen gleichsam Kind ward und durch das äß, das er nahm,
 wie durch einen Dolmetscher Antworten gab, soweit es die Natur der <lb n="5"/>
@@ -5168,13 +6109,13 @@ oder Mannes, ob es die Stimme eines Weisen und ünftigen oder <lb n="20"/>
 im Gegenteil eines Toren und Idioten ist, äß aber auch: selbst
 wenn wir ällig nicht vor Augen haben och sehen jene göttlichen
 Taten, die der öttliche Logos vollbrachte, als er auf Erden seinen
-Umgang hielt, sondern selbst (wenn wir auch nur) &lt;urteilen&gt; aus der
+Umgang hielt, sondern selbst (wenn wir auch nur) <add>urteilen</add> aus der
 Lehre seiner eigenen Worte, deren Stimme seltsam ist und das gemeine <lb n="25"/>
 Denken übersteigt, und aus dem Vorherwissen der ünftigen Dinge
 die er voraussagte, und aus dem was er auch in äteren Zeiten zu Zeiten
 tun versprach, und aus der üllung der vorausgesagten Dinge, *deren
 Vollendung bis jetzt vor unseren eigenen Augen infolge seiner Kraft
-<note type="marginal">Σ123</note> gewirkt wird, — äß) ist nicht gering der Beweis, der sich inbetreff <lb n="30"/>
+<milestone unit="altnumbering" n="123"/> gewirkt wird, — äß) ist nicht gering der Beweis, der sich inbetreff <lb n="30"/>
 der Dinge ergibt, welche seine Gottheit bezeugen. Denn die
 von ihm geschehenen Wunder verteilen sich auf (zwei) Zeiten: auf die-
 <note type="footnote">24 Man ßt ein Verbum, etwa <foreign xml:lang="abbr">ABBREV</foreign> 28 „und deren" Σ str. (??)</note>
@@ -5212,9 +6153,12 @@ noch nicht bestanden und noch nicht ins ßtsein der Menschen getreten,
 <lb n="30"/> (wohl) aber von ihm öttlichem Vorherwissen
 und ür ätere Zeiten überliefert waren und bis jetzt in unserer eigenen
 Zeit sichtbar sind, (sie) aus folgendem kennen zu lernen, ist tunlich.</p>
-<p>II. Es gab (einmal) einen ühmten Mann im Heere, der einen
+</div>
+   
+<div type="textpart" subtype="chapter" n="2">
+<p>Es gab (einmal) einen ühmten Mann im Heere, der einen
 Rang und eine Machtstellung bei den ömern inne hatte. Da sein geliebter
-<lb n="35"/> Sklave, dem die Glieder ähmt waren, zu Hause <note type="marginal">Σ124</note>
+<lb n="35"/> Sklave, dem die Glieder ähmt waren, zu Hause <milestone unit="altnumbering" n="124"/>
 und da er sah, welche äfte unser öser an anderen zeigte, wie er
 <note type="footnote">33—S 167, 8 = 4. ück der griech. Theoph. 33 vgl. Matth 85 ff.</note>
 <note type="footnote">14 streiche <foreign xml:lang="abbr">ABBREV</foreign> vor <foreign xml:lang="abbr">ABBREV</foreign> 21 lies <foreign xml:lang="abbr">ABBREV</foreign> vgl. Σ 13826 f. 35 „geliebter
@@ -5226,7 +6170,7 @@ da er im Geiste urteilte, ß das Wunder keineswegs von Menschen
 sei, so nahte er sich ihm wie einem Grotte, indem er nicht auf das sicht-
 bare äß des Leibes blickte, durch das er den Umgang mit den
 Menschen hielt, sondern auf den unsichtbaren Gott, der durch das Sterbliche <lb n="5"/>
-die eigene üchtigkeit offenbarte. &lt;Deswegen&gt; fiel er nieder, nieder,
+die eigene üchtigkeit offenbarte. <add>Deswegen</add> fiel er nieder, nieder,
 huldigte ihm, bat und flehte ändigst, auch selber ür seinen Sklaven
 der Hilfe von Gott teilhaftig zu werden. Als unser öser zu ihm
 sagte: „Ich will kommen und ihn heilen", antwortete ihm der Chiliarch
@@ -5247,8 +6191,11 @@ hinausgehen." Dann nach diesen Worten sagte er zum Chiliarchen:
 „Gehe hin, wie du geglaubt hast, wird dir geschehen. Und sein Sklave
 ward geheilt seit dieser Stunde. Und als sich der Chiliarch nach <lb n="25"/>
 seinem Hause wandte, fand er in derselben Stunde seinen Sklaven
-gesund."
-III. Mit welcher Vollmacht also die Stimme unseres ösers hervorging
+gesund."</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="3">
+<p>Mit welcher Vollmacht also die Stimme unseres ösers hervorging
 und welche üglichkeit er gezeigt hat und mit velcher
 Kraft er üllt war und mit welcher Freundlichkeit und Geneigtheit <lb n="30"/>
 zum Wohltun, ß er bereitwilligst sein Kommen verhieß, welcher
@@ -5263,9 +6210,9 @@ Th. gr.</note>
 
 <pb n="v.3.pt.2.p.168"/>
 geglaubt hast, wird dir geschehen", und ß er zugleich mit dem
-Worte auch seinem Kinde die Heilung gab &lt;und sofort von der <lb n="125"/>
+Worte auch seinem Kinde die Heilung gab <add>und sofort von der <milestone unit="altnumbering" n="125"/>
 Krankheit befreite ihn, der binnen kurzem in der Gewalt des Todes
-gewesen wäre,&gt; wie sollte das nicht beweisen, ß Wahrheit Gott
+gewesen wäre,</add> wie sollte das nicht beweisen, daß in Wahrheit Gott
 <lb n="5"/> durch menschliche Stimme redete? Wenn aber jemand dies ür schwer
 glaublich ält wegen des Übermaßes des Wunders, so ürde er dennoch
 nicht geziemend die Vorhersagung als Vorwand gebrauchen önnen, da
@@ -5280,7 +6227,7 @@ Gegenden des Ostens und im Sonnenuntergang wohnen, die durch die
 ürdigt werden mit den Vorfahren der äer. Weil aber auch
 der Vorfahr jener, (eben) der gepriesene Abraham, der von ötzendienerischen
 ätern abstammte, sein Leben änderte, von dem Irrtum
-der vielen Götter &lt;zurückwich&gt; und Einen über alles (regierenden) Gott
+der vielen Götter <add>zurückwich</add> und Einen über alles (regierenden) Gott
 <lb n="20"/> erkannte, *so sagte dieser (Jesus) voraus, ß ihm und seinen Kindern,
 Isaak und Jakob, Myriaden gleich sein ürden in der ganzen Menschenwelt,
 und (zwar) besonders diejenigen ölker, die im Osten, und diejenigen
@@ -5309,7 +6256,7 @@ gottgeliebten Männer zu sein, ausgestoßen sind nicht nur aus
 dem Reiche Gottes, sondern auch aus ihrer eigenen heiligen und königlichen
 Hauptstadt, in welcher sie allein, wie das Gesetz es bestimmte, ihren <lb n="5"/>
 glänzenden Gottesdienst vollziehen sollten, und (wie) sie Knechte wurden
-<note type="marginal">Σ126</note> aus Freien, früher Söhne vorzüglicher Väter, und vermischt mit fremden
+<milestone unit="altnumbering" n="126"/> aus Freien, früher Söhne vorzüglicher Väter, und vermischt mit fremden
 Völkern — was ihnen nicht gestattet war — in einem Lande, das nicht
 ihr eigen war, umherirrten, sodaß ihnen nicht einmal erlaubt war, aus
 der Ferne das Land ihrer Verehrung zu sehen. Ohne Führer und ohne <lb n="10"/>
@@ -5320,7 +6267,11 @@ Propheten bei ihnen wie früher, noch eine Offenbarung wie früher, noch
 eine Hilfe oder ein göttliches Werk. All dies kam durchaus nicht bevor, <lb n="15"/>
 sondern nachdem unser Erlöser sein Antlitz von ihnen abgewandt
 hatte, über sie, entsprechend seinen Prophezeiungen. Dies über die
-Juden also derart. IV. Anstatt des Einen Chiliarchen aber, der in jener
+Juden also derart.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="4">
+<p>Anstatt des Einen Chiliarchen aber, der in jener
 Zeit sich unserm Erlöser nahte, kam eine unsagbare Anzahl von Leuten
 aus allen Völkern, nicht Chiliarchen allein, sondern auch die Menge der <lb n="20"/>
 römischen Truppen wie auch Myriaden von Herrschern und ἡγεμόνες,
@@ -5336,7 +6287,11 @@ geben soll, die im Sonnenaufgang wohnen, und wie durch die Worte <lb n="30"/>
 unsers Erlösers bei diesen Weiber, liebende Jungfrauen und Männer
 zur vollendeten Heiligkeit übergehen und zur Enthaltsamkeit eines
 philosophischen und züchtigen Lebens, und (wie) Myriaden Bekenner
-Gottes eben unter ihnen leben, V. und wie eben sie den, der vom
+Gottes eben unter ihnen leben,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="5">
+<p>und wie eben sie den, der vom
 Samen Abrahams aufleuchtete, den Christus Gottes bekennen und durch <lb n="35"/>
 <note type="footnote">18—27 = 5. Bruchstück der griech. Theoph. S. 17 1—9</note>
 <note type="footnote">4 „heiligen“] ἱερᾶς Th. gr. 11 „sich ablösend“] „durch Überlieferung“ Σ
@@ -5346,9 +6301,9 @@ mißverstandenes ὡς</note>
 <pb n="v.3.pt.2.p.170"/>
 neue Geburt in ihm Kinder Abrahams geworden sind und eben das
 vorhersagende Wort unsers ösers versiegeln, (wie) gerade ebenso
-aber auch in den westlichen Teilen der Welt alle Spanier und Gallier <note type="marginal">Σ127</note>
-und (wie man) &lt;in&gt; den ändern der Mauren und Afrer, sogar im Ozean:
-<lb n="5"/> [und] in Britannien Christus bekennt und den Gott Abrahams, lsaaks und
+aber auch in den westlichen Teilen der Welt alle Spanier und Gallier <milestone unit="altnumbering" n="127"/>
+und (wie man) <add>in</add> den ändern der Mauren und Afrer, sogar im Ozean:
+<lb n="5"/> <del>und</del> in Britannien Christus bekennt und den Gott Abrahams, lsaaks und
 Jakobs anerkennt und auch in Gebeten anruft und als Teilhaber jener
 äter) in der Gottesverehrung erscheint — wenn also jemand eben
 dies zu Herzeu nimmt, dann wird er verstehen, welches die Kraft des
@@ -5359,12 +6314,15 @@ dem Chiliarchen. Aber auch zu andern Zeiten, als er mit den üdischen
 Lehrern zusammen redete, prophezeite er dem Ahnliches und redete in
 dieser Weise: „ Wenn ihr sehen werdet Abraham, Isaak und Jakob und
 <lb n="15"/> die Propheten, alle im Reiche Gottes, euch aber hinausgeworfen, dann
-werden sie kommen von Morgen &lt;und Abend&gt;, von Westen und üden
+werden sie kommen von Morgen <add>und Abend</add>, von Westen und üden
 und werden zu Tische sitzen im Reiche Gottes." Eben diese (Worte)
 empfangen ihre ätigung offenbar durch die Bekehrung aller Völker
 zu dem über alles (waltenden) Gott. Dies also sagte er jenen über die
 <lb n="20"/> Bekehrung aller ölker zu dem über alles (waltenden) Gott.</p>
-<p>VI. Durch welche änner er bereit war, eilends die Berufung der
+</div>
+   
+<div type="textpart" subtype="chapter" n="6">
+<p>Durch welche änner er bereit war, eilends die Berufung der
 ölker zu veranstalten, kannst du aus der Schrift seiner Jünger lernen,
 die in dieser Weise lautet: „Da Jesus entlang ging am Landsee von
 äa, sah er zwei üder, Simon, genannt Petrus, und seinen Bruder
@@ -5387,7 +6345,7 @@ kommen" Σ 16 „und Abend"] καὶ δυσμῶν Lukas &lt; Σ lies <foreign x
 Simon gleich diesem prophetischen Wort geredet habe: Da Jesus ämlich
 viel Volks anlag, sagt er, sei er in eins der Schiffe gestiegen, das
 dem Simon örte, und als er darin ß, dolmetschte er her Menge.
-<note type="marginal">Σ128</note> Xach ügender Belehrung aber, weil es geziemend war, ß er auch
+<milestone unit="altnumbering" n="128"/> Xach ügender Belehrung aber, weil es geziemend war, ß er auch
 ein öttliches Werk zu seinen Worten ügte zur Hilfe derer, <lb n="5"/>
 die es sahen, befahl er dem Simon, seine Netze zum Fange auszuwerfen.
 Der aber sprach zu ihm: Die ganze Nacht haben wir gearbeitet, aber
@@ -5430,7 +6388,7 @@ und (indem) er ihnen dann ß, er werde sie zu Fischern und
 Herolden der Menschen machen, damit sie anstatt der Netze, die sie
 hatten, von ihm das Netz empfingen, das aus allerlei Worten der Gesetze
 <lb n="5"/> und Propheten und aus solchen seiner eigenen öttlichen
-Lehre gewebt war, und (damit) sie (es) in das Meer der Menschenwelt ürfen <note type="marginal">Σ129</note>
+Lehre gewebt war, und (damit) sie (es) in das Meer der Menschenwelt ürfen <milestone unit="altnumbering" n="129"/>
 und einfingen, soviele sie änden, indem sie ihre geistigen Netze mit
 jeder Art ünftiger Fische üllten. Aber dies waren, als man damals
 im Worte es örte, Phrasen und öne und nichts Das Work
@@ -5458,7 +6416,7 @@ sinken. Als dies aber so geschehen war, brachte er den Simon zum
 erschrecken, sagte unser öser zu ihm; denn noch ist es (Kinder)spiel
 und ein Bild des ünftigen. Denn dies sind stumme und unver-
 <note type="footnote">6 εἰς τὴν τοῦ ἀνθρωπείου βίου θάλατταν] „in das menschliche Meer der Welt"
-Σ 12 ὡς ἐν βραχεῖ χρόνῳ τὴν σύμπασαν &lt;ὁμοῦ&gt; ἀνθρώπων οἰκουμένην μυρία
+Σ 12 ὡς ἐν βραχεῖ χρόνῳ τὴν σύμπασαν <add>ὁμοῦ</add> ἀνθρώπων οἰκουμένην μυρία
 πλήθη τῶν σαγηνευθέντων . . . . κτήσασθαι] „daß er in kurzer Zeit die ganze
 Menschenwelt zumal ählige Scharen der Mengen (= συναχθέντων?) von diesen
 . . . . Menschen erwarb" Σ 14 πληρωθῆναί τε ἐκκλησιῶν πάντα τόπον Ἐλλήνων
@@ -5473,7 +6431,7 @@ Etwas äter also, das ßt vielmehr: augenblicklich jetzt auf der
 Stelle, wirst du ein Menschenfischer sein, wirst du von dieser üdenden,
 nutzlosen Fischerei ablassen, vielmehr ein Fischer ünftiger <lb n="5"/>
 Lebewesen anstatt der ünftigen werden und nicht mehr
-<note type="marginal">Σ130</note> aus den Tiefen des Meeres, sondern aus der salzigen Bitterkeit der Welt
+<milestone unit="altnumbering" n="130"/> aus den Tiefen des Meeres, sondern aus der salzigen Bitterkeit der Welt
 und aus den finstern Winkeln der Gottlosigkeit und Schlechtigkeit
 zum geistigen Licht und zur reinen Luft heraufziehen diejenigen, die
 von dir gefangen werden, das ßt vielmehr: du wirst sie zum Leben <lb n="10"/>
@@ -5498,7 +6456,7 @@ die ganze Nacht hindurch vor seiner Erscheinung viel arbeiteten, das
 hat der äische Mann, der Arme, der Barbar seiner Sprache nach,
 eben jener Simon getan. Ein Beweis aber ür das damals von Simon <lb n="30"/>
 Vollbrachte sind die bis jetzt leuchtenden Kirchen, die viel voller sind
-an geistigen Fischen als jene Fahrzeuge, wie es die ist &lt;zu&gt; Cäsarea in
+an geistigen Fischen als jene Fahrzeuge, wie es die ist <add>zu</add> Cäsarea in
 ästina, wie die zu Antiochien in Syrien, wie die in der Stadt der
 ömer. Denn man berichtet, ß Simon selber diese Kirchen und alle
 <note type="footnote">4 vgl. Luk 510 17 = Luk 510 28 vgl. Luk 55</note>
@@ -5515,7 +6473,7 @@ durch den zum ünger gewonnenen Markus ür sich auf. Während er
 ämlich selber in Italien und unter den ölkern weilte, machte
 <lb n="5"/> er seinen ünger Markus zum Lehrer und Fischer ür die in Ägypten. die
 Richte aber deinen Sinn auch auf die übrigen ünger unsers Erlösers,
-denen er ß, er werde sie zu Menschenfiscbern machen, und <note type="marginal">Σ131</note>
+denen er ß, er werde sie zu Menschenfiscbern machen, und <milestone unit="altnumbering" n="131"/>
 (denen) er sein Wort durch die Tat zeigte. Bis jetzt also schafft und
 wirkt derselbe, indem er überall auf Erden zugegen ist und die ganze
 <lb n="10"/> Menschenwelt mit seinen geistigen Netzen üllt und mit vernünftigen
@@ -5525,7 +6483,9 @@ der Menschen herausziehend, sie hinwendend an jedem Tage und zu
 jeder Stunde zu dem Lichte der von ihm ündeten Gotteserkenntnis.
 <lb n="15"/> Indem dies so mit unsern Augen gesehen wird, scheint es mir ein
 zweifelloses Zeugnis ür die Theophanie unsers Erlösers darzustellen.</p>
-<p>VII. Willst du aber auch das dritte Wort der öttlichen Stimme
+</div>
+<div type="textpart" subtype="chapter" n="7">
+<p>Willst du aber auch das dritte Wort der öttlichen Stimme
 ören, die vorhersagte, daß seine ünger in aller Welt leuchten würden,
 so öre auch dies. Es liegt aber in folgender Weise vor: „Ihr seid das
 <lb n="20"/> Licht der Welt. Eine Stadt, die auf einem Berge gebaut ist, kann
@@ -5547,7 +6507,7 @@ weise, eben jenen Fischern sagte er, ß sie das Licht der Welt sein
 <note type="footnote">1 „und"] καὶ „nämlich" Σ | „und eben" Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 4 „nämlich"] γὰρ &lt;
 vgl. zu Ζ. 1 6 ὅμοια δ’ ἂν εὕροι τις τῷ Πέτρῳ τὸν νοῦν ἐπιστήσας καὶ ἐπὶ
 τίον λοιπῶν . . . . μαθητῶν Th. gr. 10 πληρῶν ἐκ παντὸς γένους λογικῶν
-ἰχθύων βαρβάρων τε καὶ Ἑλλήνων, ἀνασπῶν &lt;ἐκ&gt; τοῦ τῆς κακίας βυθοῦ . . . .
+ἰχθύων βαρβάρων τε καὶ Ἑλλήνων, ἀνασπῶν <add>ἐκ</add> τοῦ τῆς κακίας βυθοῦ . . . .
 τῶν ἀνθρώπων ψυχάς, ἀνέλκων τε αὐτὰς ἐπὶ τὸ φῶς Th gr.</note>
 
 <pb n="v.3.pt.2.p.175"/>
@@ -5559,7 +6519,7 @@ als an die, die üher waren, ß er sogar einer herrlichen ätte <lb n="5"/>
 vor der Stadt ürdigt wurde, zu dem wie zu einem ßen Heiligtum
 und Tempel Gottes Myriaden Scharen des ömischen Reiches eilten.
 Wie sollte dies nicht die Wahrheit dessen ätigen, was er seinen
-<note type="marginal">Σ123</note> Jüngern sagte: „Ihr seid das Licht der Welt. So aber leuchtet ferner
+<milestone unit="altnumbering" n="132"/> Jüngern sagte: „Ihr seid das Licht der Welt. So aber leuchtet ferner
 auch der Name des Johannes, des Sohnes äi, den er beim Fischfang <lb n="10"/>
 mit seinem Vater und Bruder die Netze flicken sah und den er
 derselben Berufung und ßung ürdigte, in der ganzen Welt, und
@@ -5601,7 +6561,7 @@ seine Sache allein war es zu sagen: „Ich bin das Licht der Welt".
 Über ihn ist in Wahrheit geredet: „Er war das Licht, das in die Welt
 kam, das jedermann erleuchtet.“ Aber indem dies so gesagt und erfüllt
 wurde, siehe, wie er ferner auch seinen üngern sagte und und erklärte:
-<lb n="10"/> „Was ich euch in der Finsternis sage, sollt ihr im Lichte sagen, und <note type="marginal">Σ133</note>
+<lb n="10"/> „Was ich euch in der Finsternis sage, sollt ihr im Lichte sagen, und <milestone unit="altnumbering" n="133"/>
 was ihr ins Ohr ört, sollt ihr auf den ächern und
 ürchtet euch nicht vor denen, die den Leib öten, aber die Seele nicht
 öten önnen; ürchtet euch vielmehr vor dem, der Seele und leib verderben
@@ -5622,7 +6582,10 @@ Seele lehrte und ein Dogma der Philosophen in kurzen Worten darlegte.</p>
 zu Menschenfischern machen, und am Ende offenkundig prophezeite, sie
 <lb n="30"/> ürden sofort alle ölker mit (Hilfe) seiner Kraft zu jüngern machen, (wird)
 nach dem Evangelium des äus (beschrieben).</p>
-<p>VIII. Nach seiner Auferstehung von den Toten gingen alle
+</div>
+
+<div type="textpart" subtype="chapter" n="8">
+<p>Nach seiner Auferstehung von den Toten gingen alle
 zumal, denen es aufgetragen war, nach äa, wohin er ihnen
 gesagt hatte (zu gehen). „Und da sie ihn sahen, fielen einige nieder,
 andere aber zweifelten. Er aber trat zu ihnen, redete mit ihnen und
@@ -5641,7 +6604,7 @@ der ünger und die Vorsicht ihres Denkens, ß nicht alle ihn
 anbeteten, als sie ihn sahen, sondern (nur) die einen taten dies äubig
 und gern, die andern aber hielten ür jetzt ück, ß sie nicht
 leicht(sinnig) und schnell diesem Wunder zustimmten, sondern mit
-<note type="marginal">Σ134</note> reiflicher üfung und aller Vorsicht. Dann am Ende ßen auch sie <lb n="10"/>
+<milestone unit="altnumbering" n="134"/> reiflicher üfung und aller Vorsicht. Dann am Ende ßen auch sie <lb n="10"/>
 sich überzeugen, zogen aus zu allen Menschen und wurden selbst Prediger
 seiner Auferstehung. Da aber in der Schrift der Propheten mit
 Bezug auf ihn prophetisch gesagt ist: „Bitte von mir, so will ich dir
@@ -5649,7 +6612,7 @@ Bezug auf ihn prophetisch gesagt ist: „Bitte von mir, so will ich dir
 der Erde (reichen)," sagt er zu seinen üngern, als ob das prophetische <lb n="15"/>
 Zeugnis jetzt durch die Tat üllt ürde: „Mir ist jede Gewalt wie im
 Himmel (so) auch auf Erden gegeben.“ Denn die Herrschaft der
-im Himmel hatte er von Ewigkeit an inne, die &lt;Macht&gt; der Dinge
+im Himmel hatte er von Ewigkeit an inne, die <add>Macht</add> der Dinge
 Erden aber, sagt er, sei ihm jetzt gegeben vom Vater, entsprechend dem
 (Worte): „Bitte von mir, so will ich dir Völker zu deinem Erbe
 geben.“ Denn einst, wie Mose bezeugt: „Als der öchste
@@ -5683,7 +6646,7 @@ das bewahren, was er selber ihnen auftrug. Dies war es, was alle
 an und macht sie geneigt, zu fischen und herumzugehen bei allen
 ölkern und jedes Geschlecht der Menschen zu lehren, durch die Verheißung,
 die er ihnen gab, indem er sagte: „Siehe, ich bin bei each.“
-Denn diesem Worte der ßung ügte er die Tat hinzu, war mit <note type="marginal">Σ138</note>
+Denn diesem Worte der ßung ügte er die Tat hinzu, war mit <milestone unit="altnumbering" n="135"/>
 <lb n="10"/> öttlicher Kraft bei jedem einzelnen von ihnen, war allen zumal ärtig,
 schaffte und wirkte mit ihnen und äftigte das Sieges(werk),
 indem er sie zu Lehrern aller ölker in der von ihm überlieferten
@@ -5716,7 +6679,6 @@ Tb. gr. 14 „zögernd"] ὑπερθέμενοι lies <foreign xml:lang="abbr">
 Bernstein 24 „und bedachten" Σ 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.179"/>
-Die syrische Theophanie Buch IV. <lb n="179"/>
 der Tod. Deswegen auch überkam sie Furcht, wenn sie nicht gehorchten,
 sodaß sie daher die Gefahren mit ganzer Seele ertrugen, indem
 sie die ürgschaft des Lebens nach dem Tode vom Meister
@@ -5725,14 +6687,17 @@ indem sie durch Werke die ßungen ihres Meisters bestätigten. <lb n="5"/>
 Er aber ügte zu seinen Versprechungen an sie (noch) ein übriges Wort
 hinzu, und (noch) wunderbarer: er ährt es bis jetzt. Indem er zu
 ihnen sagt: „Siehe ich bin bei euch alle Tage", ügt er hinzu: „bis
-<note type="marginal">Σ136</note> ans Ende der Welt." Dies üllt er keineswegs nur an ihnen,
+<milestone unit="altnumbering" n="136"/> ans Ende der Welt." Dies üllt er keineswegs nur an ihnen,
 auch an allen denen, die ihnen folgten und eben von ihnen seine Lehre <lb n="10"/>
 empfingen, und auf der Stelle bis jetzt ist er allen denen nahe, die ihm
 zu üngern gewonnen werden. Deswegen ächst seine von ihm behütete
 Kirche alle Tage, wird ößer an Macht und mehrt sich und
 wird durch seine Kraft bis ans Ende der Welt gesammelt.</p>
-<p>Über die Bekehrung aller ölker zu Gott. Aus dem Evangelium des Lukas.</p> <lb n="15"/>
-<p>IX. Wiederum zu einer anderen Zeit nach der Auferstehung von
+<p>Über die Bekehrung aller ölker zu Gott. Aus dem Evangelium des Lukas.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="9">
+<lb n="15"/><p>Wiederum zu einer anderen Zeit nach der Auferstehung von
 den Toten erschien er anderen seiner ünger. Da sie noch zweifelten
 und nicht an ihn glaubten, brachte er folgende Worte vor und sagte:
 „Das sind die Reden, die ich zu euch gesagt habe, als ich noch bei
@@ -5763,7 +6728,7 @@ und verdolmetscht in alle Sprachen der Griechen und Barbaren,
 <lb n="5"/> sodaß seine Lehre von allen ölkern ört wurde und zur Bekehrung
 und ße Myriaden Scharen derer brachte, die üher in polytheistischem
 Irrtum und ötzenverehrung frevelhaft und ungeziemend lebten. Aber
-er befiehlt nicht, zuerst Vergebung und dann ße, sondern zuerst Buße <note type="marginal">Σ137</note>
+er befiehlt nicht, zuerst Vergebung und dann ße, sondern zuerst Buße <milestone unit="altnumbering" n="137"/>
 und dann Vergebung zu ünden. Denn denen, die eine lautere Buße
 <lb n="10"/> der üheren ünden zeigten, schenkte die Güte unsers Erlösers die
 Vergebung ihrer Taten, um derentwillen er auch den Tod auf sich nahm
@@ -5779,7 +6744,10 @@ der üheren ünden der Seele ündeten und so große Tüchtigkeit
 änner in der ganzen Menschenwelt wirksam ist.</p>
 <p>Wie seine *Taten ört und ündet werden in der ganzen welt.
 Aus dem Evangelium des äus und aus Markus.</p>
-<p>X. Als sich unser öser in Bethanien, einer Stadt nicht weit von
+</div>
+
+<div type="textpart" subtype="chapter" n="10">
+<p>Als sich unser öser in Bethanien, einer Stadt nicht weit von
 <lb n="25"/> Jerusalem, befand und bei einem gewissen Simon eingeladen war und
 dort zu Tische lag, nahm ein Weib eine Alabasterflasche voll Balsams,
 dessen Preis teuer war, trat herzu und ß es über seine Füße. Seine
@@ -5801,7 +6769,7 @@ die in der Nachbarschaft wohnten, — wie es wahrscheinlich
 ist, — das kannten, was geschah, sondern nur diejenigen, die zufällig
 zugegen waren. Dennoch aber sprach er sogleich dies große Wort
 und prophezeite, daß die von seinen Jüngern verfaßten Evangelien in <lb n="5"/>
-<note type="marginal">Σ138</note> der ganzen Welt ündigt werden sollten, und ügte die Tat sogleich
+<milestone unit="altnumbering" n="138"/> der ganzen Welt ündigt werden sollten, und ügte die Tat sogleich
 zu dem Worte hinzu, indem er sagte, daß mit seinen Taten im Evangelium
 auch das, was von diesem Weibe getan war, aufgeschrieben und
 geredet werden sollte in der ganzen Welt zu ihrem ächtnis. Daß
@@ -5813,7 +6781,10 @@ Dies also über diese. öre aber, was er über die Kirche verhieß.</p>
 <p>Wie er seine Kirche mit Namen ähnte, obwohl sie noch nicht bestand, <lb n="15"/>
 und wie er sagte, daß die Pforten des Todes sie niemals überwinden
 üren. Aus dem Evangelium Matthäus.</p>
-<p>XI. Als er einst seine ünger fragte, was die Menschen über ihn
+</div>
+
+<div type="textpart" subtype="chapter" n="11">
+<p>Als er einst seine ünger fragte, was die Menschen über ihn
 sagten, und sie ihm die Meinung vieler antworteten, fragte er sie zum
 zweiten Male: „Ihr (aber), was sagt ihr?" Als Simon zu ihm sagte: <lb n="20"/>
 „Du bist Christus, der Sohn des lebendigen Gottes", antwortete er ihm
@@ -5840,7 +6811,7 @@ Todes sie niemals besiegen ürden. Die üllung zeigte er besser als
 alle Worte (es darstellen önnen). Denn Myriaden *Verfolgungen und
 viele Arten des Todes ergingen über seine Kirche, vermochten aber
 <lb n="5"/> nichts wider sie. So zeigte die Prophezeiung eben in Taten offenkundig
-ihre Wahrheit durch die üllung. Dies war aber ein nicht geringes <note type="marginal">Σ139</note>
+ihre Wahrheit durch die üllung. Dies war aber ein nicht geringes <milestone unit="altnumbering" n="139"/>
 Vorherwissen, daß er jene Schar, die auf seinen Namen ündet werden
 sollte, „Kirche" nannte. Denn die Scharen der Juden ßen „Synagogen“,
 und zu der Zeit, wo er unter Menschen wandelte, weilte
@@ -5861,7 +6832,10 @@ bis jetzt üllt hat, er hat in der ganzen Menschenwelt durch
 öttliche Kraft den Bau und das Wachstum, seiner Kirche befördert.</p>
 <lb n="25"/> <p>Über die Spaltungen, die in den äusern und Familien bis jetzt wegen
 seiner Lehre stattfinden. Aus dem Evangelium des Matthäus.</p>
-<p>XII. „Denket nicht, ß ich gekommen sei, Frieden zu bringen
+</div>
+
+<div type="textpart" subtype="chapter" n="12">
+<p> „Denket nicht, ß ich gekommen sei, Frieden zu bringen
 auf die Erde; ich bin nicht gekommen, Frieden zu bringen, sondern
 das Schwert. Denn ich bin gekommen, zu entzweien einen Mann mit
 <lb n="30"/> seinem Vater, die Tochter mit ihrer Mutter, die Schwiegertochter mit
@@ -5883,7 +6857,7 @@ gegen die Schwiegermutter." Wer sollte da nicht staunen, daß
 nicht einmal das dem Vorherwissen unseres ösers verborgen
 was in jedem einzelnen Hause in fernen, äteren Zeiten bis jetzt
 üllt? Denn als ob er den Dingen selber nahe sei und in den
-<note type="marginal">Σ140</note> Wohnungen aller Menschen umherwandle, sagte er seinen üngern die <lb n="10"/>
+<milestone unit="altnumbering" n="140"/> Wohnungen aller Menschen umherwandle, sagte er seinen üngern die <lb n="10"/>
 (Dinge) voraus, die bis jetzt sich ereignen, Dinge, die bis dahin noch
 nicht existiert hatten und (noch) nicht waren zu der Zeit, wo er jene
 Worte sprach. Denn damals waren sie noch nicht Taten geworden, als sie
@@ -5922,7 +6896,7 @@ Tat ügte zu seinem Worte, ächlich zu dem, was geschrieben steht:
 <lb n="5"/> gibt.“ Indessen aber (wenn es) jetzt (auch ßt): „Ich bin nicht gekommen,
 Frieden auf die Erde zu bringen", so setzt er doch an einer
 andern (Stelle) seinen üngern auseinander und sagt: „Den Frieden lasse
-ich euch, meinen Frieden gebe ich euch. Nicht gebe auch ich ebenso <note type="marginal">Σ141</note>
+ich euch, meinen Frieden gebe ich euch. Nicht gebe auch ich ebenso <milestone unit="altnumbering" n="141"/>
 Heil, wie die Welt Heil gibt“, indem er in dieser Weise das Wissen
 <lb n="10"/> von Gott und die Liebe (zu ihm), die er bei seinen üngern förderte,
 und die Unerschrockenheit der Seele und die Klarheit und Festigkeit
@@ -5931,7 +6905,10 @@ des Verstandes benennt. Dies also auch über dies. Was er aber auch
 Folgendem zu prüfen</p>
 <lb n="15"/> <p>Was er im Gleichnis über das Volk der Juden prophezeite.
 Aus dem Evangelium des Matthäus</p>
-<p>XIII. Als in Jerusalem die ührer des Volkes der Juden, die
+</div>
+  
+<div type="textpart" subtype="chapter" n="13">
+<p>Als in Jerusalem die ührer des Volkes der Juden, die
 Hohenpriester und Schriftgelehrten gemeinsam versammelt waren, sagte
 er, ährend er im Tempel selber verweilte, was sie in Zukunft gegen
 <lb n="20"/> ihn sich erdreisten ärden, und das Verderben, das sie wegen dieser
@@ -5968,14 +6945,17 @@ und einem Volke gegeben werden, das üchte bringt.“ Dieses
 Gleichnis ist verwandt mit dem des Propheten Jesaja, bei dem es diese
 Form hat: „Einen Weinberg ß mein Geliebter auf dem Horn, an
 fettem Orte und er bearbeitete ihn, umgab ihn mit einem Zaun, pflanzte
-<note type="marginal">Σ142</note> *Reben darin und baute einen Turm in seine Mitte. Auch eine Kelter <lb n="15"/>
+<milestone unit="altnumbering" n="142"/> *Reben darin und baute einen Turm in seine Mitte. Auch eine Kelter <lb n="15"/>
 machte er in ihm und hoffte, daß er Trauben bringe, aber er brachte
 Heerlinge." Aber das (Gleichnis) bei dem Propheten hat den Weinberg
 beschuldigt, den er auch seinem Wesen nach verdolmetscht, indem er
 sagt: „Denn der Weinberg des Herrn Zebaoth ist das Haus Israel und
 der Mann aus Juda ist die neue und geliebte Pflanze. Sie hoffte auf <lb n="20"/>
-Recht, aber es ward Raub, auf Gerechtigkeit und siehe Wehklagen."
-XIV. Das Gleichnis unsers ösers aber ist ähnlich jenem des Propheten
+Recht, aber es ward Raub, auf Gerechtigkeit und siehe Wehklagen."</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="14">
+<p>Das Gleichnis unsers ösers aber ist ähnlich jenem des Propheten
 gesagt, damit es erkannt und üft ürde von denen, die zugegen
 waren und örten, aber es ist keineswegs über den Weinberg
 gesagt, da der Prophet die Weissagung über diesen vorwegnehmend <lb n="25"/>
@@ -6007,10 +6987,10 @@ mit dem Blute der Propheten, sondern sie öteten zuletzt auch den
 Sohn selbst — das ßt aber den Sohn Gottes — nicht aus Unwissenheit,
 sondern obwohl sie vollkommen und genau ßten, ß er der
 <lb n="10"/> Erbe sei. Dies aber sprach der öser vor seinem Leiden über sich
-selbst im ätsel und sagte die Zukunft im Vorauswissen vorasus. &lt;Er
-sagte&gt; dies &lt;aber&gt; während er im Tempel wandelte,
+selbst im ätsel und sagte die Zukunft im Vorauswissen vorasus. <add>Er
+sagte</add> dies <add>aber</add> während er im Tempel wandelte,
 Weinberges zu seiner Zeit: den Hohenpriestern, den Lehrern und den
-übrigen, die an der Spitze des Volkes standen, und setzte sie durch <note type="marginal">Σ143</note>
+übrigen, die an der Spitze des Volkes standen, und setzte sie durch <milestone unit="altnumbering" n="143"/>
 <lb n="15"/> das Gleichnis sehr deutlich in den Stand, den Urteilsspruch gegen sich
 selbst zu ällen. Er fragt sie also am ß der Parabel und sagt:
 „Wenn der Herr des Weinberges kommt, was wird er jenen Arbeitern
@@ -6050,10 +7030,13 @@ weissagte und zeigte. „Es wird aber einem anderen Volke gegeben
 werden, das üchte bringt": dies ist das Volk der Christen, das in der <lb n="10"/>
 ganzen örfung einer öttlichen ührung passende und würdige
 üchte in Taten und Worten täglich zeigt.
-<note type="marginal">Σ144</note> Über die Verwerfung der Juden zumal und über die Berufung der ölker
+<milestone unit="altnumbering" n="144"/> Über die Verwerfung der Juden zumal und über die Berufung der ölker
 und über diejenigen, die ürdig in seiner Kirche versammelt werden,
-und über das Ende eben dieser. Aus dem Evangelium des äus. <lb n="15"/>
-XV. Nach dem (soeben) ähnten Gleichnis schreibt das Wort göttlicher
+und über das Ende eben dieser. Aus dem Evangelium des äus. <lb n="15"/></p>
+</div>
+
+<div type="textpart" subtype="chapter" n="15">
+<p>Nach dem (soeben) ähnten Gleichnis schreibt das Wort göttlicher
 Schrift: „Da die Hohenpriester und die äqer siene Gleichnisse
 örten, erkannten sie, ß er über sie rede, und trachteten, ihn zu
 fassen, aber sie ürchteten sich vor dem Volke, weil sie ihn als einen
@@ -6083,14 +7066,18 @@ die geschickt und ötet wurden, und zuletzt wurde der Sohn des Weinbergbesitzers
 selbst er, ötet, ótet, wodurch das Volk der Juden, der Tempel,
 der Altar und die üdischen Herrscher angedeutet waren und die ersten
 <lb n="5"/> und letzten Propheten und zuletzt der Sohn Gottes, den die ösen
-Arbeiter, die an der Spitze des Volkes standen, öteten. XVI. Das
+Arbeiter, die an der Spitze des Volkes standen, öteten.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="16">
+<p>Das
 (jetzige) vor unsern Augen liegende Gleichnis aber ührt eine Hochzeit
 ein, eine Verbindung offenbar und Gemeinschaft des äutigams und
 der Braut und ein Hochzeitsmahl und wiederum auch hier Sklaven, die
 <lb n="10"/> geschlagen und ötet werden, und erste und letzte, de geladen
 Er zeigt aber durch diese (Worte) wiederum verborgen das, was nach
 seiner Auferstehung von den Toten sich ereignen wird. Denn der äutigam
-ist der öttliche Logos und die Braut ist die ünftige Seele, <note type="marginal">Σ145</note>
+ist der öttliche Logos und die Braut ist die ünftige Seele, <milestone unit="altnumbering" n="145"/>
 die sich mit ihm vereinigt und den öttlichen Samen von ihm empfängt,
 <lb n="15"/> und die öttliche und die ünftige Gemeinschaft (ist) die seiner
 Kirche, und darauf (folgt) das ünftige Gelage und Hochzeitsmahl
@@ -6130,13 +7117,13 @@ sollte, und sagte durch das Gleichnis die Zukunft voraus, bevor sie geschah,
 durch folgende Worte: „Der önig aber ward zornig über die
 ßhandlung und den Mord der Knechte und schickte ein Heer und <lb n="10"/>
 ötete die örder, und ihre Stadt verbrannte er." Was ist offenbarer
-<note type="marginal">Σ146</note> als dies Vorher wissen und die Εrfüllung dieser Dinge? Denn das Heer
+<milestone unit="altnumbering" n="146"/> als dies Vorher wissen und die Εrfüllung dieser Dinge? Denn das Heer
 der ömer kam nach kurzer Zeit, belagerte die Stadt und vernichtete
 den Tempel im Feuer. Und wessen war (dies Werk), wenn nicht des
 über allem (stehenden) önigs Gott? Deswegen ßt es: „Der König <lb n="15"/>
 aber schickte sein Heer, ötete die örder und verbrannte die Stadt.“
 Bis jetzt also ist es öglich, mit eigenen Augen die Brandtrümmer der
-ätze [mit Augen] zu sehen, ür diejenigen, die nach dem orte
+ätze <del>mit Augen</del> zu sehen, ür diejenigen, die nach dem orte
 reisen. Wie aber die örder der Apostel bei der Eroberung ergriffen
 wurden und die ührende Strafe erlitten, ist nicht ürdig zu sagen. <lb n="20"/>
 Man kann in der Schrift des *Juden Flavius Josephus das finden, was
@@ -6156,7 +7143,7 @@ zur Hochzeit." Als sie dies durch die Tat vollendeten, gingen sie hinaus
 <note type="footnote">2 vgl. Euseb. Hist, eccles. II 23 ff. 9. 15 = Matth 227 28 = Matth
 <lb n="28"/> 19 30 = Matth 10 6</note>
 <note type="footnote">2 l. <foreign xml:lang="abbr">ABBREV</foreign> Bernstein mit HS 18 „mit Augen" Σ ist überflüssig nach „mit
-eigenen Augen" 21 „des Juden“] ,,der ömer“ Σ. Schreibfehler, l. <foreign xml:lang="abbr">ABBREV</foreign>
+eigenen Augen" 21 „des Juden“] „der ömer“ Σ. Schreibfehler, l. <foreign xml:lang="abbr">ABBREV</foreign>
 nach Σ 152 2 23 „und taten" Σ str. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.190"/>
@@ -6173,7 +7160,7 @@ Ende derer sein wird, die, obwohl ürdig, in seiner Kirche versammelt
 voll wurde der Festsaal von Geladenen. Als aber der önig hereinkam,
 die äste zu sehen, sah er dort einen Mann, der hatte kein Hochzeitskleid
 an. Und er sagte zu ihm: Mein Lieber, wie bist du hier
-hereingekommen, obwohl du kein Hochzeitskleid anhast? Er aber <note type="marginal">Σ147</note>
+hereingekommen, obwohl du kein Hochzeitskleid anhast? Er aber <milestone unit="altnumbering" n="147"/>
 <lb n="15"/> schwieg. Darauf sprach der Κönig zu den Dienern: Fesselt ihm Ηände
 und Füße und bringt ihn hinaus in die äußerste Finsternis, dort wird
 sein Weinen und ähneknirschen. Denn viele sind berufen, wenige
@@ -6181,7 +7168,10 @@ aber ählt.“ Eben mit (diesen) voraussagenden Worten unterwiew
 er auch vorher diejenigen, die nicht recht in seiner Kirche leben.</p>
 <lb n="20"/> <p>Wiederum über die Verwerfung des üdischen Volkes.
 Aus dem äusevangelium.</p>
-<p>XVII. „Ihr Schlangen (und) Otternbrut, wie wollt ihr der ölle
+</div>
+
+<div type="textpart" subtype="chapter" n="17">
+<p> „Ihr Schlangen (und) Otternbrut, wie wollt ihr der ölle
 entfliehen? Darum siehe, ich sende zu euch Propheten und Weise und
 Schriftgelehrte, und ihr werdet die einen öten und kreuzigen, die andern
 <lb n="25"/> in euren Synagogen ßeln und sie verfolgen von Stadt zu Stadt,
@@ -6213,7 +7203,7 @@ den ätern her überliefert, bis zu jener Zeit bewahrt worden war, und
 die Freiheit von ihnen genommen. Eben durch Taten ward (jetzt) ersichtlich,
 sichtlich, ß die Strafe all des von jenem Geschlechte (vergossenen)
 Blutes der Gerechten den voraussagenden Worten unsers ösers Erlösers ent-
-Σ148 sprechend war. Es ist aber notwendig, zu sehen, mit wie ßer Vollmacht <lb n="15"/>
+<milestone unit="altnumbering" n="148"/> sprechend war. Es ist aber notwendig, zu sehen, mit wie ßer Vollmacht <lb n="15"/>
 und aus wie ßer Kraft gesagt ward: „Siehe ich sende zu euch
 Propheten und Weise". Denn das „Siehe ich sende" zeigt, ß es in
 Vollmacht Gottes (gesagt ward), und ß er den Herrschern der Juden
@@ -6228,7 +7218,10 @@ Reiches durch öttliches Vorauswissen voraus bezeugte, ß sie zum
 äußersten Unheil sich ändern ürden wegen der Frechheit der Bewohner
 gegen ihn, über die er sogar weinte in seiner Liebe.</p>
 <p>Über die örung des Tempels von Jerssalem.</p>
-<p>XVIII. Wie das, was über das Volk der Juden vorausgesagt war, <lb n="30"/>
+</div>
+
+<div type="textpart" subtype="chapter" n="18">
+<p>Wie das, was über das Volk der Juden vorausgesagt war, <lb n="30"/>
 üllung fand, ist im Vorhergehenden gezeigt worden. Da aber der
 Logos Gottes auch über ihre Orte weissagte, so üssen wir auch seine
 Worte über sehen (und üfen). Da sie seine reine Lehre nicht ertrugen
@@ -6252,8 +7245,8 @@ war es ötig, ß nicht nur die Bewohner der Stadt, sondern auch das
 Land selbst, auf das sie ächtig stolz waren, dem Entsprechendes litt,
 was seine Bewohner taten; was sie auch bald darauf gelitten haben, als
 die ömer öber über die Stadt kamen und von den Bewohnern die einen
-<lb n="15"/> Kriegsrecht öteten, die andern durch Hunger vernichteten, andere in <note type="marginal">Σ149</note>
-die Gefangenschaft ührten, andere verfolgten &lt;und an jeden Ort zerstreuten&gt;
+<lb n="15"/> Kriegsrecht öteten, die andern durch Hunger vernichteten, andere in <milestone unit="altnumbering" n="149"/>
+die Gefangenschaft ührten, andere verfolgten <add>und an jeden Ort zerstreuten</add>
 ihr *Haus aber und ihren Tempel verbrannten und in die
 äußerste üstung warfen. Aber obwohl dies in äterer Zeit geschah,
 nahm unser öser die Zukunft durch Vorauswissen vorweg als Logos
@@ -6294,7 +7287,7 @@ Zeit, in der es einer besseren Erneuerung ürdigt wurde, größer als
 dieses Hauses wird ß sein, der letzte mehr als der erste." Wie sie
 aber nach dem Wort unsers ösers verlassen wurden und ihr Haus
 durch den Urteilsspruch Gottes in die äußerste üstung geriet, zeigt <lb n="15"/>
-<note type="marginal">Σ150</note> denen, die zu jenen Orten kommen, der Anblick selbst, mehr als das
+<milestone unit="altnumbering" n="150"/> denen, die zu jenen Orten kommen, der Anblick selbst, mehr als das
 Wort, die üllung. Und die Zeit ist ährig und lang geworden,
 ß sie nicht nur das Doppelte ägt der siebzigjährigen verwüstung,
 die zur Zeit der Babylonier stattfand, sondern sogar das Vierfache
@@ -6315,7 +7308,7 @@ bewunderten, daß an dem Orte, den sie bewunderten, kein Stein auf
 dem anderen ört gelassen ürde. Denn der Ort müsse um der
 Frechheit *seiner Bewohner willen ändige Vernichtung und Ver- <lb n="35"/>
 <note type="footnote">12 = Hag 29 21 vgl. Matth 24 1 24 = Matth 24 2</note>
-<note type="footnote">16 ἡ ὄψις αὐτὴ τοῦ λόγου μᾶλλον δείκνυσι τὸ ἀποτέλεσμα Th. gr. ,,die üllung
+<note type="footnote">16 ἡ ὄψις αὐτὴ τοῦ λόγου μᾶλλον δείκνυσι τὸ ἀποτέλεσμα Th. gr. „die üllung
 des Wortes" Σ 27 τά τε τῆς ἄλλης κατασκευῆς Th. gr.] 1. <foreign xml:lang="abbr">ABBREV</foreign>
 mit HS 35 1. <foreign xml:lang="abbr">ABBREV</foreign>
 Eusebiua III*.</note>
@@ -6337,17 +7330,20 @@ haben: es sei ämlich nicht über alle äude gesprochen, sondern nur
 über den Ort, den seine ünger bewundernd ihm gezeigt hätten; denn
 <lb n="15"/> über diesen habe er die Prophezeiung gesprochen.</p>
 <p>Wiederum aber lehrt die über ihn ßte) Schrift seiner Jünger
-Folgendes über die örer des Ortes.</p>
-<p>Über die Eroberung der Stadt. Aus dem Evangelium des Lukas.</p> <note type="marginal">Σ151</note>
-<p>XIX. „Als er die Stadt sah, weinte er über sie und sagte: Wenn
+Folgendes über die örer des Ortes.</p></div>
+   
+<note>Über die Eroberung der Stadt. Aus dem Evangelium des Lukas.</note> 
+   
+<div type="textpart" subtype="chapter" n="19">
+<p><milestone unit="altnumbering" n="151"/> „Als er die Stadt sah, weinte er über sie und sagte: Wenn
 <lb n="20"/> du erkannt ättest, wenn auch nur an diesem Tage, was zu deinem
 Frieden (dient); jetzt aber ward es vor deinen Augen verborgen. Es
 werden Tage über dich kommen, wo deine Feinde dich umgeben, dich
-umzingeln und von allen Seiten ängen werden. &lt;Und&gt; sie werden
+umzingeln und von allen Seiten ängen werden. <add>Und</add> sie werden
 dich ausrotten und deine Kinder in dir." Das Vorher(gehende) wurde
 <lb n="25"/> über den Tempel geweissagt, das Vorliegende aber über die Stadt selbst,
 welche die Juden eine „Stadt Gottes“ nannten wegen des in ihr erbauten
-Tempels Gottes. Er weinte aber über die ganze &lt;Stadt&gt;, der
+Tempels Gottes. Er weinte aber über die ganze <add>Stadt</add>, der
 Mitleidige, indem er nicht so (sehr) mit ihren äuden noch mit dem
 Erdboden als (vielmehr) mit den Seelen ihrer einstigen Bewohner und
 <lb n="30"/> mit ihrem Untergang Mitleid hatte. Er legt aber auch die Ursache
@@ -6362,7 +7358,7 @@ Th. gr. 1. + <foreign xml:lang="abbr">ABBREV</foreign></note>
 <pb n="v.3.pt.2.p.195"/>
 er ist es, über den gesagt ist: „Es wird aufleuchten in seinen Tagen
 die Gerechtigkeit und die ülle des Friedens." Er kam aber eben deswegen,
-zu ündigen ,,Frieden den Nahen und Frieden den Fernen“,
+zu ündigen „Frieden den Nahen und Frieden den Fernen“,
 und sagte denen, die ihn aufnahmen: „Den Frieden lasse ich euch,
 meinen Frieden gebe ich euch", den Frieden, den alle ölker in der <lb n="5"/>
 ganzen öpfung, die an ihn glaubten, angenommen haben. Das Volk
@@ -6370,7 +7366,7 @@ aus der Beschneidung aber, das nicht an ihn glaubte, erkannte nicht
 die (Dinge) seines Friedens. Deswegen sagt er hinterher: „Jetzt ist es
 verborgen vor deinen Augen, ß Tage über dich kommen und deine
 Feinde dich umgeben werden." Das also, was sie in kurzer Zeit erreichen <lb n="10"/>
-sollte in der Belagerung, weil sie nicht [vorher] merkten auf den Frieden.
+sollte in der Belagerung, weil sie nicht <del>vorher</del> merkten auf den Frieden.
 der ihnen vorher ündigt war. war vor ihren Augen verborgen. Sie
 also sahen voraus, was ihnen nachher geschah, er aber weissagte dies
 deutlich durch (sein) Vorauswissen und zeigte die Eroberung, die sie
@@ -6380,7 +7376,7 @@ deinem Frieden (dient)". Denn um dieser Ursache willen „werden Tage
 über dich kommen und deine Feinde werden dich umgeben, dich umzingeln
 und dich von allen Seiten ängen, und sie werden dich ausroten
 und deine Kinder in dir." Er beschreibt aber hierdurch die Ar
-Σ152 des Krieges, der gegen sie ührt) werden sollte. Wie dies zur Erfüllung
+<milestone unit="altnumbering" n="152"/> des Krieges, der gegen sie ührt) werden sollte. Wie dies zur Erfüllung
 kam, kann man aus der Schrift des Josephus Stsehen, der ein
 Jude war und in einer Familie eben der Juden geboren war von bekannten
 und ühmten ännern im Volk (und) der um die Zeit der
@@ -6388,7 +7384,10 @@ Belagerung alles das, was bei ihnen geschah, niederschrieb und zeigte. <lb n="25
 ß es in der Tat den uns vor (liegenden) voraussagenden Worten
 entspreche.</p>
 <p>Wiederum über die Eroberung der Stadt. Aus dem Evangelium des Lukas.</p>
-<p>XX. „ Wenn ihr", sagt er, „Jerusalem umgeben seht von einem
+</div>
+
+<div type="textpart" subtype="chapter" n="20">
+<p> „ Wenn ihr", sagt er, „Jerusalem umgeben seht von einem
 Heer, so wisset, ß seine üstung nahe ist. Hierauf sollen diejenigen, <lb n="30"/>
 die in Juda sind, entrinnen auf den Berg, und diejenigen, die
 drinnen sind, fliehen, und diejenigen, die *auf dem Lande sind, nicht
@@ -6424,7 +7423,7 @@ Wird, nicht von den Juden, sondern von den Völkern, indem er so sagt:
 <lb n="25"/> „Jerusalem wird zertreten warden von den Völkern“, und *deher weiß
 Er, daß sie bewohnt sein wird von den Völkern. Ihre Verwüstung aber
 Nennt er (die Tatsache), daß sie nicht mehr von ihren Kindern (bewohnt
-Wird) und daß kein gesetzlicher Gottesdienst in ihr besteht. Wie aber <note type="marginal">Σ 153</note>
+Wird) und daß kein gesetzlicher Gottesdienst in ihr besteht. Wie aber <milestone unit="altnumbering" n="153"/>
 Auch dies erfüllt wurde, bedarf nicht vieler Worte, da man mit Augen
 <lb n="30"/> sehen kann, daß die Juden unter alle Völker zerstreut sind, und daß
 Fremde und Andersgeschlechtige Bewohner der  (Stadt) sind, die einst
@@ -6467,7 +7466,7 @@ Stadt kommen werde, sah unser Erlöser *voraus und riet (daher) seinen <note typ
 Jüngern, bei der Belagerung, die über die Juden kommen sollte,
 Zuflucht nicht zur Stadt zu nehmen als zu einem festen und von Gott
 beschützten Orte, was den meisten widerfahren ist, sondern sich von
-<note type="marginal">Σ154</note> wegzuwenden und auf die Berge zu fliehen, und diejenigen inmitten
+<milestone unit="altnumbering" n="154"/> wegzuwenden und auf die Berge zu fliehen, und diejenigen inmitten
 Judäas sollen zu den Völkern entweichen und diejenigen in seinen <note type="marginal">30</note>
 Land(gebieten) sollen nicht ihre Zuflucht nehmen zu ihm (zu Jerusalem)
 wie zu einem festen Ort. Deswegen sagt er: „Die *auf dem Lande (sind),
@@ -6488,7 +7487,10 @@ des Josephus lernen. Wenn es aber recht ist, daß wir, sei es auch nur
 (etwas) hersetzen, so hindert nichts, den Schriftsteller selbst zu hören,
 der in dieser Weise schreibt:</p>
 <p>Aus dem sechsten (Buch) der Schrift des Josephus.</p>
-<p>XXI. „Was habe ich nötig, die Schamlosigkeit des Hungers gegen
+</div>
+
+<div type="textpart" subtype="chapter" n="21">
+<p> „Was habe ich nötig, die Schamlosigkeit des Hungers gegen
 <lb n="10"/> die seelenlosen (Dinge) auszusagen. Denn ich gehe daran, ein Werk
 (von ihm) zu Künden, wie es weder bei Griechen noch bei Barbaren
 beschrieben ist. Denn es ist furchtbar zu sagen und unglaublich zu hören.
@@ -6519,11 +7521,11 @@ auch war zu finden" Σ. 1. <foreign xml:lang="abbr">ABBREV</foreign> vor <foreig
 nahm" Σ str· <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.199"/>
-aber einen Säugling — und sprach: Unseliges &lt;Kind;&gt; in Kampf, Hunger
-<note type="marginal">Σ155</note> und Aufruhr, für wen soll ich dich bewahren? Bei den Römern wirst du
+aber einen Säugling — und sprach: Unseliges <add>Kind;</add> in Kampf, Hunger
+<milestone unit="altnumbering" n="155"/> und Aufruhr, für wen soll ich dich bewahren? Bei den Römern wirst du
 Sklave sein, selbst wenn du vielleicht bis dahin lebst; es kommt aber
 der Hunger der Knechtschaft zuvor. Die Aufrührer aber sind schlimmer
-&lt;als beide&gt;. Komm und diene mir als Speise, den Aufrührern zur Strafe <lb n="5"/>
+<add>als beide</add>. Komm und diene mir als Speise, den Aufrührern zur Strafe <lb n="5"/>
 und der Welt zum Mythus, der allein noch fehlt den Leiden der Juden.
 Als sie dies gesagt hatte, tötete sie zugleich ihren Sohn. Dann briet
 sie ihn, aß die eine Hälfte auf und verbarg und bewahrte den Rest auf.“
@@ -6537,7 +7539,10 @@ Xot sein, dergleichen es nicht gegeben hat seit Anfang der Welt *bis <lb n="15"/
 jetzt und nicht sein wird“, so ist es recht, von dem Schriftsteller zu
 hören, wie er die Erfüllung eben dieser Dinge so beschreibt:</p>
 <p>Aus dem fünften (Buch) der Schrift des Josephus.</p>
-<p>XXII. „Jede einzelne ihrer Bosheit also zu erzählen, ist unmöglich.
+</div>
+
+<div type="textpart" subtype="chapter" n="22">
+<p> „Jede einzelne ihrer Bosheit also zu erzählen, ist unmöglich.
 Um es aber zusammenfassend zu sagen: keine andere Stadt hat so viel <lb n="20"/>
 gelitten und kein Geschlecht ist jemals zeugungskräftiger gewesen an
 Bosheit als dies. Denn die Stadt zerstörten sie selbst und erzwangen,
@@ -6548,7 +7553,7 @@ zu weinen.“ Dies (geschah) wegen des (Wortes): „Es wird in jener Zeit
 eine große Not sein, dergleichen es nicht gegeben hat seit Anfang der
 <note type="footnote">9— S. 200, 7 = 13. Bruchstück der griech. Theoph. 10. 12 = Luk 21 23
 14 = Matth 24 21 19—26 = Jos. bell. Jud. V 10 5 26 = Matth 24 21</note>
-<note type="footnote">1 βρέφος, εἶπεν, ἄθλιον] ,,Kind“ &lt; Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 3 κἀν ζήσωμεν (1. <foreign xml:lang="abbr">ABBREV</foreign> ?
+<note type="footnote">1 βρέφος, εἶπεν, ἄθλιον] „Kind“ &lt; Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 3 κἀν ζήσωμεν (1. <foreign xml:lang="abbr">ABBREV</foreign> ?
 ἐπ’ αὐτούς] „auch wenn du vielleicht lebst bei ihnen“ (= ἐπ’ αὐτοῖς) Σ 4 οἱ
 στασιασταὶ δὲ ἀμφοτέρων χαλεπώτεροι] „als beide“ &lt; Σ. 1. <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign>
 15 „und bis“ Σ stf. <foreign xml:lang="abbr">ABBREV</foreign> 22 Ῥωμαίους δὲ ἄκοντας ἠνάγκασαν ἐπιγραφῆναι σκυθρωπῷ
@@ -6565,11 +7570,14 @@ voraussagenden Worten hinzu und bestimmt die Zeit, bis wann Jerusalem
 <lb n="5"/> niedergetreten sein soll von den Völkern. Denn er sagt, „bis
 daß die Zeiten der Völker erfüllt werden“. und weist hiermit auf das
 Ende der Welt.</p>
-<p>Ferner darüber, daßk das Gesetz der Juden nicht mehr auf den Bergen <note type="marginal">Σ156</note>
+</div>
+<note>Ferner darüber, daßk das Gesetz der Juden nicht mehr auf den Bergen <milestone unit="altnumbering" n="156"/>
 Garizim noch in Jerusalem erfüllt werden soll, und über den gottgeziemenden
 <lb n="10"/> Gottesdienst, der in seiner Kirche entstanden ist. Aus dem Evangelium
-des Johannes.</p>
-<p>XXIII. In der Nähe der uns benachbarten Stadt, in dem palästinischen
+des Johannes.</note>
+   
+<div type="textpart" subtype="chapter" n="23">
+<p>In der Nähe der uns benachbarten Stadt, in dem palästinischen
 Neapel — einer keineswegs kleinen, sondern sogar berühmten
 Stadt — traf ihn ein samaritisches Weib und sagte nach (einigen) anderen
 <lb n="15"/> Worten zu ihm: „Herr, ich sehe, daß du ein Prophet bist. Unsere
@@ -6605,10 +7613,10 @@ Worten verwüstet. Denn der Tempel in der Nähe der Stadt Neapel
 ward durch unziemliche Bilder, Götzen, Opfer und blutvergießen be <lb n="5"/>
 fleckt und beschmutzt, derjenige aber in Jerusalem bestand so lange Zeit,
 wie (eben) gesagt ist, und wurde (dann) von Grund aus durch äußerste Verwüstung
-<note type="marginal">Σ157</note> und Brand zerstört. Durch die Tat (also) wurde von jener Zeit
+<milestone unit="altnumbering" n="157"/> und Brand zerstört. Durch die Tat (also) wurde von jener Zeit
 an bis jetzt die Prophezeiung unsers Erlösers erfüllt, die lautete: „Es
 kommt die Stunde, wo ihr weder auf diesem Berge noch in Jerusalem <lb n="10"/>
-werdet anbeten.“ ,,Stunde“ aber nannte er die Zeit, die noch nicht nahe
+werdet anbeten.“ „Stunde“ aber nannte er die Zeit, die noch nicht nahe
 war, sondern (erst) kommen sollte. Über den vernünftigen Gottesdienst
 aber, der von ihm seinen Jüngern *überliefert wurde, fügte er hinzu
 und sagte: „Es kommt die Stunde und ist (schon) jetzt, wo die wahrhaftigen
@@ -6637,11 +7645,14 @@ blieb in äußerster Verwüstung und Brand so lange Zeit, wie gesagt ist“. Ver
 ungeschickte Auflösung eines Partizipialsatzes und falsche Verbindung
 13 „vollendet wurde“ Σ, 1. <foreign xml:lang="abbr">ABBREV</foreign> (Druckfehler?) 21 „prophezeite hierduch,
 indem er zeigte“ Σ</note>
+</div>
 
 <pb n="v.3.pt.2.p.202"/>
-<p>Über das Volk, das aus fremden Völkern durch seine Lehre gegründet wird.
-Aus dem Evangelium des Johannes.</p>
-<p>XXIV. „Ich bin der gute Hirte und kenne die Meinen und die
+<note>Über das Volk, das aus fremden Völkern durch seine Lehre gegründet wird.
+Aus dem Evangelium des Johannes.</note>
+
+<div type="textpart" subtype="chapter" n="24">
+<p> „Ich bin der gute Hirte und kenne die Meinen und die
 Meinen kennen mich, wie mich mein Vater kennt und ich meinn Vater
 <lb n="5"/> kenne, und ich lasse mein Leben für meine Schafe. Und andere Schafe
 habe ich, die nicht aus diesem Hofe sind. Ich muß sie führen, und sie
@@ -6651,7 +7662,7 @@ zu den irrenden Schafen aus dem Hause Israel.“ Er nannte aber das
 <lb n="10"/> Volk der Juden in dieser Weise und prophezeite durch die vorliegenden
 (Aussprüche), daß keineswegs nur diejenigen, die aus den Juden ihm
 zu Jüngern gewonnen wurden, in seine Herde gerechnet werden sollten,
-sondern auch (die) außerhalb dieses ,,Hofes“. So aber pflegt der Logos bisweilen <note type="marginal">Σ158</note>
+sondern auch (die) außerhalb dieses „Hofes“. So aber pflegt der Logos bisweilen <milestone unit="altnumbering" n="158"/>
  das ganze Volk der Juden, bisweilen Jerusalem und den dortigen
 <lb n="15"/> Gottesdienst zu nennen, der nach dem Gesetz des Mose erfüllt wurde.
 Daß er „andere Schafe“ sammeln will, „die nicht aus diesem Hofe sind“. —
@@ -6669,7 +7680,7 @@ Einen Hirten, eben des Logos Gottes. Dnn in Jerusalem erstanden
 sich ablösend aus den Juden fünfzehn Episkopen der dortigen Kirche
 von Jakobus dem ersten an, und Myriaden Juden zumal und Heiden gab
 <lb n="30"/> es. die dort zusammen vereinigt waren bis auf die Belagerung in den
-Tagen Hadrians. Daß er aber der ,,Hirte“ sei, offenbarte uns der, der
+Tagen Hadrians. Daß er aber der „Hirte“ sei, offenbarte uns der, der
 viele Male durch Prophetenworte verkündet wurde, die den Logos
 Gottes erwähnen und lehren, daß er der Hirt der menschlichen Seelen
 wie der vernünftigen Herden sei. So also heißt es bald bei den Propheten:
@@ -6691,18 +7702,21 @@ und im Vergleich zu seiner Kraft gleichsam unvernünftiger als alle
 Herden. Ein guter und treuer Hirte aber ist in Wahrheit derjenige, der
 seine Schafe nicht vernachlässigt (und zuläßt), daß sie von den Wölfen <lb n="10"/>
 gefressen w erden, das heiß aber: von den bösen, seelenverderbenden
-Σ159 Dämonen. Dies zwingt uns, auf das Wort dessen zu achten, der mit
+<milestone unit="altnumbering" n="159"/>Dämonen. Dies zwingt uns, auf das Wort dessen zu achten, der mit
 vieler Vollmacht“ und Kraft sagt: „Ich bin der gute Hirte“. Wenn er
-aber sagt: ,,Ich lasse mein Leben für meine Herden“, so weist er (damit)
+aber sagt: „Ich lasse mein Leben für meine Herden“, so weist er (damit)
 geheimnisvoll auf seinen Tod hin und lehrt zugleich auch die Ursache: <lb n="15"/>
 daß er für die Erlösung der Seelen der vernünftigen Herden sein Leben
 ließ. Das (Wort): „Ich habe andere Schafe“ deutet darauf, daß zu
 seinem Besitztum nicht nur Juden, sondern auch alle Völker gehören,
 die ihm von seinem Vater gegeben sind, entsprechend jener (Verheißung):
-,,Bitte von mir, so will ich dir Völker zu deinem Erbe geben.“ <lb n="20"/></p>
+„Bitte von mir, so will ich dir Völker zu deinem Erbe geben.“ <lb n="20"/></p>
 <p>Wie sein Tod die Ursache der Erlösung vieler ist. Aus dem Evangelium
 des Johannes.</p>
-<p>XXV. Meist verweilte er unter den Juden, weil ihnen die voraussagenden
+</div>
+
+<div type="textpart" subtype="chapter" n="25">
+<p>Meist verweilte er unter den Juden, weil ihnen die voraussagenden
 Prophezeiungen der Propheten über ihn bekannt waren. Wreil
 aber einmal auch Griechen sich seinen Jüngern näherten und baten, ihn <lb n="25"/>
 zu sehen, so steht seine Antwort geschrieben, als man ihm dies sagte:
@@ -6715,7 +7729,7 @@ die Verherrlichung seiner Gottheit stark werden solle. Denn
 keineswegs war die Stunde der Verherrlichung gekommen, solange er
 <note type="footnote">1 = Ps 80 (LXX: 79)2 13 vgl. Joh 10 18 13 = Job 10 14 14 = Joh
 10 15 17 = Joh 10 ig 20 = Ps 2 s 27 = Joh 12 23. 24</note>
-<note type="footnote">1 ,,lehrt“] wörtlich „führt ein“ = εἰσηγέομαι wie Σ 193 18 6 „viel mehr“]
+<note type="footnote">1 „lehrt“] wörtlich „führt ein“ = εἰσηγέομαι wie Σ 193 18 6 „viel mehr“]
 wörtlich „über mehr“ = ἐπὶ πλέον</note>
 
 <pb n="v.3.pt.2.p.204"/>
@@ -6735,7 +7749,7 @@ also der Same, der fällt und aufgeht, der stirbt und auflebt, der nach
 seinem Fall durch den Tod in Menge sich mehrte, der durch seine Auferstehung
 <lb n="15"/> die Länder der Völker nach Art der Felder mit göttlicher,
 unaussprechlicher Kraft füllte. Deswegen sagt er: „Die Ernte ist reich,
-aber der Arbeiter sind weige.“ Und wiederum: „Hebt eure Augen auf <note type="marginal">Σ160</note>
+aber der Arbeiter sind weige.“ Und wiederum: „Hebt eure Augen auf <milestone unit="altnumbering" n="160"/>
 und seht die Felder an, die weiß sind zur Ernte.“ Auch dies deutet hin
 auf diejenigen, die nach seinem Tode ihm vereinigt sind durch echten
 <lb n="20"/> Glauben an ihn, (durch) deren Menge in der ganzen Welt der Griechen
@@ -6745,10 +7759,14 @@ auf die Tennen seiner Kirchen gesammelt werden. Deswegen heißt es:
 „Er hat seine Wurfschaufel in der Hand, reinigt seine Tennen und
 <lb n="25"/> sammelt den Weizen in die Scheuern. Die Spreu aber wird er verbrennen
 mit unverlöschlichem Feuer.“</p>
-<p>Wie Simon, das Haupt der Jünger, gleich seinem Meister dem Kreuz
+</div>
+   
+<note>Wie Simon, das Haupt der Jünger, gleich seinem Meister dem Kreuz
 übergeben wurde und aus dem Leben schied. Aus dem Evangelium des
-Johannes.</p>
-<lb n="30"/> <p>XXVI. „Kinder, (nur noch) eine kleine Weile bin ich bei euch. Dann
+Johannes.</note>
+
+<div type="textpart" subtype="chapter" n="26">
+<p><lb n="30"/> „Kinder, (nur noch) eine kleine Weile bin ich bei euch. Dann
 werdet ihr mich suchen. Wie ich den Juden sagte: Wohin ich gehe,
 könnt ihr nicht kommen, so wiederum sage ich auch euch.“ „Sagt zu
 ihm Simon Petrus: Wohin gehst du? Antwortete ihm Jesus: Wohin
@@ -6776,13 +7794,16 @@ Kreuzigung voraus, durch die er später bei seinem Aufenthalt in Rom
 sein Leben vollendete, durch das Wort: „Wenn du alt wirst, wirst du
 deine Hände ausstrecken, aber andere werden dir die Lenden gürten.“
 Demgemäß aber zeigte er auch geheimnisvoll durch das Wort: „Wohin
-<note type="marginal">Σ161</note> ich gehe, kannst du jetzt nicht kommen. Du wirst aber später (dorthin) <lb n="20"/>
+<milestone unit="altnumbering" n="161"/> ich gehe, kannst du jetzt nicht kommen. Du wirst aber später (dorthin) <lb n="20"/>
 kommen.“ Denn dies wurde keineswegs allen gesagt, sondern nur dem
 Simon, weil er allein in der Schrift (genannt) ist. der nach Art des
-Leidens unsers Erlösers sein Leben vollenden werde.</p>
-<p>Wie er seinen übrigen Jüngern die Verfolgungen voraussagte, die von Zeit
-zu Zeit über sie ergehen sollten. Aus dem Evangelium des Matthäus.</p> <lb n="25"/>
-<p>XXVII. „Hütet euch vor den Menschen. Denn sie werden euch der
+Leidens unsers Erlösers sein Leben vollenden werde.</p></div>
+   
+<note>Wie er seinen übrigen Jüngern die Verfolgungen voraussagte, die von Zeit
+zu Zeit über sie ergehen sollten. Aus dem Evangelium des Matthäus.</note> <lb n="25"/>
+
+<div type="textpart" subtype="chapter" n="27">
+<p> „Hütet euch vor den Menschen. Denn sie werden euch der
 Obrigkeit ausliefern und euch in ihren Synagogen geißeln; und vor
 Statthalter und Könige werden sie euch führen um meinetwillen zum
 Zeugnis für sie und die Völker.“ Und wiederum: „Selig seid ihr, wenn
@@ -6817,7 +7838,7 @@ wo er zugegen war und mit seinen Jüngern redete, und daß seine Worte
 <lb n="20"/> sich so ereigneten und in die Tat übergingen, wie sollte das nicht größer
 sein als ein Wunder? Denn viele andere, Barbaren und Griechen, die
 sich für Lehrer der Weisheit ausgaben, haben vieles mit ihren Jüngern geredet,
-indem die einen Gottloses verkündeten, die anderen das Wort der <note type="marginal">Σ162</note>
+indem die einen Gottloses verkündeten, die anderen das Wort der <milestone unit="altnumbering" n="162"/>
 Vorsehung und andere selbst die bei vielen als Götter Geltenden aufhoben,
 <lb n="25"/> während andere als Anfänger böser Dogmen auftraten und andere
 sagten, daß das (höchste) Ziel die Lust sei und noch andere, daß die
@@ -6830,15 +7851,17 @@ durch göttliches Vorauswissen die Verfolgungen vorausbezeugte, die
 über seine ünger kommen würden, sondern auch die Ursache derselben
 vorher zeigte durch das Wort: um seinetwillen solle ihnen das
 <lb n="35"/> widerfahren?</p>
+</div>
 <note type="footnote">13 vgl. Matth 5 12 34 vgl. Matth 5 11</note>
-<note type="footnote">7 „ein Christ„] wörtlich „kein Christ“ (Pleonasmus) 22 „Weisheit versprachen“
+<note type="footnote">7 „ein Christ „] wörtlich „kein Christ“ (Pleonasmus) 22 „Weisheit versprachen“
 Σ = σοφίαν ἐπαγγέλλεσθαι 27 „gleichgültig“] wörtlich „ohne Unter-
 schied“ = ἀδιάφορος | „und wie“ Σ str. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.207"/>
-<p>Wie auch diejenigen, die verwandt *sind, wider einander aufstehen werden
-in der Zeit der Verfolgung. Aus dem Evangelium des Matthäus.</p>
-<p>XXVIII. „Es wird ein Bruder den andern ausliefern zum Tode und
+<note>Wie auch diejenigen, die verwandt *sind, wider einander aufstehen werden
+in der Zeit der Verfolgung. Aus dem Evangelium des Matthäus.</note>
+<div type="textpart" subtype="chapter" n="28">
+<p> „Es wird ein Bruder den andern ausliefern zum Tode und
 ein Vater seinen Sohn, und es werden aufstehen Söhne gegen ihre Väter
 und sie zum Tode bringen. Und ihr werdet gehaßt sein von jedermann <lb n="5"/>
 um meines Namens willen. Wer aber ausharrt bis ans Ende, der wird
@@ -6860,15 +7883,17 @@ Worten, überredet ihn, Götzen zu verehren, und bringt ihn (dadurch)
 zum Tode. So bringen auch de Söhne ihre Väter in der Liebe zu ihnen
 dahin, *daß sie das zeitliche, sterbliche Leben dem bei Gott vorziehen,
 und werden (so) die Ursache des Todes und der Seelenverderbnis für ihre
-<note type="marginal">Σ163</note> Väter. Denn oftmals sehen wir solches zur Verfolgungszeit mit eigenen <lb n="25"/>
+<milestone unit="altnumbering" n="163"/> Väter. Denn oftmals sehen wir solches zur Verfolgungszeit mit eigenen <lb n="25"/>
 Augen, sodaß *dadurch erfüllt wird das (Wort): „Ihr werdet gehaßt sein
 von jedermann um meines Namens willen.“ Indessen aber ist auch hier
 sorgfältig der Zusatz gemacht worden, der lehrt, daß seine Jünger um
 keiner andern schimpflichen Tatsache als (allein) um seines Namens
-willen gehaßt werden sollen.</p> <lb n="30"/>
-<p>Über diejenigen, die unrein in seine Kirche aufgenommen werden sollen, und
-über die Strafe, die über sie kommen wird. Aus dem Evangelium des Matthäus.</p>
-<p>XXIX. „Das Himmelreich ist gleich einem Netze, das ins Meer
+willen gehaßt werden sollen.</p>
+</div> <lb n="30"/>
+<note>Über diejenigen, die unrein in seine Kirche aufgenommen werden sollen, und
+über die Strafe, die über sie kommen wird. Aus dem Evangelium des Matthäus.</note>
+<div type="textpart" subtype="chapter" n="29">
+<p> „Das Himmelreich ist gleich einem Netze, das ins Meer
 fiel und allerhand aufnahm. Als es voll war, zogen sie es ans Ufer,
 <note type="footnote">3—7 = Matth 10 21 f. 33—S. S. 208, 5 = Matth 13 <lb n="4751"/>
 1 l. <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> Lee (Druckfehler) 22 „in der Liehe zu ihnen“] wörtlich „(ziehen)
@@ -6895,14 +7920,16 @@ die mit den Guten in seine Kirche bis heute aufgenommen
 werden, da er lehrt, daß eben sie in der Zeit des Endes durch die damit
 betrauten Engel ausgesondert werden sollen und ein jeder von ihnen
 die seinem Denken gebührende Strafe empfangen solle.</p>
-<lb n="20"/> <p>Wie Betrüger und Verführer seine Lehre sich aneignen und heuchlerisch
-sich ihm anähneln. Aus dem Evangelium des Matthäus.</p>
-<p>XXX. „Hütet euch vor den Lügenpropheten, die zu euch kommen
+</div>
+<lb n="20"/> <note>Wie Betrüger und Verführer seine Lehre sich aneignen und heuchlerisch
+sich ihm anähneln. Aus dem Evangelium des Matthäus.</note>
+<div type="textpart" subtype="chapter" n="30">
+<p> „Hütet euch vor den Lügenpropheten, die zu euch kommen
 in Schafskleidern, inwendig aber sind sie reißende Wölfe. An ihren
 Früchten sollt ihr sie erkennen. Denn nicht sammelt man von den
 Α· Dornbüschen Trauben -ι Feigen von den Disteln. So bringt jeder
 gute Baum gute Früchte, der schlechte Baum aber bringt schlechte
-Früchte." Durch Vorauswissen Ἡ er vorher, sich vor gottlosen, andersgläubigen <note type="marginal">Σ164</note>
+Früchte." Durch Vorauswissen Ἡ er vorher, sich vor gottlosen, andersgläubigen <milestone unit="altnumbering" n="164"/>
 (Ketzern) zu hüten; die in späterer Zeit seine göttlichen
 Schriftworte zum Vorwand nehmen und den christlichen Namen sich aneignen
 <lb n="30"/> eignen würden, und zeigte die Zeichen und Zeugnisse des in ihnen verborgenen
@@ -6938,9 +7965,11 @@ Schafe gehalten wurden, wurden nach kurzer Zeit als reißende Wölfe <lb n="20"/
 offenbar. Deswegen lehrt uns unser Erlöser, uns vorher vor ihnen in
 Acht nehmen, indem er mahnt und sagt: „An ihren Früchten sollt ihr
 sie erkennen.“</p>
-<note type="marginal">Σ165</note> <p>Wie man glaubt, daß sowohl er wie auch seine Jünger vermittelst Zauberei
-und durch Gemeinschaft mit den Dämonen die Menschen überwältigt haben.</p> <lb n="25"/>
-<p>XXXI. „Nicht ist ein Jünger größer als sein Meister noch ein Sklave
+</div>
+<milestone unit="altnumbering" n="165"/> <note>Wie man glaubt, daß sowohl er wie auch seine Jünger vermittelst Zauberei
+und durch Gemeinschaft mit den Dämonen die Menschen überwältigt haben.</note> <lb n="25"/>
+<div type="textpart" subtype="chapter" n="31">
+<p> „Nicht ist ein Jünger größer als sein Meister noch ein Sklave
 (größer) als sein Herr. Genug für den Jünger, zu sein wie sein Meister,
 und für den Skaven. (zu sein) wie sein Herr. Wenn sie den Hausherrn
 Beelzebub genannt haben, wieviel mehr seine Hausgenossen? Fürchtet euch
@@ -6973,14 +8002,17 @@ und haben die Meinung ausgelöscht, die früher bei vielen über sie
 <p>Über diejenigen, die in seiner Kirche in vollkommener Heiligkeit und in
 einem der (ehelichen) Gemeinschaft nicht teilhaftig gewordenen Leben
 existieren werden. Aus dem Evangelium des Matthäus.</p>
-<p>XXXII. Als er für seine Jünger bestimmte, daß es nicht recht sei,
+</div>
+
+<div type="textpart" subtype="chapter" n="32">
+<p>Als er für seine Jünger bestimmte, daß es nicht recht sei,
 <lb n="20"/> sein Weib zu entlassen außer aus dem Grunde der Unzucht, und sie zu
 ihm sagten, „wenn die Ursache des Mannes mit dem Weibe derart ist,
 so nützt es nichts zu heiraten,“ heißt es, daß er darüber sagte: „Nicht
 jedermann ist genügend (stark) für dies Wort, sondern (nur) diejenigen,
 denen es gegeben ist. Es gibt Verschnittene, die von Mutterleib an so
 <lb n="25"/> waren, und gibt Verschnittene, die von den Menschen verschnitten wurden.
-und gibt Verschnittene, die sich selbst zu Verschnittenen gemacht haben <note type="marginal">Σ166</note>
+und gibt Verschnittene, die sich selbst zu Verschnittenen gemacht haben <milestone unit="altnumbering" n="166"/>
 um des Himmelreichs willen. Wer es ertragen kann, ertrage es.“ Niemals
 hat jemand durch Offenbarung, die unter den Menschen, das heißt
 vielmehr im Volke der Jaden existiert, ein solches Wort gesagt, noch
@@ -7005,7 +8037,9 @@ auch in betreff dieser (Männer) das Vorauswissen unsers Erlösers, in
 Wahrheit des Logos Gottes, versiegelt wurde.
 Über die Unterschiede derer, die nicht würdig den Samen seiner Lehre <lb n="10"/>
 aufnehmen sollten. Aus dem Evangelium des Matthäus.</p>
-<p>XXXIII. Als eine große Menge Menschen zu ihm kam, weissagte
+</div>
+<div type="textpart" subtype="chapter" n="33">
+<p>Als eine große Menge Menschen zu ihm kam, weissagte
 er durch ein Glichnis, wie diejenigen sein würden, die den Samen seiner
 Lehre empfingen, indem er so sagte: „Siehe, ein Säemann ging aus zu
 säen, und da er säte, fiel das eine an den Rand des Weges, und es <lb n="15"/>
@@ -7021,7 +8055,7 @@ Erklärung des Gleichnisses sei, und er lehrte und sprach: „So hört ihr
 also das Gleichnis des *Säemanns! Jeder, der das Wort vom Reiche <lb n="25"/>
 hört und es nicht versteht, da kommt der Böse und raubt den Samen
 aus seinem Herzea. Das ist der, der an den Rand des Weges gesät
-<note type="marginal">Σ167</note> wurde. Was aber auf den Felsen gesät wurde, das ist der, welcher das
+<milestone unit="altnumbering" n="167"/> wurde. Was aber auf den Felsen gesät wurde, das ist der, welcher das
 Wort hört und es in Eile aufnimmt. Da er aber nicht darin festgewurzelt
 ist, so strauchelt er über eine kleine Not. Was aber unter die <lb n="30"/>
 Dornen fiel, das ist der, welcher das Wort ört, und die Sorge der Welt
@@ -7065,7 +8099,7 @@ in Gott als in einer der genannten Weisen. Die aber, welche jenen entgegengesetz
 <lb n="30"/> mit reiner Seele und liebevollem Geist den Erlösungssamen
 aufgenommen haben, vervielfältigen wiederum ihre Früchte nach der
 Kraft ihrer Seele. Aber auch ihre Unterschiede vergleicht er den guten
-und schönen Ländern, die dreißigfach, und hundertfach <note type="marginal">Σ168</note>
+und schönen Ländern, die dreißigfach, und hundertfach <milestone unit="altnumbering" n="168"/>
 (tragen). Denn *derartige Kräfte werden bisweilen in den Seelen der
 <lb n="35"/> Menschen gefunden. Dies also prophezeite er darüber.</p>
 <note type="footnote">8 = Hebr. 4 12 f. 13—32 = 14. Bruchstück der griech. Theoph.</note>
@@ -7089,10 +8123,11 @@ Arbeiter hergebe zu seiner Ernte.“ Wenn er aber sagt, daß „ein Säemann
 ausging zu säen“, so zeigte er hierdurch, daß ein anderer der
 Säemann und ein anderer der Same (sei). Woher und wohin er ausging,
 sagte und lehrte er durch das sich daran schließende Gleichnis in <lb n="15"/>
-folgender Weise.</p>
-<p>Über heterodoxe Lehren, die mit seinem Worte in die Seelen der Menschen
-gesät werden. Aus dem Evangelium des Matthäus.</p>
-<p>XXXIV. „Ein anderes Gleichnis fügte er hinzu und sagte: Das
+folgender Weise.</p></div>
+<note>Über heterodoxe Lehren, die mit seinem Worte in die Seelen der Menschen
+gesät werden. Aus dem Evangelium des Matthäus.</note>
+<div type="textpart" subtype="chapter" n="34">
+<p> „Ein anderes Gleichnis fügte er hinzu und sagte: Das
 Himmelreich gleicht einem Manne, der guten Samen auf sein Landgut <lb n="20"/>
 säte. Während aber die Menschen schliefen, kam ein Feind und
 säte Unkraut unter den Weizen und ging davon. Als aber Weizen
@@ -7114,7 +8149,7 @@ Jüngern im Hause auseinander, als sie zu ihm traten und zu ihm sagten:
 <pb n="v.3.pt.2.p.214"/>
 „Setze uns das Gleichnis auseinander vom Unkraut des Landgutes. Er
 aber antwortete ihnen und sprach: Der den guten Samen sät, ist der
-Menschensohn. Das Landgut aber ist die Welt; der gute Same aber, <note type="marginal">Σ169</note>
+Menschensohn. Das Landgut aber ist die Welt; der gute Same aber, <milestone unit="altnumbering" n="169"/>
 das sind die Söhne des Reiches, das Unkraut aber sind die Söhne des
 <lb n="5"/> Bösen. Der Feind aber, der es gesät, ist der Verleumder. Die Ernte
 aber ist das Ende der Welt und die Schnitter sind die Engel. Wie
@@ -7136,7 +8171,7 @@ stieg zu uns selbst herab außerhalb seines Himmelreiches und brachte
 den himmlischen Samen mit sich, den er in die Seelen der Menschen
 wie in verschiedene Ländereien säte. Das vorliegende Wort aber belehrt
 auch über die Beschaffenheit des Landgutes, auf das er den Samen
-<lb n="25"/> warf. Er sagt aber: ,,Das Landgut ist die Welt“, und zeigt, wem dies
+<lb n="25"/> warf. Er sagt aber: „Das Landgut ist die Welt“, und zeigt, wem dies
 Landgut gehört: keinem andern als ihm selbst, der aus dem Innern
 seines Reiches zu *denen außerhalb hinausging, indem er stagt, daß
 „die Knechte herzutraten und zu ihm sprachen: Herr, hast du nicht
@@ -7156,7 +8191,7 @@ Menschen existierte. Indessen aber war es ihm nicht verborgen, daß
 dies kommen werde. Denn da in späteren Zeiten auf der ganzen Erde
 Schriftstücke und Worte betrügerischer Schriften seiner Lehre angeähnelt
 wurden von entgegengesetzter Natur, so wurden sie nach Art
-<note type="marginal">Σ170</note> des Unkrauts mit dem reinen und belebenden Worte seiner *ausgesät. <lb n="5"/>
+<milestone unit="altnumbering" n="170"/> des Unkrauts mit dem reinen und belebenden Worte seiner *ausgesät. <lb n="5"/>
 Myriaden aber, die bald des Mani sich rühmen, bald des Markion,
 bald anderer unter den gottlosen Heterodoxen, *bringen bis jetzt Unkraut
 hervor, indem sie sich der Lehre unsers Erlösers anähneln und
@@ -7175,16 +8210,20 @@ daß aber das Ende der guten (Dinge) denjenigen (zu teil werde), die <lb n="20"/
 den lebendigen, reinen und lebenbringenden Samen bewahrt und vermehrt
 haben, von denen gesagt ist: „Dann werden die Gerechten leuchten
 wie die Sonne im Reiche ihres Vaters.“</p>
-<p>Über diejenigen, die in Zukunft sich selbst fälschlich *Christusse nennen.
-Aus dem Evangelium des Matthäus.</p> <lb n="25"/>
-<p>XXXV. „Da er auf dem Olberg saß traten seine Jünger zu ihm
+</div>
+   
+<note>Über diejenigen, die in Zukunft sich selbst fälschlich *Christusse nennen.
+Aus dem Evangelium des Matthäus.</note> <lb n="25"/>
+
+<div type="textpart" subtype="chapter" n="35">
+<p> „Da er auf dem Olberg saß traten seine Jünger zu ihm
 besonders und sprachen zu ihm: Sage uns, wann wird das sein und
 was ist das Zeichen deiner Ankunft und des Endes der Welt? Jesus
 antwortete ihnen und sprach: Sehet zu, daß euch niemand irre führe.
 Denn viele werden kommen in meinem Namen und werden sagen: Ich <lb n="30"/>
 bin der Christus und werden viele irre führen.“ Wiederum aber sagte er
 26—31 = Matth 24 3—5
-<note type="footnote">5 l. <foreign xml:lang="abbr">ABBREV</foreign> 7 „und “ Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 18 ,,Die Ernte und das Ende
+<note type="footnote">5 l. <foreign xml:lang="abbr">ABBREV</foreign> 7 „und “ Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 18 „Die Ernte und das Ende
 und die Engel die “ Σ str. <foreign xml:lang="abbr">ABBREV</foreign> vor ABBERV 20 viell. zu übersetzen:
 „daß aber das Ende derer gut (sein werde), die“ . . . . 241. <foreign xml:lang="abbr">ABBREV</foreign> Lee
 statt „Christen“ Σ</note>
@@ -7199,7 +8238,7 @@ euch sagen: Siehe, er ist in der Wüste, so geht nicht hinaus, oder siehe,
 er ist im Gemache, so glaubt es nicht. Denn wie der Blitz vom Osten
 blitzt und bis zum Westen gesehen wird, so wird die Ankunft des
 Menschensohnes sein“. Zu anderer Zeit aber, als er mit den Juden
-<lb n="10"/> redete, fügte er dies hinzu und sagte: „Ich bin im Namen meines Vaters <note type="marginal">Σ171</note>
+<lb n="10"/> redete, fügte er dies hinzu und sagte: „Ich bin im Namen meines Vaters <milestone unit="altnumbering" n="171"/>
 gekommen, aber ihr habt mich nicht aufgenommen. Wenn aber ein
 anderer in seinem eigenen Namen kommt, den werdet ihr aufnehmen.“
 Dies sagte er über den lügnerischen Antichristen voraus, den sie erwarten
@@ -7227,7 +8266,7 @@ der sichtbaren Erde. Damit aber niemand (dies) meine, lehrt er so und
 <note type="footnote">27 πλείους τοιούτους ἔσεσθαι, ἐξ ὧν δὴ καὶ αὐτῶν ἡ ἀλήθεια τῶν σωτηρίων
 προγνώσεων τὴν μαρτυρίαν εἴληφεν Th. gr. „von denen eben auch Zeugnis über
 die Wahrheit des Vorauswissens unsers Erlösers empfangen hat“ Σ. Lies viell.
-<foreign xml:lang="abbr">ABBREV</foreign> ,,von denen . . . . . auch wir Zeugnis empfangen haben“</note>
+<foreign xml:lang="abbr">ABBREV</foreign> „von denen . . . . . auch wir Zeugnis empfangen haben“</note>
 
 <pb n="v.3.pt.2.p.217"/>
 sagt: „Wenn jemand zu euch spricht: Siehe hier ist der Christus oder
@@ -7238,15 +8277,18 @@ eines Menschen und in Einem Winkel erschienen. Wie aber seine
 zweite gelobte Ankunft vom Himmel her stattfinden werde, lehrt er,
 indem er sagt: „Denn wie der Blitz ausgeht vom Osten und gesehen
 wird bis zum Westen, so wird die Ankunft des Menschensohnes sein.“</p>
-<p>Über das, was sich am Ende der Dinge ereignen werde.
-Aus dem Evangelium des Matthäus.</p> <lb n="10"/>
-<p>XXXVI „Es wird aber dazu kommen, daß ihr hört von Kriegen
+</div>
+<note>Über das, was sich am Ende der Dinge ereignen werde.
+Aus dem Evangelium des Matthäus.</note> <lb n="10"/>
+
+<div type="textpart" subtype="chapter" n="36">
+<p> „Es wird aber dazu kommen, daß ihr hört von Kriegen
 Kriegsgerüchten; üchten; seht zu, damit ihr nicht erschreckt. Denn es
 muß kommen, aber das ist noch nicht das Ende. Denn es wird sich
 erheben ein Volk wider das andere und ein Reich wider das andere,
 und es werden sein Hungersnöte, Seuchen und (Erd)beben an jedem <lb n="15"/>
 Ort. Dies alles aber ist der Anfang der Wehen. Hierauf werden sie
-Σ 172 euch ausliefern zur Drangsal und euch töten, und ihr werdet gehaßt
+<milestone unit="altnumbering" n="172"/> euch ausliefern zur Drangsal und euch töten, und ihr werdet gehaßt
 sein von allen Völkern um meines Namens willen.“ Er fügt aber
 hinzu und sagt: „Hierauf werden viele Anstoß nehmen und werden
 einer den andern ausliefern und einander hassen. Und viele Lügenpropheten <lb n="20"/>
@@ -7275,7 +8317,10 @@ und schwere Verfolgungen und gewaltige Drangsale sein werden.
 Darauf aber sagt er: „Und ihr werdet gehaßt sein von allen Völkern,“
 <lb n="5"/> nicht wegen anderer verhaßter Taten, sondern (nur) um seines Namens
 willen.</p>
-<p>XXVII. Diese Beweise der göttlichen Offenbarung unsers Erlösers,
+</div>
+      
+<div type="textpart" subtype="chapter" n="37">
+<p>Diese Beweise der göttlichen Offenbarung unsers Erlösers,
 die bis jetzt mit Augen gesehen werden, zeigen, zeigen, Worte zumal
 und Taten göttlich (sind). Denn früher wurden einfach die Stimmen
 <lb n="10"/> gehört, jetzt aber in unsern Zeiten sind die Erfüllungen seiner Worte
@@ -7286,7 +8331,7 @@ gegen das Offenbare sich aufzulehnen pflegt, sodaß er auch gegen die
 <lb n="15"/> über alles (waltende) Vorsehung mit feindlichen Worten zu reden
 wagt, und so auch Gott selbst leugnet und so auch über vieles andere
 schamlos streitet, über das die Wahrheit Zeugnis ablegt. Aber wie
-ihre Verleumdung dem wahren Worte der Natur nichts schadet, so <note type="marginal">Σ173</note>
+ihre Verleumdung dem wahren Worte der Natur nichts schadet, so <milestone unit="altnumbering" n="173"/>
 schadet auch die Bosheit des Unglaubens einiger nichts der Vorzüglichkeit
 <lb n="20"/> der offenbaren Gottheit unsers Erlösers. Indessen aber, wenn es
 recht ist, dass wir auch ihnen die Art, die einer vernünftigen Heilung
@@ -7295,14 +8340,16 @@ hier ihnen nützlich nahe zu bringen. Was wir früher andern gegenüber
 geprüft haben, das wollen wir auch jetzt solchen erzählen, die sich
 <lb n="25"/> durch das Gesagte nicht haben überzeugen lassen.</p>
 <p>Zu Ende ist das vierte Buch des Cäsareensers.</p>
-<note type="footnote">21 „ihnen . . . . an[assen“] wörtlich „zu ihnen hinzufügen.“ Vermutlich =
+<note type="footnote">21 „ihnen . . . . an<del>assen“</del> wörtlich „zu ihnen hinzufügen.“ Vermutlich =
 ἁρμόζω πρός τινα 26 Die Unterschrift stammt nicht von Eusebius</note>
 </div>
+ </div>
 
  <div type="textpart" subtype="book" n="5">
 <pb n="v.3.pt.2.p.219"/>
 <head>Das fünfte Buch des Cäsareensers.</head>
-<p>I. Derartig sind die Beweise der Theophanie des gemeisamen Erlösers
+<div type="textpart" subtype="chapter" n="1">
+<p>Derartig sind die Beweise der Theophanie des gemeisamen Erlösers
 aller, Jesu Christi, die bis jetzt mit den Augen wahrgenommen
 werden (und die) zeigen, daß Worte zumal und Taten göttlich sind. Denn
 früher wurden einfach die Stimmen gehört, die die kommenden Dinge <lb n="5"/>
@@ -7324,13 +8371,16 @@ Wort sie überzeugte. Indessen aber wollen wir zum Überfluß das gegen <lb n="2
 sie wieder aufnehmen, was wir auch früher in den Evangelienbeweisen
 mit Fragen geprüft haben. Wenn also irgend jemand nach alledem der
 Wahrheit hartnächkig widerstrebt und schamlos zu sagen sich erfrecht,
-<note type="marginal">Σ174</note> daß er (Jesus) keineswegs der Christus Gottes sei, wie wir meinen, sondern
+<milestone unit="altnumbering" n="174"/> daß er (Jesus) keineswegs der Christus Gottes sei, wie wir meinen, sondern
 ein Zauberer, Betrüger und Verführer, so wollen wir ihm, als einem <lb n="25"/>
 Unmündigen im Geiste, eben das vorlegen, was wir schon früher geprüft
 haben.</p>
 <p>Wider diejenigen, die den Christus Gottes für einen Zauberer und
 Betrüger halten.</p>
-<p>II. Fortan wollen wir fragen, ob man jemals von aller Ewigkeit an <lb n="30"/>
+</div>
+
+<div type="textpart" subtype="chapter" n="2">
+<p>Fortan wollen wir fragen, ob man jemals von aller Ewigkeit an <lb n="30"/>
 von einem Betrüger und Zauberer gehört hat, daß er Lehrer der
 <note type="footnote">30—S. 220,19 = Dem. III 331—2 31 vgl. Matth 53 ff.</note>
 
@@ -7353,7 +8403,11 @@ ist, aus seinen Worten, die bis jetzt auf der ganzen Erde verkündigt
 (Lebens) führung sei, infolge deren jeder, der die Wahrheit liebt, bekennt,
 daß er nicht nur kein Zauberer und Betrüger, sondern in Wahrheit das
 Wort Gottes und ein Lehrer der göttlichen und frommen Philosophie,
-aber nicht der weltlichen (und) gemeinen Philosophie sei. III. Aber das
+aber nicht der weltlichen (und) gemeinen Philosophie sei.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="3">
+<p>Aber das
 <lb n="20"/> Ethische seiner Lehre (ist) derart.</p>
 <p>Wohlan aber, prüfen wir, ob nicht seine Verirrung in denn Hauptpunkten
 seiner Dogmatik bestand. Steht denn nicht von ihm geschrieben,
@@ -7361,14 +8415,14 @@ daß er selbst den Allkönig Gott, die einzige Ursache alles Guten, lehrte
 und seine Jünger (eben dahin) brachte, und führen nicht bis jetzt die
 <lb n="25"/> Worte seiner Lehre jeden Griechen und Barbaren nach oben in ihrem
 Geist zu dem höchsten Gott, dem Schöpfer Himmels und der Erden
-und der ganzen Welt, der jede sichtbare und gewordene Natur übertrifft? <note type="marginal">Σ175</note>
+und der ganzen Welt, der jede sichtbare und gewordene Natur übertrifft? <milestone unit="altnumbering" n="175"/>
 <note type="footnote">3 vgl. Matth 528 5 vgl. Matth 542 6 2 ff. 11 vgl. Matth 533 ff.
 19—S. 222,4 = Dem. III 3 4—9</note>
 <note type="footnote">5 τοὺς φοιτητάς παιδεύειν τῶν ὑπαρχόντων ἐνδεέσι κοινωνεῖν D „daß die, die
 arm sind in ihren Besitztümern, ihm anhingen“ Σ (mißverstandenes κοινωνεῖν!)
 8 ὁ τῆς πανδήμου καὶ ἀγελαίου καὶ θορυβώδους συνουσίας ἀνεγείρων (1. ἀείργων) D
 20 „das Ethische“] genauer „das Charakteristische“ Σ τὰ . . . . ἠθικώτερα D
-22 „Dogmatik“] genauer„ Lehrr“ Σ δογμάτων D 23
+22 „Dogmatik“] genauer „ Lehrr“ Σ δογμάτων D 23
 doch vgl. 8111 | „lehrte“] ἀνακείμενος D 1. <foreign xml:lang="abbr">ABBREV</foreign> Ptz. Pass? 27 θεὸν . . .
 πᾶσαν ὁρατὴν φύσιν ὑπερκύψαντα D „und springen (nicht die Worte) aus jeder
 . . . . Natur hervor“ Σ</note>
@@ -7384,8 +8438,11 @@ Philosophen mächtig gefördert wurden und mit deren Lehre sie übereinstimmten.
 Es rühmen sich aber auch die Weisesten der Griechen
 wegen der Orakel ihrer Götter, da sie (die Orakel) die Hebräer so erwähnen:
 „Allein die Chaldäer erlangten Weisheit und die Hebräer, die <lb n="10"/>
-Gott, den König des Alls, den ans sich selbst Erzeugten, fromm verehrten.“
-IV. Wenn also auch einst die Gottliebenden, über die besonders
+Gott, den König des Alls, den ans sich selbst Erzeugten, fromm verehrten.“</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="4">
+<p>Wenn also auch einst die Gottliebenden, über die besonders
 auch die Orakel Zeugnis ablegen, zu dem allerhöchsten Gott die
 Verehrung erhoben, warum bekennen wir (dann), daß er ein Verführer
 sei, und nicht vielmehr ein bewundernswerter Lehrer der Frömmigkeit, <lb n="15"/>
@@ -7397,31 +8454,36 @@ zumal, die einst die wildesten waren, und der weisen und hellenischen <lb n="20"
 Männer, die nach Art der früheren Propheten und frommen Männer
 zur Gottesverehrung erzogen waren durch seine Kraft allein und seine
 Lehre?</p>
-<p>V. Aber wir wollen auch das Dritte prüfen! War es etwa dies,
+</div>
+
+<div type="textpart" subtype="chapter" n="5">
+<p>Aber wir wollen auch das Dritte prüfen! War es etwa dies,
 um dessentwillen sie ihn einen Verführer heißen: daß er lehrte, nicht <lb n="25"/>
 mehr durch Stieropfer, noch durch Schlachtungen unvernünftiger Tiere,
 noch durch Blut und Feuer, noch durch Räucherwerk, das von der Erde
 (aufsteigt), Gott verehren, deswegen, weil er *zeigte, daß dies minderwertig
-und irdisch sei &lt;und&gt; niemals entspreche der unsterblichen
+und irdisch sei <add>und</add> niemals entspreche der unsterblichen
 unkörperlichen Natur, vielmehr urteilte, daß von allen Opfern dies das <lb n="30"/>
 angenehmste und Gott wohlgefälligste sei, die göttlichen Gebote zu halten,
 und lehrte, durch sie sich rein erhalten an Leib und Seele und sich um
 <note type="footnote">10 = Porphyrius: Περί τῆς ἐκ λογίων φιλοσοφίας Ι 135 f. Wolff; Praep. IX 10 4</note>
-<note type="footnote">1 ἢ ὅτι μὴ καὶ πλείους σέβειν θεοὺς ἐκ τῆς ἀνωτάτω („offenbaren“ Σ <lb n="1."/>
-<foreign xml:lang="abbr">ABBREV</foreign> mit HS) καὶ μόνης μόνης θεολογίας &lt;εἰς&gt; τὸν ὡς ἀληθπῶς πλάνον τραχηλισθέωτα
+<note type="footnote">1 ἢ ὅτι μὴ καὶ πλείους σέβειν θεοὺς ἐκ τῆς ἀνωτάτω ( „offenbaren“ Σ <lb n="1."/>
+<foreign xml:lang="abbr">ABBREV</foreign> mit HS) καὶ μόνης μόνης θεολογίας <add>εἰς</add> τὸν ὡς ἀληθπῶς πλάνον τραχηλισθέωτα
 συγχωρεῖ D εἰς + Gr 10 μοῦνοι Χαλδαῖοι ἐπὶ σοφίην λάχον D
-14 „warum“] τι δὴ D Σ? Vielleicht τι δεῖ Σ vgl. Stud. 122 28 ,,und zeigte“ Σ]
+14 „warum“] τι δὴ D Σ? Vielleicht τι δεῖ Σ vgl. Stud. 122 28 „und zeigte“ Σ]
 ταπεινὰ μὲν καὶ γεώδη ταῦτα καὶ τῆς ἀθανάτου φύσεως οὐδαμῶς οἰκεῖα λογισάμενος
 D. Das ABBERV gehört vor <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.222"/>
 klaren Verstand und fromme Lehren bemühen, um sich der Ähnlichkeit
-mit Gott anzuähneln. Wenn aber jemand von den Griechen dies tadelt, <note type="marginal">Σ176</note>
+mit Gott anzuähneln. Wenn aber jemand von den Griechen dies tadelt, <milestone unit="altnumbering" n="176"/>
 so wisse er, daß er keineswegs das sinnt, was seinen Lehrern angenehm
 ist, die vieles darüber anordneten, daß man nicht glauben dürfe, Gott
 <lb n="5"/> durch Blut und Opfer unvernünftiger Tiere und durch Feuer, Rauch
 und (Fett)geruch zu ehren.</p>
-<p>VI. Außerdem aber wissen wir, die wir von ihm (Christus) gelernt
+</div>
+<div type="textpart" subtype="chapter" n="6">
+<p>Außerdem aber wissen wir, die wir von ihm (Christus) gelernt
 haben, daß die Welt geworden ist und (daß) der Himmel selbst, die
 Sonne, der Mond und die Sterne Werke Gottes sind, und daß ma nicht
 <lb n="10"/> diese (Dinge), sondern (nur) den Werkmeister und Schöpfer aller verehren
@@ -7443,7 +8505,10 @@ Augenbrauen in die Höhe ziehen, die gesagt haben, daß die Seele im
 und Fliegen, aber (daß) auch nicht einmal von der Seele der Schlange,
 der Natter, des *Bären, des Panthers und des Schweines sich ihre eigene
 Stele ihrem Wesen nach in irgend etwas unterscheide?</p>
-<p>VII. Indem er aber überdies häufig an das Gericht Gottes erinnert
+</div>
+
+<div type="textpart" subtype="chapter" n="7">
+<p>Indem er aber überdies häufig an das Gericht Gottes erinnert
 <lb n="30"/> und den Gottlosen die Strafen und Züchtigungen, die unvermeidbar sind,
 und den Frommen die Verheißungen des ewigen Lebens, des himmliischen
 Reiches und des glückseligen Daseins bei Gott verspricht — wen führt
@@ -7459,11 +8524,13 @@ zu sein und zu wissen“ Σ (1. <foreign xml:lang="abbr">ABBREV</foreign> ?) 25 
 um der Kampf(preise) willen, die den Frommen aufbewahrt werden, dagegen
 jede Boshaftigkeit zu fliehen und von sich zu stoßen wegen der
 Strafen, die den Gottlosen auferlegt werden? Denn derart waren die
-<note type="marginal">Σ177</note> Unterweisungen, die in den Dogmen der Lehre unsers Erlösers eingeschlossen
+<milestone unit="altnumbering" n="177"/> Unterweisungen, die in den Dogmen der Lehre unsers Erlösers eingeschlossen
 sind. Welcher Platz also bleibt für den Argwohn, zu <lb n="5"/>
 glauben, daß er ein Betrüger und Zauberer sei? Aber jedoch prüfen
 wir auch dies.</p>
-<p>VIII. Zu was für Leuten macht der Zauberer seine Genossen, wenn
+</div>
+<div type="textpart" subtype="chapter" n="8">
+<p>Zu was für Leuten macht der Zauberer seine Genossen, wenn
 er ihnen Anteil gibt an den (Dingen) der Bosheit? (Macht er sie) nicht
 zu Zauberern und Betrügern und Giftmischern, die in allem ihm gleichen? <lb n="10"/>
 Ist denn jemals jemand im ganzen Geschlecht der Christen gefunden
@@ -7474,7 +8541,11 @@ Er also, der in der ganzen Menschenwelt für alle Völker die Ursache <lb n="15"
 eines reinen und keuschen Lebens und des Wissens (und) der Verehrung
 des Schöpfers aller war — was darf mit Recht geglaubt werden als dies,
 daß er in Wahrheit der gemeinsame Erlöser aller ist und der Lehrer
-eines gottesfürchtigen Lebens? IX. Diejenigen aber, die von Anfang
+eines gottesfürchtigen Lebens?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="9">
+<p>Diejenigen aber, die von Anfang
 an ihm anhingen, und diejenigen, die später die Überlieferung der Gewohnheit <note type="marginal">20</note>
 jener (Apostel) übernahmen, waren so weit entfernt von bösen
 und bitteren Gedanken, daß sie nicht einmal den Kranken erlaubten,
@@ -7504,16 +8575,23 @@ einer Lehre ausgibt, ein großer Beweis die Gemeinschaft seiner Jünger
 ihrer Lehre für sie war, daß er besser sei als sie. Denn wie auch
 Ärzte Zeugen sind für die Richtigkeit *der Lehre ihres Meisters, die
 Geometer aber — wen anders erkennen sie als Führer für sich an, wenn
-nicht einen Geometer, und die Arithmetiker einen Arithmetiker? Demgemäß <note type="marginal">Σ178</note>
+nicht einen Geometer, und die Arithmetiker einen Arithmetiker? Demgemäß <milestone unit="altnumbering" n="178"/>
 <lb n="10"/> sind aber auch die besten Zeugen für einen Zauberer seine
 Jünger, die ebenfalls ihrem Meister durchaus ähnliche (Dinge) tun.
 Aber auch nicht ein Jünger unsers Erlösers ist jemals in allen diesen
 Jahren als Zauberer erfunden worden, obwohl zu allen Zeiten Könige
 und ἡγεμόνες sorgfältig durch böse (Folter)qualen eine Untersuchung
-<lb n="15"/> der Dinge veranstaltet haben. X. So wenig war aber irgend ein Zauberer
+<lb n="15"/> der Dinge veranstaltet haben.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="10">
+<p>So wenig war aber irgend ein Zauberer
 sein Jünger, daß freigelassen wurde und jedes (gefährlichen) Prozesses
-ledig war, wer nur zu opfern von ihnen gezwungen war.
-XI. Damit aber nicht unsere Rede dahinfließe außerhalb der Schrift,
+ledig war, wer nur zu opfern von ihnen gezwungen war.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="11">
+<p>Damit aber nicht unsere Rede dahinfließe außerhalb der Schrift,
 su empfange den Beweis dafür auch aus der Schrift: Die ersten Vertrauten
 <lb n="20"/> und Jünger unsers Erlösers machten nach der Schrift ihrer
 Πραξεῖς diejenigen, die aus den Heiden zu ihrer Lehre kamen, derart,
@@ -7521,10 +8599,18 @@ daß viele von ihnen, die früher der Zauberei *beschuldigt waren, ihre
 Art so sehr veränderten, daß sie mitten in die Menge die verworfenen
 Bücher zu bringen wagten, die einst bei ihnen verborgen waren, und
 <lb n="25"/> eben sie vor jedermann dem Feuer übergaben. Höred aber, wie die
-Schrift hierüber lautet: XII. „Ein gut Teil aber von denen, die
+Schrift hierüber lautet:</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="12">
+<p> „Ein gut Teil aber von denen, die
 trieben, brachten ihre Bücher hinein und verbrannten sie vor jedermann;
 man rechnete aber ihren Preis zusammen und fand, daß sie fürf Myriaden
-wert waren.“ XIII. *Derart also waren die Jünger unsers Erlösers,
+wert waren.“</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="13">
+<p>*Derart also waren die Jünger unsers Erlösers,
 <lb n="30"/> und sie brachten eine so große Kraft *der Worte
 mit den den Hörern hervor, daß sie in die Tiefe ihrer Seele trafen
 <note type="footnote">17—225,8 = Dem. III 614—18 26 = Act 19 19</note>
@@ -7543,7 +8629,7 @@ die Irre geführt wurden, sondern das Verborgene ans Licht brachten
 und Zeugen wurden wider sich selbst und wider ihre frühere Bosheit.
 *Derartig waren aber auch die, welche von ihnen zu Jüngern gemacht <lb n="5"/>
 wurden: rein und lauter in ihrer Seele und echt in ihrer Liebe, sodaß
-<note type="marginal">Σ179</note> sie nichts Tadelnswertes in sich versteckt ließen, sondern sich rühmten
+<milestone unit="altnumbering" n="179"/> sie nichts Tadelnswertes in sich versteckt ließen, sondern sich rühmten
 und frohlockten wegen der Wandlung vom Schlechteren zum Besseren.
 Wenn also die Jünger unsers Erlösers ersichtlich so geworden so geworden sind,
 wie sollte nicht ihr Meister noch viel besser sein? Wenn du aber auch <lb n="10"/>
@@ -7553,7 +8639,11 @@ Menge Scharen von Männern sind, die sich wappnen wider die natürlichen
 Lüste des Leibes und ihren Geist unverwundet von allen schändlichen
 Leidenschaften zu bewahren sich bemühen, die ihr ganzes Leben <lb n="15"/>
 hindurch in Reinheit alt geworden sind und glänzende Zeugnisse infolge
-der aus seinen Worten (geschörften) Nahrung aufwiesen. XIV. Aber
+der aus seinen Worten (geschörften) Nahrung aufwiesen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="14">
+<p>Aber
 nicht nur Männer wurden bei ihm in dieser Weise Philoaophen, sondern
 auch Myriaden von Weibern in der ganzen Welt, die nach Art von
 Priesterinnen des über alles (waltenden) Gottes den höchsten (Gottes)dienst <lb n="20"/>
@@ -7593,7 +8683,7 @@ der Worte unsers Erlösers emporgehoben wurden über jede polytheistische
 dieser ganzen Welt erkannten und bekannten? Ihn, den einst Einer:
 Platon, erkannte, aber bekannte, daß er nicht wage, es vor jedermann
 zu sagen, weil ihm keine so große Kraft der Frömmigkeit zu Gebote
-stand. Die Jünger unsers Erlösers aber, denen es ein leichtes war, <note type="marginal">Σ180</note>
+stand. Die Jünger unsers Erlösers aber, denen es ein leichtes war, <milestone unit="altnumbering" n="180"/>
 <lb n="15"/> durch die Hilfe ihres Meisters den Vater und Schöpfer des Alls zu
 erkennen und zu finden, offenbarten ihn im ganzen Geschlecht der
 Menschen und verkündeten die Kenntnis von ihm allen in der ganzen
@@ -7606,7 +8696,10 @@ waren die Siegestaten des gemeinsamen Erlösers aller, die Verführungskünste
 dessen, der für einen Verführer gehalten wurde, und nur derart
 <lb n="25"/> seine Jünger und Vertrauten, aus denen man erkennen darf, wie ihr
 Meister war.</p>
-<p>XV. Wohlan aber, ferner wollen wir das Wort auch so prüfen!
+</div>
+
+<div type="textpart" subtype="chapter" n="15">
+<p>Wohlan aber, ferner wollen wir das Wort auch so prüfen!
 Einen Zauberer nennst du ihn, du da!, aber auch einen geschickten
 Quacksalber und Verführer heißt du ihn. Ist er denn jetwa als der
 <lb n="30"/> alleinige (und) erste Erfinder dieser Sache aufgetreten, oder dúrfen wir
@@ -7628,19 +8721,21 @@ und Selbstgebildeter, als Schöpfer dieser Dinge erschienen ist, obwohl
 es nicht möglich ist, die Lehre einer Handwerkskunst oder der logischen <lb n="5"/>
 Wissenschaft und nicht (einmal) der ersten Elemente ohne irgend einen
 Unterweiser und Lehrer (in sich) aufzunehmen, es sei denn, daß jemand
-außerhalb der &lt;gemeinsamen&gt; (Menschen)natur stehe. Niemals also trat
+außerhalb der <add>gemeinsamen</add> (Menschen)natur stehe. Niemals also trat
 ein Selbstgelehrter hervor als Lehrer der Grammatik, noch ein Rhetor.
-ohne gelernt zu haben, noch wurde ein Arzt &lt;aus sich&gt; selbst, noch ein <lb n="10"/>
+ohne gelernt zu haben, noch wurde ein Arzt <add>aus sich</add> selbst, noch ein <lb n="10"/>
 Zimmermanu, noch der Schöpfer einer andern Kunst, obwohl dies gering
 ring und menschlich ist. Die (Tatsache) aber, daß jemand von dem
 Lehrer der ganzen Menschenwelt, der die Wunder getan hat, die in der
-<note type="marginal">Σ181</note> Schrift seiner Jünger geschrieben sind, sagt, er sei aus sich selbst so
+<milestone unit="altnumbering" n="181"/> Schrift seiner Jünger geschrieben sind, sagt, er sei aus sich selbst so
 geworden, ohne von den Vorgängern empfangen zu haben noch von <lb n="15"/>
 neueren Lehrern unterstützt zu sein, die ihm gleich (auch) vor ihm handelten,
 — was bedeutet das anderes als das Zeugnis und Bekenntnis,
 daß (hier) etwas Göttliches war und (einer, der) besser (war) als jede
 menschliche Natur?</p>
-<p>XVI. Aber du sagst, daß er verführende Lehrer besaß und daß <lb n="20"/>
+</div>
+<div type="textpart" subtype="chapter" n="16">
+<p>Aber du sagst, daß er verführende Lehrer besaß und daß <lb n="20"/>
 ihm nicht verborgen waren die weisen (Theorien) der Ägypter und die
 geheimen (Mysterien), die einst bei ihnen verkündet wurden, von denen
 er sammelte und als derartiger Mann erschien, wie das Wort (der
@@ -7657,9 +8752,9 @@ daß er derartige Heilungen vollbrachte wie die, von denen man berichtet,
 daß unser Erlöser sie getan habe? Von welchem ander aber
 <note type="footnote"> „Handwerkskunst“] βαναύσου τέχνης D 8 μή οὐχὶ τὴν κοινὴν ἐκβεβηκότα
 φύσιν D κοινὴν &lt; Σ 1. ABBERV 10 οὐδὲ αὐτοφυὴς ἰατρός D 1. ABBERV
-ABBERV ABBERV 16 διδασκάλων τὰ ὅμοιαα καὶ πρὸ αὐτοῦ πεποιηκότων D ,,die
+ABBERV ABBERV 16 διδασκάλων τὰ ὅμοιαα καὶ πρὸ αὐτοῦ πεποιηκότων D „die
 gemäß dem, was vor ihm war, handelten“ Σ 24 τί δῆτα οὐν, ἤ τιωες ἄλλοι D
-26 „bevor — machte“] örtlicher ,,vor dem Namen dieses“ Σ πρὸ τῆς τούτου
+26 „bevor — machte“] örtlicher „vor dem Namen dieses“ Σ πρὸ τῆς τούτου
 κατηγορίας D</note>
 
 <pb n="v.3.pt.2.p.228"/>
@@ -7678,7 +8773,7 @@ was sie sahen und von ihm bezeugten, und alle Arten von Qualen
 erduldeten und schließlich die Zeugnisse, die sie von ihm als dem Sohne
 Gottes, geschweige denn (als von) einem Zauberer ablegten, durch ihr
 <lb n="15"/> eigenes Blut versiegelten? Wem aber von den Zauberern kam es jemals
-in den Sinn, die Sammlung eines neuen Volkes auf seinen Namen <note type="marginal">Σ182</note>
+in den Sinn, die Sammlung eines neuen Volkes auf seinen Namen <milestone unit="altnumbering" n="182"/>
 zu veranstalten? Die (Tatsache) aber, daß er es nicht nur überlegte,
 sondern auch die Überlegung ausführte, wie sollte das nicht jede
 Natur der Menschen in den Schatten stellen? Und die (Tatsache),
@@ -7686,7 +8781,11 @@ Natur der Menschen in den Schatten stellen? Und die (Tatsache),
 (waren), wider die Satzungen der Könige, der früheren Gesetzgeber,
 der Philosophen, Poeten und Theologen, und diese (Gesetze) *bestätigte
 und für die lange Ewigkeit als unbesiegbar und unüberwindlich
-zeigte — XVII. wer jemals von den Zauberern ersann (das)? Unser
+zeigte —</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="17">
+<p>wer jemals von den Zauberern ersann (das)? Unser
 <lb n="25"/> Erlöser aber ersann es nicht ohne daß er wagte, hand anzulegen, sondern
 er legte nicht einmal Hand an, ohne es auszuführen. Mit Einem Worte
 und mit Einer Stimme sagte er zu seinen Jüngern: „Gehet hin und
@@ -7717,13 +8816,16 @@ worden in dieser Zauberei? Wenn man aber einen andern nicht <lb n="10"/>
 nennen kann, der ihm ähnlich war, so war ihm also niemand die Ursache
 für so große Tüchtigkeit. Zeit ist *also zu bekennen, daß
 eine fremde und göttlche Natur in die Welt gekommen sei, die allein
-(und) zuerst das tat, was niemals unter den Menschen berichtet wird.
-XVIII. Nach diesem wollen wir ferner fragen, ob jemals jemand <lb n="15"/>
+(und) zuerst das tat, was niemals unter den Menschen berichtet wird.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="18">
+<p>Nach diesem wollen wir ferner fragen, ob jemals jemand <lb n="15"/>
 mit seinen Augen sah oder durch Hören (sagen) erfuhr, daß es irgend
 welche Zauberer und Giftmischer gebe, die ohne Spenden, Opfer und
 Anrufung von Dämonen zaubern, da doch jedermann bekannt und offenbar
 ist, daß jede Zauberei durch diese (Dinge) ausgeführt zu werden
-<note type="marginal">Σ183</note> pflegt? Kann also etwa jemand auch gegen unsern Erlöser oder gegen <lb n="20"/>
+<milestone unit="altnumbering" n="183"/> pflegt? Kann also etwa jemand auch gegen unsern Erlöser oder gegen <lb n="20"/>
 seine Jünger oder gegen diejenigen, die bis jetzt in seiner Lehre
 leben, eine derartige Verleumdung vorbringen? Ist es nicht auch dem
 Blinden klar, daß wir in allem diesem entgegengesetzt bereitet sind
@@ -7753,7 +8855,9 @@ mit den Menschen ausübte, seinen Anblick nicht ertrugen, sondern
 <lb n="5"/> eine rief von hier, der andere von der andern Seite und sagte: „Was
 haben wir mit dir gemein, Sohn Gottes? Bist du vor der Zeit gekommen,
 uns zu quälen?“</p>
-<p>XIX. Ein Mann, der nur auf die Zauberei seinen Sinn richtete und
+</div>
+<div type="textpart" subtype="chapter" n="19">
+<p>Ein Mann, der nur auf die Zauberei seinen Sinn richtete und
 völlig verworfene Dinge angriffe, wäre der nicht seiner Art
 <lb n="10"/> und offenbar lüstern, schändlich, frevelhaft, gottlos
 Und wenn er so wäre, woher oder wie könnte er die (Worte)
@@ -7763,9 +8867,9 @@ Kenntnis Gottes oder die über die Unsterblichkeit der Seele oder die
 <lb n="15"/> Gottes? Würde er denn nicht das Gegenteil von alledem
 indem er das täte, was der Schlechtigkeit entspräche, würde
 die Vorsehung Gottes leugnen, das Gericht Gottes und seine Gerechtigkeit
-als einen Mythos *verhöhnen und die Worte über die Tugend und <note type="marginal">Σ184</note>
+als einen Mythos *verhöhnen und die Worte über die Tugend und <milestone unit="altnumbering" n="184"/>
 die Unsterblichkeit der Seele verspotten? Wenn derartiges gesehen
-<lb n="20"/> würde auch bei unserm &lt;Erlöser&gt;, so wäre nichts dagegen
+<lb n="20"/> würde auch bei unserm <add>Erlöser</add>, so wäre nichts dagegen
 Wenn es aber ersichtlich ist, daß er bei allen seinen Worten und
 den oberhalb von allem (stehenden) Gott, den König des Alls
 und seine Jünger bereitete, so zu sein, und wenn er selbst
@@ -7778,7 +8882,7 @@ ist, wie sollte es nicht dem entsprechen, zu glauben, daß er nichts
 δικαιωτηρίου D 15 οὐχὶ τούτων ἀπάντων τὰ ἐναντία πρεσβεύει, ἀκόλουθα
 τῇ ἑαυτοῦ μοχθηρίᾳ πράττων D 18 καὶ θεὸν μὲν ἀρνήσεται καὶ θεοῦ πρόνοιαν
 καὶ θεοῦ κρίσιν, χλευάσει δὲ τοὺς περὶ ἀρετῆς καὶ τοὺς περὶ ψυχῆς ἀθανασίας
-λόγους,, D „verhöhnen“] „rooting up“ (= „raufen“ = 1. <foreign xml:lang="abbr">ABBREV</foreign> =
+λόγους „D „verhöhnen“] „rooting up“ (= „raufen“ = 1. <foreign xml:lang="abbr">ABBREV</foreign> =
 ABBERV = „murmeln“ PSm 1. ABBERV = „ermahnen“ Bernstein 1
 ἐμ παραιτήσει verlesen aus ἐμ)παροινήσει Gr. Schultheß verweist auf das Pe
 ABBERV (c. ABBERV p.) bei Ps. Dionys. ed. Chabot p. ABBERV ult. 20 περὶ τὸν
@@ -7789,7 +8893,9 @@ ABBERV (c. ABBERV p.) bei Ps. Dionys. ed. Chabot p. ABBERV ult. 20 περὶ τ�
 den wunderbaren Werken durch Zauberei getan habe, sondern zu bekennen,
 daß er sie durch verborgene und in Wahrheit göttliche
 gewirkt habe?</p>
-<p>XX. Dies also wider diejenigen, die mit gottlosem Munde ihn zu
+</div>
+<div type="textpart" subtype="chapter" n="20">
+<p>Dies also wider diejenigen, die mit gottlosem Munde ihn zu
 schmähen gewagt haben. Wenn sie sich aber wandeln und bekennen.
 er selbst sei zwar ein Lehrer reinen und keuschen Lebens und ein Einführer
 in die Lehre der Gottesverehrung gewesen, aber er habe die
@@ -7799,7 +8905,10 @@ nicht gewirkt, sondern seine Jünger hätten sie vollständig
 ist es Zeit, auch dieser Verleumdung zu begegnen.</p>
 <p>Wider diejenigen, die den Zeugnissen der ünger unsers unsers über
 seine wunderbaren Taten nicht glauben.</p>
-<p>XXI. Wenn sie aber sagen, daß er überhaupt nichts von
+</div>
+
+<div type="textpart" subtype="chapter" n="21">
+<p>Wenn sie aber sagen, daß er überhaupt nichts von
 Wundern noch von den staunenswerten Taten vollbracht habe, die seine <lb n="15"/>
 Jünger über ihn bezeugen, sondern daß seine Jünger
 und erlogen hätten deswegen, weil sie über ihn
@@ -7809,7 +8918,7 @@ Jünger, er aber der Meister hieß. Denn derjenige, der lehrt, gibt sich <note t
 als den Meister irgend einer Lehre aus, die Jünger aber wiederum,
 die Worte und die Lehren oder irgend eine Kunst lieben, überlassen
 sich dem Lehrer. Welchen Grund also könnte jemand nennen,
-<note type="marginal">Σ185</note>die Jünger unsers Erlösers q mit ihm verkehrten und was
+<milestone unit="altnumbering" n="185"/>die Jünger unsers Erlösers q mit ihm verkehrten und was
 sich um ihn zu bekümmern? Als Lehrer welcher Lehren erkannten sie
 ihn an? Oder ist dies klar? Denn (es ist) durchaus (notwendig, daß
 sie ihn als Lehrer dessen anerkannten), was sie von ihm lernten (und)
@@ -7856,6 +8965,7 @@ daß man nicht einmal eines Treueides bedürfe, geschweige
 Mein(eides), sondern ihren Charakter (so) zu machen, daß er
 <lb n="30"/> erschien als jeder Eid, bis zum (einfachen) „Ja“ fortzuschreiten und
 Wort mit Wahrhaftigkeit zu gebrauchen.</p>
+</div>
 <note type="footnote">4—S. 233,21 = Dem. III 433—38 5 = Matth 109f. 11 ff.
 5 21 ff. 30 vgl. Matth 5 37</note>
 <note type="footnote">2 „der “ oder „des Wohnungen“ 15 αὐτοὺς δὲ δεῖν τούτους
@@ -7866,7 +8976,8 @@ war, daß sie solcher Gesetze nicht bedurften“ Σ 27 „außerdem“]
 erschienen“ Σ</note>
 
 <pb n="v.3.pt.2.p.233"/>
-<note type="marginal">Σ186</note> <p>XXII. Wir müssen also fragen, ob es irgend einen Grund gibt,
+<milestone unit="altnumbering" n="186"/> <div type="textpart" subtype="chapter" n="22">
+<p>Wir müssen also fragen, ob es irgend einen Grund gibt,
 meinen, daß diejenigen, die Ηörer dieser (Worte) waren und auf
 Stelle auch als Lehrer anderer, *eigener Jünger auftraten, alles das
 haben, was sie als Taten ihres Meisters bezeugt haben. Was
@@ -7880,7 +8991,11 @@ gottesfürchtiges Leben liebten, alle ihre Hausgenossen
 und anstatt ihrer Geliebten, ich meine aber ihrer Weiber, Kinder und
 ihrer ganzen Familie, ihre Leben(sart) besitzlos machten und ein ϋbereinstimmendes
 Zeugnis über ihren Meister wie aus Einem Munde unter
-alle Menschen hinaustrugen. XXIII. Der erste Grund also, der hauptsächliche
+alle Menschen hinaustrugen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="23">
+<p>Der erste Grund also, der hauptsächliche
 und wahre, wäre dies; prüfen wir aber auch das hauptsächliche <lb n="15"/>
 und wahre, wäre dires; prüfen wir aber auch das Gegenteil!</p>
 <p>Er möge nämlich nämlich der Lehrer und sie die Jünger
@@ -7907,7 +9022,7 @@ Lehre (und) der Verheißung einer neuen Frömmigkeit. Sie
 θάνειν δ’ ἐπὶ πᾶσι τούτοις σπουδάζειν D „nach alledem“ Σ</note>
 
 <pb n="v.3.pt.2.p.234"/>
-dem nachtrachten und dem, was noch schlimmer ist als dies wegen der <note type="marginal">Σ187</note>
+dem nachtrachten und dem, was noch schlimmer ist als dies wegen der <milestone unit="altnumbering" n="187"/>
 abschüssigen Bahn des Bösen und seiner
 In die Höhe erheben (gewaltig preisen) mögen sie ihren
 erdichteten Worten, ohne auch nur Ein lügnerisches Wort zu
@@ -7915,7 +9030,10 @@ erdichteten Worten, ohne auch nur Ein lügnerisches Wort zu
 ihm zuschreiben, damit man auch sie bewundere und ihnen die Glückseligkeit
 gebe, die gewürdigt waren, die Jünger
 (Meisters) zu werden.</p>
-<p>XXIV. Wohlan also, wir wolleD sehen, ob es möglich war,
+</div>
+
+<div type="textpart" subtype="chapter" n="24">
+<p>Wohlan also, wir wolleD sehen, ob es möglich war,
 <lb n="10"/> wenn sie so waren, das zustande kommen konnte, was sie inbetreff
 seiner wagten. Denn man sagt, daß das Böse dem Bösen
 sei. und nicht einmal dem Guten. Woher also wurde bei der Menge
@@ -7956,7 +9074,7 @@ ihrem Charakter schändlich und lustliebend wären, dann wäre es vielleicht
 wahrscheinlich von ihnen zu meinen, daß sie deswegen die Sache <lb n="5"/>
 machten und bis zum Tode Wagehälse waren. Wenn sie aber das
 Gegenteil davon verkündeten und es durchaus in die Ohren aller
-<note type="marginal">Σ188</note> Scharen riefen und bald auch durch den Unterricht in der Schrift sie
+<milestone unit="altnumbering" n="188"/> Scharen riefen und bald auch durch den Unterricht in der Schrift sie
 ermahnten, jede schändliche und lüsterne Begierde zu fliehen, sich von
 jeder Übervorteilung fernzuhalten und alle Leidenschaften und die Geldgier <lb n="10"/>
 zu überwinden, und wenn sie derartiges diejenigen lehrten, die
@@ -7966,7 +9084,9 @@ Leben der Ruhe und des Ergötzens teil hatten. Da sie also durch eins
 von diesen (Dingen) nicht geleitet wurden, *wie ertrugen sie es, für <lb n="15"/>
 nichts eine böse Strafe und eine Züchtigung zu empfangen nur für das
 Zeugnis über ihren Meister, der nicht mehr war?</p>
-<p>XXV. Das möge zugegeben werden, daß sie ihn ehrten, während
+</div>
+<div type="textpart" subtype="chapter" n="25">
+<p>Das möge zugegeben werden, daß sie ihn ehrten, während
 er noch bei ihnen war und seinen Verkehr mit ihnen unterhielt und
 durch Verführung, wie jemand sagen möchte, sie verführte. Warum <lb n="20"/>
 also haben sie ihn auch nach dem Tode, und noch viel mehr damals
@@ -7994,7 +9114,7 @@ Ursache für sie geworden war, sondern ein Lehrer alles Bösen?
 ein Mann, der Verstand und Tugend besitzt, würde für eine
 oder für einen guten Menschen vielleicht geziemend einmal
 Tod ruhmreich erleiden. Wer aber böse ist in seinem Charakter,
-<lb n="5"/> er allein dem zeitlichen und an Begierden angenehmen Leben nachjagt, <note type="marginal">Σ189	</note>
+<lb n="5"/> er allein dem zeitlichen und an Begierden angenehmen Leben nachjagt, <milestone unit="altnumbering" n="189"/>
 würde niemals den Tod dem Leben vorziehen und nicht einmal
 seine Lieben eine harte Strafe erdulden, geschweige denn für den,
 wegen seiner Bosheit getadelt (und verurteilt) wird. Wie sollten also
@@ -8014,7 +9134,9 @@ mit Lobpreisen priesen, solange es ihnen die Herrschaft erlaubte.
 Sogleich aber, als für jene eine Änderung eintrat, änderten auch
 ihre Worte und wollten fernerhin keine Frwähnung tun derer, die
 (regierten), aus Furcht vor denen, die in der Gegenwart herrschten.</p>
-<lb n="25"/> <p>XXVI. Wenn also die Jünger unsers Erlösers
+</div>
+<lb n="25"/> <div type="textpart" subtype="chapter" n="26">
+<p>Wenn also die Jünger unsers Erlösers
 gewesen wären — nimm aber auch dies hinzu, daß
 und durchaus Laien waren, das heißt aber auch Barbaren und
 die nicht mehr verstanden als die syrische Sprache — wie konnten sie,
@@ -8035,20 +9157,26 @@ ruhig (liegen) lassen, sondern den Kamen unsers Erlösers
 verkünden und seine wunderbaren Taten *nicht nur, sondern auch
 Befehle in Dorf und Stadt lehren, und (daß) die einen in die
 der Römer und in die königliche Stadt sich verbreiten, die andern in
-<note type="marginal">Σ190</note> Land der Perser, andere in das Land der Armenier, andere zum Volk der
+<milestone unit="altnumbering" n="190"/> Land der Perser, andere in das Land der Armenier, andere zum Volk der
 Parther und ferner auch zu den Skythen, und (daß) andere sogar bis
 den Enden der Welt ausziehen und ins Land der Inder vordringen, und
 (daß) andere jenseits des Ozeans bis zu den (so)genannten
 Inseln hinÜbergehen — dies, meine ich, ist nicht (Sache) von Menschen,
 geschweige denn von Geringen und Laien, und noch weniger von Verführern
 und Zauberern.</p>
-<p>XXVII. Diejenigen aber, die ihren Meister als böse und
+</div>
+<div type="textpart" subtype="chapter" n="27">
+<p>Diejenigen aber, die ihren Meister als böse und
 erprobten und eben seinen Todesausgang mit ihren Augen sahen, welcher
 Worte bedienten sie sich denn, um mit einander übereinstimmend über <lb n="15"/>
 ihn zu faseln? Denn wie aus Einem Munde bezeugten sie alle die Reinigung
 der Aussätzigen, die Vertreibung der Dämonen,
 der Toten, das (Wiedererhalten des) Gesichts der Blinden und Myriaden
-andere Heilungen, die von ihm geschahen, XXVIII. und nach allem seine
+andere Heilungen, die von ihm geschahen,</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="28">
+<p>und nach allem seine
 eigene Auferstehung nach dem Tode, die ihnen zuerst sichtbar ward. Denn <lb n="20"/>
 da dies weder geschehen noch je gehört war zu ihren Zeiten, wie
 sie aus Einem Munde bezeugen und bestätigen, daß es geschehen
@@ -8076,10 +9204,10 @@ die Aufgeblasenheit des Irrwahns. Dafür, wohlan, wollen wir
 die Rechte geben und alle zumal einen Vertrag unter uns festsetzen,
 damit wir übereinstimmend den Betrug in betreff seiner unter alle Menschen
 <lb n="5"/> hinausbringen und sagen, wir hätten ihn gesehen, wie er
-Blinden die Sehkraft gab, was niemals einer #x003C;bemerkt hat, und wie er
-den Tauben das Gehör schenkte, was niemals einer&gt; gehört
+Blinden die Sehkraft gab, was niemals einer <add>bemerkt hat, und wie er
+den Tauben das Gehör schenkte, was niemals einer</add> gehört
 wie er die Aussätzigen rein und die Toten lebendig machte. Und
-es zusammenfassend zu sagen, was wir weder mit unsern Augen gesehen <note type="marginal">Σ191</note>
+es zusammenfassend zu sagen, was wir weder mit unsern Augen gesehen <milestone unit="altnumbering" n="191"/>
 <lb n="10"/> haben als von ihm geschehen, noch mit unsern Ohren gehört
 haben als (von ihm) gesagt, *das wollen wir als in Wahrheit geschehen
 kräftig behaupten. Aber wenn auch sein letztes Ende berühmt
@@ -8128,7 +9256,7 @@ aufheben, wollen ferner aber auch in ein anderes barbarisches Land
 gehen und das bei jedermann (Geltende) zerstören. An dem Willen
 (hierzu) möge niemand von uns es fehlen lassen! Denn keineswegs <lb n="15"/>
 ist klein der ἆθλος dessen, was wir wagen, da auch nicht die gewöhnliehen
-<note type="marginal">Σ192</note> Sieges (kränze) uns erwarten, sondern, wie es billig ist, Strafen
+<milestone unit="altnumbering" n="192"/> Sieges (kränze) uns erwarten, sondern, wie es billig ist, Strafen
 von den Gesetzen, die an jedem Ort (bestehen), Fesseln nämlich, Foltern,
 Einkerkerung, Feuer, Eisen, Kreuze und (wilde) Tiere, um derentwillen
 wir besonders in Freuden wollen und auf das Verderben gerade lossehen. <lb n="20"/>
@@ -8160,16 +9288,22 @@ Dinge an ihm kennen, sondern für uns selbst alles dieses faseln und
 verführen, soviele wir können. Wenn aber jemand sich
 <lb n="5"/> läßt, so wollen wir doch für das, was wir unter
 haben, den gebührenden (Lohn) für den Irrtum uns selbst zuziehen.“</p>
-<p>XXIX. Erscheint dir dies überzeugend und redest du dir noch ein,
+</div>
+<div type="textpart" subtype="chapter" n="29">
+<p>Erscheint dir dies überzeugend und redest du dir noch ein,
 daß derartiges faselten und als Vertrag unter sich festsetzten
 und laienhafte (Leute) und (dann) ins Reich der Römer
 <lb n="10"/> Oder daß die menschliche Natur, die die Liebe zum Leben zu
 besitzt, jemals aus freiem Willen den Tod für nichts ertragen
 Oder daß die Jünger unsers Erlösers zu so großer
 gediehen seien, daß sie, obwohl sie keine wunderbare Tat
-die von ihm geschehen sei, infolge eines Vertrages alle zumal derartiges <note type="marginal">Σ193</note>
+die von ihm geschehen sei, infolge eines Vertrages alle zumal derartiges <milestone unit="altnumbering" n="193"/>
 <lb n="15"/> faselten und ferner lügnerische Worte über ihn zusammensetzten
-dafür bereitwillig starben? XXX. Aber sie zogen keineswegs
+dafür bereitwillig starben?</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="30">
+<p>Aber sie zogen keineswegs
 eines Vertrages zu der Verkündigung über ihn aus noch setzten
 (einen solchen) unter sich fest. Woher (stammt) ihnen (denn) die
 Übereinstimmung ihres Zeugnisses über seine Taten? *Natürlich
@@ -8187,47 +9321,52 @@ darüber, nichts Wahres zu sagen, sondern zu faseln und Lügen
 Wahres sterben, (wie) vermochten weder Feuer noch Eisen noch wilde
 Tiere noch die Tiefe des Meeres, daß sie für Lüge
 den sie über ihren Meister erdichtet hatten?</p>
-<p>XXXI. Aber was sagst du? Sie hätten weder erwartet noch
+</div>
+<div type="textpart" subtype="chapter" n="31">
+<p>Aber was sagst du? Sie hätten weder erwartet noch
 <lb n="35"/> etwas Böses zu erleiden von dem Zeugnis über ihn,
 seien sie auch ohne Furcht zu der Verkündigung über ihn
 34—S. 246, 6 = Dem. III 5 60—87
-<note type="footnote">19 ,,Oder natürlich“ Σ wohl ἦ εἰκός 27 l. <foreign xml:lang="abbr">ABBREV</foreign></note>
+<note type="footnote">19 „Oder natürlich“ Σ wohl ἦ εἰκός 27 l. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.241"/>
-Aber es war unmöglich, nicht zu hoffen, daß sie alles
-würden, da sie die Zerstörung der Götter der Römer
+Aber es war unmöglich, nicht zu hoffen, daß sie alles Böse erleiden
+würden, da sie die Zerstörung der Götter der Römer zumal und der
 Griechen und der Barbaren einführten. Die Geschichte über sie zeigt
 deutlich, daß nach dem Tode ihres Meisters gewisse Feinde und Nachsteller
 des Logos sie ergriffen, zuerst dem Gefängnis übergaben, dann <lb n="5"/>
 sie befreiten und ihnen befahlen, mit niemandem (mehr) über den Namen
 Jesu zu reden. Da man sie hinterher fand, wie sie öffentlich die
-Menge über ihn belehrten, schleppte man sie hinweg und geißelte
-und bedrohte sie, nicht (mehr) zu lehren, während Simon Petrus
-antwortete, indem er sagte: ,,Man muß Gott mehr gehorchen als den <lb n="10"/>
-Menschen.“ Darnach aber wurde Stephanus gesteinigt und getötet,
-daß er freimütig mit der Menge der Juden redete, und
+Menge über ihn belehrten, schleppte man sie hinweg und geißelte sie
+und bedrohte sie, nicht (mehr) zu lehren, während Simon Petrus ihnen
+antwortete, indem er sagte: „Man muß Gott mehr gehorchen als den <lb n="10"/>
+Menschen.“ Darnach aber wurde Stephanus gesteinigt und getötet, darob
+daß er freimütig mit der Menge der Juden redete, und eine keineswegs
 geringe Verfolgung erhob sich wider die, welche den Namen Jesu predigten.
-<note type="marginal">Σ194</note> Und wiederum zu anderer Zeit, als Herodes König der
+<milestone unit="altnumbering" n="194"/> Und wiederum zu anderer Zeit, als Herodes König der Juden
 (War), tötete er den Jakobus, den Bruder des Johannes, mit dem Schwerte, <lb n="15"/>
 den Simon Petrus band ebenderselbe mit Fesseln, wie in den Πραξεῖς
-der Apostel geschrieben ist. Während sie dies litten, harrten die
-Jünger aus und hingen fest an der Lehre unsers Erlösers
+der Apostel geschrieben ist. Während sie dies litten, harrten die überigen
+Jünger aus und hingen fest an der Lehre unsers Erlösers und
 blieben noch mehr dabei, ihn und seine wunderbaren Taten jedermann
 zu verkünden. Später wurde Jakobus, den diejenigen, die früher in <lb n="20"/>
 Jerusalem wohnten, den Gerechten nannten wegen der gewaltig in ihm
 vorhandenen Tugend, von den Hohenpriestern und den Lehrern des jüdischen
 Volkes gefragt, was er von Jesus halte, und als er ihnen antwortete,
-daß er der Sohn Gottes sei, wurde auch er von ihnen mit
+daß er der Sohn Gottes sei, wurde auch er von ihnen mit Steinen
 gesteinigt. Simon Petrus aber wurde zu Rom kopfüber gekreuzigt, <lb n="25"/>
-Paulus aber geköpft und Johannes auf eine Insel verbannt.
-sie dies litten, ließ keiner der übrigen von seiner Lehre ab, sondern
-beteten alle, daß auch ihnen ähnliches dem vorher Gesagten
-möchte wegen der Gottesfurcht, so daß sie deswegen noch
-Erlöser und seine wunderbaren Taten freimütig bezeugten.
-Und fürwahr, wenn Lügen wären und (wenn)
-faselten das, was sie über ihn verkündigten, so müßte man
-wie eine so große Schar die Ubereinstimmung in ihren Lügen
-Tode bewahrte und niemals einer von ihnen sich fürchtete wegen
+Paulus aber geköpft und Johannes auf eine Insel verbannt. Während
+sie dies litten, ließ keiner der übrigen von seiner Lehre ab, sondern sie
+beteten alle, daß auch ihnen ähnliches dem vorher Gesagten zustoßen
+möchte wegen der Gottesfurcht, so daß sie deswegen noch mehr unsern
+Erlöser und seine wunderbaren Taten freimütig bezeugten.</p>
+</div>
+   
+<div type="textpart" subtype="chapter" n="32">
+<p>Und fürwahr, wenn Lügen wären und (wenn) sie nach Verabredung
+faselten das, was sie über ihn verkündigten, so müßte man sich wundern
+wie eine so große Schar die Ubereinstimmung in ihren Lügen bis zum
+Tode bewahrte und niemals einer von ihnen sich fürchtete wegen der
 Dinge), die den früher Getöteten zustießen, und aus der Genossenschaft <lb n="35"/>
 austrat und nicht das Gegenteil von seinen Genossen verkündete und
 ans Licht brachte das, was sie unter sich festgesetzt hatten, sondern
@@ -8238,15 +9377,18 @@ Eusebius III*.</note>
 
 <pb n="v.3.pt.2.p.242"/>
 (daß) auch der geldgierige (Judas), der ihn seinen *Feinden
-wagte, durch sich selbst sogleich die Strafe auf sich nahm. XXXIII.
-Wie sollte aber dies nicht voll Wunder sein, daß betrügerische
+wagte, durch sich selbst sogleich die Strafe auf sich nahm.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="33">
+<p>Wie sollte aber dies nicht voll Wunder sein, daß betrügerische
 laienhafte Männer, die weder mehr zu reden noch zu hören
-<lb n="5."/> als die Sprache ihrer Väter, nicht nur &lt;zu überlegen&gt; wagten,
+<lb n="5."/> als die Sprache ihrer Väter, nicht nur <add>zu überlegen</add> wagten,
 und umherzugehen bei allen Völkern, sondern (auch)
 und die Sache ausführten? Überlege aber, wie das sei, daß
 einer von ihnen jemals ein entgegengesetztes Wort über die Taten des
-Meisters vorbrachte. Denn wenn bei allen Dingen, über die es Zweifel <note type="marginal">Σ195</note>
-<lb n="10"/> gibt, in den gewöhnlichen Streitigkeiten &lt;und&gt; an den gesetzlichen Gerichtsstätten
+Meisters vorbrachte. Denn wenn bei allen Dingen, über die es Zweifel <milestone unit="altnumbering" n="195"/>
+<lb n="10"/> gibt, in den gewöhnlichen Streitigkeiten <add>und</add> an den gesetzlichen Gerichtsstätten
 die Übereinstimmung der Zeugen das besiegelt, worüber Streit
 — und das Gesetz Gottes sagt: auf Aussage von zwei und drei Zeugen wird
 jedes Wort fest — wie sollte da nicht auch hierbei die Wahrheit feststehen,
@@ -8258,7 +9400,9 @@ von Qualen und allerlei Mißhandlungen, Schlägen,
 und Tod, deswegen weil auch sie von Gott bestätigt wurden, der
 <lb n="20"/> durch sie verkúndigten Logos in der ganzen Menschenwelt bis jetzt
 in alle Ewigkeit verbürgt.</p>
-<p>XXXIV. Dies also sei (genug) geprüft, nachdem wir dafür
+</div>
+<div type="textpart" subtype="chapter" n="34">
+<p>Dies also sei (genug) geprüft, nachdem wir dafür
 dem Zugeständnis einen unziemlichen Anfang gemacht haben.
 die (Tatsache), daß jemand das Gegenteil der Schrift vermute und
 <lb n="25"/> daß der gemeinsame Erlöser aller ein Lehrer
@@ -8267,13 +9411,13 @@ Lüsternheit gewesen sei, und daß seine Jünger eben dies
 hättenn und nach allem begierig und durchweg böser
 als alle Menschen von Ewigkeit her, haben wir der Hypothese gemäß
 <lb n="30"/> zugestanden, was das allerungeziemendste ist. Denn es ist ähnlich, wie
-wenn jemand den Mose, der im Gesetz sagt: ,,Du sollst nicht töten,
+wenn jemand den Mose, der im Gesetz sagt: „Du sollst nicht töten,
 ehebrechen, stehlen, falsch Zeugnis ablegen“ verdrehte und
 und behauptete, er sage dies in *Ironie und Heuchelei. Denn er wolle,
 <note type="footnote">1 vgl. Act 116 ff. 12 = Dtn 1915 II Kor 131 31 = Ex 20 13—16</note>
 <note type="footnote">11 l. <foreign xml:lang="abbr">ABBREV</foreign> mit HS (Druckfehler) 5 μὴ μόνον διανοηθῆναι
 προελθεῖν D 1. + <foreign xml:lang="abbr">ABBREV</foreign> 10 ἔν τε τοῖς κατὰ νόμους
-καὶ ἐν ταῖς κοιναῖς ἀμφισβητήσεσι D 1. <foreign xml:lang="abbr">ABBREV</foreign> 17 ,,nicht ohne Bedrängnis“]
+καὶ ἐν ταῖς κοιναῖς ἀμφισβητήσεσι D 1. <foreign xml:lang="abbr">ABBREV</foreign> 17 „nicht ohne Bedrängnis“]
 ἀνιδρωτί D 22 ταῦτα μὲν οὖν ἀρχῆς ἀτόπου κατὰ συγχώρησιν δοθείσης γεγυμνάσθω
 D 33 εἰρωνείᾳ D 1. <foreign xml:lang="abbr">ABBREV</foreign> Bernstein</note>
 
@@ -8288,7 +9432,7 @@ geschrieben ist, gewesen und hätten (im Gegensatz dazu) gelebt,
 sich aber heuchlerisch gestellt, als wären sie in einem
 Leben. So aber könnte man, um es einfach zu sagen, alle
 der Vorfahren verleumden und die in ihnen (vorhandene) Wahrheit verwerfen <lb n="10"/>
-<note type="marginal">Σ196</note> und das, was in ihnen ist, ins Gegenteil aufnehmen (verkehren).
+<milestone unit="altnumbering" n="196"/> und das, was in ihnen ist, ins Gegenteil aufnehmen (verkehren).
 Aber wie derjenige, der Verstand hat, nicht zögern würde,
 zu nennen, so auch bei den Worten unsers Erlösers und
 Lehren, wenn jemand die in ihnen (vorhandene) Wahrheit verderben
@@ -8297,7 +9441,9 @@ von dem, was er lehrte. Indessen aber auch dies wurde entsprechend
 der Hypothese gegeben (ausgeführt), damit zum Überfluß auch
 das unziemliche Zugeständnis die Haltlosigkeit des Wortes des
 erscheine.</p>
-<p>XXXV. Nachdem dies also widerlegt ist, wohlan, wollen wir auch <lb n="20"/>
+</div>
+<div type="textpart" subtype="chapter" n="35">
+<p>Nachdem dies also widerlegt ist, wohlan, wollen wir auch <lb n="20"/>
 das Zeugnis der göttlichen Schrift prüfen und die
 der Jünger unsers Erlösers sehen, in der kein
 Daran also möge, wer wohlgesinnt ist, urteilen, ob nicht aller Größe
@@ -8315,7 +9461,7 @@ weil sie nicht einmal sterbliche, sondern unsterbliche Kinder lieb-
 <note type="footnote">1 τἀναντία πράττειν οἶς νομοθετεῖ, προσποιεῖσθαι δὲ σχηματίζεσθαι καὶ καθυποκρίνεσθαι
 τὸν σεμνὸν βίον D 4 ὑποθήκας D „Pfänder“ Σ 5. 6 Genitiv Σ
 (??) 11 καὶ εἰς τοὐναντίον τὰ δηλούμενα παρεκδεχόμενος D 13 καὶ μαθημάτων
-D ,,und seinen Jüngern“ Σ (= καὶ μαθητῶν) 18 τὸ ἀσύστατον τοῦ δί’
+D „und seinen Jüngern“ Σ (= καὶ μαθητῶν) 18 τὸ ἀσύστατον τοῦ δί’
 λόγου D 23 πῶς οὐ πάσης ἀποδοχῆς αὐτοὺς ἀξίους κρίνειεν D „wählte
 aus, was . . . . wert sind“ Σ 26 καρτερικὸν καὶ ἐπίπονον D</note>
 
@@ -8330,13 +9476,15 @@ sie in der Tat das Wort erfüllt haben. Als nämlich
 die um Simon Petrus waren, Ein Lahmer bat aus der Zahl derer, die wegen
 äußerster Not betteln, und Simon Petrus kein Geld hatte, das er ihm
 <lb n="10"/> geben konnte, bekannte er, daß er von allem Besitz an Gold und
-rein sei und sagte: ,, Gold und Silber habe ich nicht“, und er
+rein sei und sagte: „Gold und Silber habe ich nicht“, und er
 darauf den kostbaren Namen, der kostbarer ist als alles, vor und sagte:
-,, Was ich habe, will ich dir geben. Im Namen Jesu Christi, stehe auf <note type="marginal">Σ197</note>
+„Was ich habe, will ich dir geben. Im Namen Jesu Christi, stehe auf <milestone unit="altnumbering" n="197"/>
 und wandle.“</p>
-<lb n="15"/> <p>XXXVI. Obwohl ihr Lehrer ihnen Trauriges verkündete und sie auf
-achteten, wodurch er zu ihnen sagte: ,,In der Welt habt ihr Trauer“
-wiederum: ,, Jhr werdet weinen und wehklagen, die Welt aber wird sich
+</div>
+<lb n="15"/> <div type="textpart" subtype="chapter" n="36">
+<p>Obwohl ihr Lehrer ihnen Trauriges verkündete und sie auf
+achteten, wodurch er zu ihnen sagte: „In der Welt habt ihr Trauer“
+wiederum: „Jhr werdet weinen und wehklagen, die Welt aber wird sich
 freuen“, wie wurde da nicht offensichtlich, daß sie fest und tief
 ihrem Charakter, da sie vor den Anstrengungen der Seele nicht flohen
 <lb n="20"/> noch den Lüsten nachjagten, daß aber auch ihr Meister
@@ -8358,8 +9506,8 @@ dem, der Christus bekennt, so bestrafen sie ihn dennoch und mißhandeln
 <note type="footnote">4 vgl. Matth 1010 11 = Act 36 16 = Job 1633 17 = Joh 16 20
 25 vgl. Matth 10 17 ff.</note>
 <note type="footnote">6 οἱ δὲ καὶ ἔργον πεποιηκότες τὸν λόγον ἀποδείκνυνται D 15 σκυθρωπὰ
-δὲ αὐτοῖς προαγγέλλοντος („befahl“ Σ) τοῦ διδασκάλω, προσέχοντες δι’ ὧν
-αὐτοὺς ἔλεγεν D ,, achteten sie auf ihn durch das, was“ Σ</note>
+δὲ αὐτοῖς προαγγέλλοντος ( „befahl“ Σ) τοῦ διδασκάλω, προσέχοντες δι’ ὧν
+αὐτοὺς ἔλεγεν D „achteten sie auf ihn durch das, was“ Σ</note>
 
 <pb n="v.3.pt.2.p.245"/>
 Wenn aber jemand seinen Namen nicht bekennt und leugnet, ein Jünger
@@ -8369,15 +9517,19 @@ vieles anzuhäufen, der ich versuche, das Leben der Jünger
 zu schreiben, da das Gesagte genügt zum Beweise der vorliegenden
 (Sache)? Dem wollen wir aber ferner folgendes hinzufügen, und
 (ist es) am Platze, auch darüber unsere Rede zu begrenzen.</p>
-<p>XXXVII. Der Apostel Matthäus leitete sein früheres
+</div>
+<div type="textpart" subtype="chapter" n="37">
+<p>Der Apostel Matthäus leitete sein früheres
 von einem besseren Umgang ab, sondern von denen, die um Zölle
 und Übervorteilung sich bemühen. Dies hat keiner von den übrigen
 Evangelisten uns geoffenbart, weder sein Mitapostel Johannes noch
 Lukas noch Markus, die Verfasser der übrigen Evangelien. Matthäus
-<note type="marginal">Σ198</note> aber beschrieb sein eigenes früheres Leben und wurde (so) sein
+<milestone unit="altnumbering" n="198"/> aber beschrieb sein eigenes früheres Leben und wurde (so) sein
 Ankläger. Höre also, wie er deutlich sich selbst mit Namen
-seiner Schrift und so redet:</p> <lb n="15"/>
-<p>XXXVIII. ,, Als Jesus von dort weiter ging, sah er einen Menschen
+seiner Schrift und so redet:</p>
+</div> <lb n="15"/>
+<div type="textpart" subtype="chapter" n="38">
+<p> „Als Jesus von dort weiter ging, sah er einen Menschen
 beim Zollhaus sitzen, mit Namen Matthäus, und sprach zu ihm:
 mir nach. Und er erhob sich und ging ihm nach. Und es geschah,
 als er zu Tische lag in dem Hause, und siehe da! viel Zöllner und
@@ -8400,38 +9552,42 @@ er ihn als den besseren kannte, zuerst aufzählt und (erst) nach ihm <lb n="35"/
 den Thomas bringt, wie auch Markus getan hat. Es lauten aber seine
 <note type="footnote">8—33 = 16. Bruchstück der griech. Theoph. 16 = Matth 9 9 f.
 Matth 10 8 f. 36 vgl. Mark 3 14 ff.</note>
-<note type="footnote">4 ,, und zu versuchen“ Σ 8 οὐκ ἀπὸ σεμνῆς διατριβῆς ὡρμᾶτο 13 „beschrieb“]
+<note type="footnote">4 „und zu versuchen“ Σ 8 οὐκ ἀπὸ σεμνῆς διατριβῆς ὡρμᾶτο 13 „beschrieb“]
 στηλιτεύων Th. gr.</note>
 
 <pb n="v.3.pt.2.p.246"/>
-Worte so: ,,Und als es Tag ward, rief er seine Jünger und wählte
+Worte so: „Und als es Tag ward, rief er seine Jünger und wählte
 aus ihnen aus, die er (auch) Apostel nannte: Simon, den er (auch) Petrus
 nannte, und Andreas, seinen Bruder, *Jakobus und Johannes und
 Philippus und Bartholomäus und Matthäus und Thomas.“
-<lb n="5"/> Lukas den Matthäus, ,,wie ihm diejenigen überliefert haben, die
+<lb n="5"/> Lukas den Matthäus, „wie ihm diejenigen überliefert haben, die
 Anfang an Augenzeugen und *Diener des Wortes wurden.“ So
 verkleinerte Matthäus durch Demut sich selbst, bekannte, daß
 Zöllner sei und zählte sich als zweiten nach seinem Mitapostel.</p>
-<p>XXXIX. Auch den Johannes findest du ähnlich dem Matthäus. <note type="marginal">Σ199</note>
-<lb n="10"/> Denn in seinem Briefe tut er nicht einmal seines eigenen &lt;Namens&gt;
+</div>
+<div type="textpart" subtype="chapter" n="39">
+<p>Auch den Johannes findest du ähnlich dem Matthäus. <milestone unit="altnumbering" n="199"/>
+<lb n="10"/> Denn in seinem Briefe tut er nicht einmal seines eigenen <add>Namens</add>
 Erwähnung, oder er nennt sich einen Altesten, niemals aber
 Apostel oder Evangelisten. In dem Evangelium aber, das auch von
 ihm geschrieben wurde, erwähnte er von sich, daß Jesus ihn
 offenbarte sich aber nicht mit Namen.</p>
-<lb n="15"/> <p>XL. Simon Petrus aber machte sich nicht einmal daran, ein Evangelium
+</div>
+<lb n="15"/> <div type="textpart" subtype="chapter" n="40">
+<p>Simon Petrus aber machte sich nicht einmal daran, ein Evangelium
 zu schreiben, aus einem Übermaß von Sehen. Markus aber, der
 sein Vertrauter und Jünger geworden war, soll die Worte Simons
 die Taten unsers Erlösers berichtet haben. Als er in seiner Schrift
 den (Worten) kam, wo Jesus fragte, was die Menschen über ihn sagten,
 <lb n="20"/> und als Simon ihm *antwortete, welche Meinung seine Jünger über
-hätten, und sagte: ,,Du bist Christus“, da schrieb er, daß
+hätten, und sagte: „Du bist Christus“, da schrieb er, daß
 weder antwortete noch etwas zu ihm sagte, außer daß er
 sie möchten dies niemandem sagen. Dies aber schrieb Markus, da
 nicht zugegen war, als Jesus dies sagte, sondern es nur von Simon
 <lb n="25"/> hörte, als er es lehrte. Petrus aber wollte das, was Jesus zu ihm
 seinetwegen sagte, nicht durch sein eigenes Zeugnis vorbringen. Was
 das aber war, was zu ihm gesagt wurde, zeigt Matthäus durch
-(Worte): ,,Ihr aber, was sagt ihr, wer ich sei? Sagte ihm Simon: Du
+(Worte): „Ihr aber, was sagt ihr, wer ich sei? Sagte ihm Simon: Du
 bist Christus, der Sohn des lebendigen Gottes. Antwortete ihm Jesus
 <lb n="30"/> und sprach zu ihm: Selig bist du, Simon Barjonan. Fleisch und Blut
 haben es dir nicht geoffenbart, sondern mein Vater im Himmel. Und
@@ -8439,7 +9595,7 @@ haben es dir nicht geoffenbart, sondern mein Vater im Himmel. Und
 11 vgl; II Joh 11 13 vgl. Job. 1323 IG vgl. Euseb. Hist. eccles. II 15 1
 18 vgl. Mark 8 27 ὖ. 28 = Mattb 16 15—19</note>
 <note type="footnote">3 l. <foreign xml:lang="abbr">ABBREV</foreign> mit HS 6 1. <foreign xml:lang="abbr">ABBREV</foreign> mit HS 10 ἐν
-ἐπιστολαῖς D I ,,seiner selbst“ Σ τῆς οἰκείας προσηγορίας 1. +
+ἐπιστολαῖς D I „seiner selbst“ Σ τῆς οἰκείας προσηγορίας 1. +
 13 ἐν δὲ τῷ εὐαγγελίῳ ἐπισημηνάμενος ὃν ἠγάπα ὁ Ἰησοῦς οὐκ ἐδήλωσεν D
 20 καὶ αὐτοὶ δὲ ὅ αὐτοῦ μαθηταὶ τίνα δόξαν ἔχοιεν περὶ αὐτοῦ, ὑπακούσαντος
 τοῖ Πέτροι ὡς περὶ Χριστοῦ D str. das <foreign xml:lang="abbr">ABBREV</foreign> vor <foreign xml:lang="abbr">ABBREV</foreign></note>
@@ -8455,7 +9611,7 @@ deswegen, weil auch Petrus, wie es wahrscheinlich ist, dies in seiner
 Lehre nicht sagte. Dies also verschwieg Simon Petrus mit Recht, sodaß
 deswegen auch Markus es ausließ. Die (Umstände)
 aber verkündete verkundete er bei allen Menschen und schrieb (so) wider <lb n="10"/>
-<note type="marginal">Σ200</note> sich selbst die Anklage, *da er darüber bitter weinte. Du findest
+<milestone unit="altnumbering" n="200"/> sich selbst die Anklage, *da er darüber bitter weinte. Du findest
 daß Markus folgendes über ihn schreibt: Während Simon
 war, kam zu ihm Eine von den Mägden des Hohenpriesters, und da
 ihn sich wärmen sah, blickte sie ihn an und sagte zu ihm: Auch
@@ -8469,8 +9625,10 @@ weil auch du ein Galiläer bist, bist. Er aber begann zu fluchen und zu
 sagen: Ich kenne diesen Menschen nicht, von dem ihr sagt, und sogleich
 krähte der Hahn zum zweiten Mal.“ Dies schreibt Markus,
 bezeugt Simon Petrus über sich selbst. Denn alle (Worte) des Markus
-sollen Erinnerungen der Worte Simons sein.</p> <lb n="25"/>
-<p>XLI. Sie also, die darauf verzichten, das zu sagen, was ihnen gutes
+sollen Erinnerungen der Worte Simons sein.</p>
+</div> <lb n="25"/>
+<div type="textpart" subtype="chapter" n="41">
+<p>Sie also, die darauf verzichten, das zu sagen, was ihnen gutes
 Lob eintrug, eine Anschuldigung aber gegen sich selbst schrieben, damit
 sie auf ewig unvergessen sei, und die Anklagen ihrer Torheit gegen
 sich selbst aufstellten, die niemand der Späteren gekannt hätte,
@@ -8481,7 +9639,7 @@ glänzende Beweise wahrheitsliebender Gesinnung zeigten?
 nun, die von denen, welche einen derartigen Charakter zeigten, glauben,
 daß sie faselten und logen, und sie als Betrüger zu schmähen versuchen, <lb n="35"/>
 <note type="footnote">8—S. 251,9 = Dem. III 592—109 12 = Mark 14 66—72</note>
-<note type="footnote">11 ,,und da“ Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 21 ,,zu sagen“] ὀμνύειν D l. <foreign xml:lang="abbr">ABBREV</foreign> ? 32 φιλαλήθους
+<note type="footnote">11 „und da“ Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 21 „zu sagen“] ὀμνύειν D l. <foreign xml:lang="abbr">ABBREV</foreign> ? 32 φιλαλήθους
 δὲ διαθέσεως σαφῆ καὶ ἐναργῆ τεκμήρια παρεσχηκέναι D</note>
 
 <pb n="v.3.pt.2.p.248"/>
@@ -8497,10 +9655,12 @@ Erlösers glauben dürfen oder nicht, und ob wir nur
 <lb n="10"/> nicht glauben dürfen oder auch allen denen (nicht), die von
 her bei den Griechen und bei den Barbaren Erinnerungen über das
 Leben und die Worte derer, die zu verschiedenen Zeiten wegen gewisser
-Siegestaten berühmt waren, geschrieben haben, *oder (ob) sie es für
+Siegestaten berühmt waren, geschrieben haben, *oder (ob) sie es für <milestone unit="altnumbering" n="201"/>
 Recht halten, den andern zu glauben, ihnen allein aber nicht zu glauben?
 <lb n="15"/> Wie ist da nicht ihr Neid offenbar?</p>
-<p>XLII. Wie aber? Diejenigen, die in betreff ihres Meisters logen und
+</div>
+<div type="textpart" subtype="chapter" n="42">
+<p>Wie aber? Diejenigen, die in betreff ihres Meisters logen und
 in ihrer Schrift das, was von ihm nicht geschah, als geschehen überlieferten,
 haben sie auch *die Leiden und die Trübsale betreffs
 erlogen? Den Verrat eines Jüngers, meine ich, die Anklage derer,
@@ -8519,7 +9679,7 @@ zwiespältige Dogma bestehen? Denn behaupten, daß
 wahr reden und wiederum über dasselbe lügen, heißt
 als in demselben (Augenblicke) Entgegengesetztes von ihnen sagen.
 <note type="footnote">19 vgl. Matth 26 f.</note>
-<note type="footnote">1 καταγέλαστοι D ,,ein Gelächter“ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 3. l. <foreign xml:lang="abbr">ABBREV</foreign>
+<note type="footnote">1 καταγέλαστοι D „ein Gelächter“ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 3. l. <foreign xml:lang="abbr">ABBREV</foreign>
 οἵγε τοὺς οὕτως ἀπανούργους καὶ ἄπλαστον ὡς ἀληθῶς καὶ ἀκέραιον ἦθος διὰ
 τῶν οἰκείων λόγων ἐπιδεδειγμένους, πανούργους τινὰς καὶ δεινοὺς ὑποτίθενται
 σοφιστάς D 13 „oder“] „und“ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 18 1. <foreign xml:lang="abbr">ABBREV</foreign>
@@ -8537,8 +9697,12 @@ berühmte Simon Petrus, ohne Fesseln und Drohungen der *Fürsten ihn
 dreimal verleugnete. Denn wenn auch andere dies gesagt hätten, so
 hätten doch sie dies leugnen müssen, die sich nichts anderes vorgenommen <lb n="10"/>
 hatten als mit Lügenworten sich und ihrem Meister *die
-(Taten) gütig zuzusprechen. XLIII. Wenn sie aber
-<note type="marginal">Σ202</note> in den traurigen Erzählungen über ihn erscheinen, so sind sie noch
+(Taten) gütig zuzusprechen.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="43">
+<p>Wenn sie aber
+<milestone unit="altnumbering" n="202"/> in den traurigen Erzählungen über ihn erscheinen, so sind sie noch
 mehr derartig auch in den (ihn) verherrlichenden (Geschichten). Denn
 diejenigen, die Ein Mal vorzogen zu lügen, hätten das Traurige viel <lb n="15"/>
 mehr vermeiden müssen, entweder durch Stillschweigen oder
@@ -8561,7 +9725,7 @@ Himmel mit göttlichem Ruhme vollführte? Denn nicht
 diejenigen leugnen, die ihren anderen Geschichten glaubten. Sie also
 <note type="footnote">1—9 = 17. Bruchstück der griech. Theoph. 5 vgl. Matth 26 57 ff.
 9 vgl. Matth 26 34. 75 19 vgl. Matth 26 48 20 vgl. Joh 18 22 22 vgl. Matth 26 57 ff.</note>
-<note type="footnote">8 ,,und Drohungen von Qualen“ Σ βασάνων ἐκτὸς καὶ ἀρχοντικῆς
+<note type="footnote">8 „und Drohungen von Qualen“ Σ βασάνων ἐκτὸς καὶ ἀρχοντικῆς
 Th. gr. 1. <foreign xml:lang="abbr">ABBREV</foreign> 11 οὐδὲν ἄλλο ἧ χαρίζεσθαι τὰ σεμνότερα τῷ
 προτεθειμένους D str. <foreign xml:lang="abbr">ABBREV</foreign> „und“ vor <foreign xml:lang="abbr">ABBREV</foreign> 19 ὁ προδοὺς
 τὸ σύμβολον ἐνδείξασθαι τῆς προδοσίας D</note>
@@ -8576,18 +9740,24 @@ Josephus als Zeugen zu gebrauchen, der im achtzehnten (Buche) seiner
 jüdischen Archäologie, indem er die (Begebenheiten)
 beschreibt, unsern Erlöser in folgenden (Worten) erwähnt:</p>
 <p>Von Josephus. Über Christus.</p>
-<lb n="10"/> <p>XLIV. ,,Es trat aber in jener Zeit Jesus auf, ein weiser Mann, wenn
+</div>
+   
+<div type="textpart" subtype="chapter" n="44">
+<p><lb n="10"/> „Es trat aber in jener Zeit Jesus auf, ein weiser Mann, wenn
 man ihn einen Menschen heißen darf. Denn er war ein
 Werke und ein Lehrer der Menschen, die mit Vergnügen
 aufnahmen, und sammelte viele aus den Juden und viele aus den
-Heiden. Dieser war der Christus. Ihn verließen, als Pilatus ihn auf <lb n="Σ203"/>
+Heiden. Dieser war der Christus. Ihn verließen, als Pilatus ihn auf <milestone unit="altnumbering" n="203"/>
 <lb n="15"/> die Anklage der ersten Männer (und) Fürsten bei uns
 in den Kopf gesetzt hatte, diejenigen nicht, die ihn vorher liebgewonnen
 hatten. Denn er erschien ihnen am dritten Tage wiederum lebendig,
 da die göttlichen Propheten dies und vieles andere über
 hatten, weshalb bis jetzt von jenem an nicht afugehört hat
 <lb n="20"/> der Christen.“</p>
-<p>XLV. Wenn also (auch) gemäß (diesem) Schriftsteller
+</div>
+  
+<div type="textpart" subtype="chapter" n="45">
+<p>Wenn also (auch) gemäß (diesem) Schriftsteller
 daß er ein Täter wunderbarer Werke war und nicht
 und siebzig Jünger sich gewann, sondern auch Myriaden andere aus
 den Juden und Myriaden aus den Heiden sich verband, so ist klar, daß
@@ -8601,10 +9771,10 @@ daß es viele Myriaden jüdischer Männer
 <note type="footnote">10—20 = Jos. Ant. XVIII 33; Euseb. Hist. eccles. I 117 f. 28 vgl. Act 2 41
 31 vgl. Euseb. Hist. eccles. IV 5</note>
 <note type="footnote">9 stammt nicht von Eusebius her &lt; D 12 ἀνθρώπων τῶν ἡδονῇ τἀληθῆ
-δεχομένων Hist. eccles. ,,die das Vergnügen in Wahrheit aufnehmen“ Σ 14 ἐνδείξει
-τῶν πρώτων ἀνδρῶν παρ’ ἡμῖν D ,,nach der Art (mißverstandenes
+δεχομένων Hist. eccles. „die das Vergnügen in Wahrheit aufnehmen“ Σ 14 ἐνδείξει
+τῶν πρώτων ἀνδρῶν παρ’ ἡμῖν D „nach der Art (mißverstandenes
 ἐνδείξει) τῶν πρώτων ἀνδρῶν ἀρχόντων παρ’ ἡμῖν Σ 25 παρὰ τοὺς λοιποὺς
-ἀνθρώπους D ,,abgesehen von den übrigen Menschen“ Σ</note>
+ἀνθρώπους D „abgesehen von den übrigen Menschen“ Σ</note>
 
 <pb n="v.3.pt.2.p.251"/>
 Jerusalem war, die von den Juden gesammelt war (und dauerte) bis
@@ -8616,14 +9786,16 @@ wird, seitdem von ihnen, und (auch) abgesehen von ihrem
 Zeugnis, bekannt wird, daß der Christus Gottes durch die
 Taten, die er vollbrachte, viele aus den Juden und aus den Heiden in
 seine Hand brachte.</p>
-<p>XLVI. Auch du aber wirst prüfen (können) die Göttlichkeit seiner <lb n="10"/>
+</div>
+<div type="textpart" subtype="chapter" n="46">
+<p>Auch du aber wirst prüfen (können) die Göttlichkeit seiner <lb n="10"/>
 Kraft, wenn du bedenkst, was er seiner Natur nach gewesen ist und
 von wie großer Vorzüglichkeit der göttlichen Kraft er
 Ausführung der Dinge war, die alle Worte in den
 stellen. Denn er beschloß, was niemals einer (beschloß),
 Gesetz und eine fremde Lehre unter alle Völker zu säen und sich selbst <lb n="15"/>
 als Lehrer des ganzen Menschengeschlechts für die Verehrung
-<note type="marginal">Σ204</note> oberhalb von allem (stehenden) Gottes zu erweisen, und wollte (daher)
+<milestone unit="altnumbering" n="204"/> oberhalb von allem (stehenden) Gottes zu erweisen, und wollte (daher)
 diejenigen, die dörfischer und geringer als alle Menschen (sind),
 Diener seines Willens benutzen, und es ist wahrscheinlich, daß
 glaubt, er habe dies ungeziemend getan. Denn wie sollten diejenigen. <lb n="20"/>
@@ -8631,19 +9803,19 @@ die nicht einmal ihre Lippen aufheben konnten, jemals Lehrer Eines
 Menschen werden, geschweige denn einer Menge von Menschen? Wie
 sollten die mit den Scharen reden, die ohne jede Bildung waren? Aber
 dies war eben der Beweis des göttlichen Willens. Denn er berief
-wie wir auch vorher gezeigt haben, und sagte zuvor: ,,Folgt mir nach. <lb n="25"/>
+wie wir auch vorher gezeigt haben, und sagte zuvor: „Folgt mir nach. <lb n="25"/>
 so will ich euch zu Menschenfischern machen.“ Da er sie aber
 als seine Nachfolger besaß, hauchte er ihnen göttliche Kraft
 erfüllte sie mit Kraft und Beherztheit, und da er selbst in
 der Logos Gottes und Täter so großer Wunder ist, so machte er
 Fischern der geistigen und vernünftigen Seelen und fürgte die Tat dem <lb n="30"/>
-Worte hinzu, das da *sagt: ,,Folgt mir nach, so will ich euch &lt;zu
-Menschenfischern&gt; machen“ &lt;und&gt; erwarb sie zugleich als Täter
+Worte hinzu, das da *sagt: „Folgt mir nach, so will ich euch <add>zu
+Menschenfischern</add> machen“ <add>und</add> erwarb sie zugleich als Täter
 <note type="footnote">10—S. 258, 4 = Dem. III 75—38 25. 31 = Mark 1 17 25 vgl. o. S. 171</note>
-<note type="footnote">6 ,,vor ihnen . . . bekennen“ Σ ὃτε καὶ πρὸς αὐτῶν καὶ δίχα τῆς αὐτῶν
+<note type="footnote">6 „vor ihnen . . . bekennen“ Σ ὃτε καὶ πρὸς αὐτῶν καὶ δίχα τῆς αὐτῶν
 μυρία ὁμολογεῖται πλήθη . . . ὁ Χριστός . . . . ὑφ᾿ ἑαυτὸν πεποιημένος D
 12 „bei der (siegreichen) Ausführung“] ἐπὶ κατορθώσει D 21 μηδέ διᾶραι
-στόμα D 22 οὐχί γε D ,,und nicht“ Σ 31 τῇ φωνή τῇ »δεῦτε
+στόμα D 22 οὐχί γε D „und nicht“ Σ 31 τῇ φωνή τῇ »δεῦτε
 φησάσῃ ὁμοῦ τε ἐργάτας καὶ διδασκάλους αὐτοὺς εὐσεβείας άπειργασμΐνονς D l.
 <foreign xml:lang="abbr">ABBREV</foreign></note>
 
@@ -8658,7 +9830,7 @@ einem jeden von ihnen lieb, wenn er auch nur in dem eigenen Lande
 seine eigene Anordnung durchführte und im stande war, die
 die ihm gut zu sein schienen, in Einem, in seinem eigenen Volke zu
 <lb n="10"/> bestätigen. Er aber, der nichts Menschliches noch Sterbliches
-— sieh zu, ob er &lt;nicht&gt; in Wahrheit wiederum die Stimme Gottes (ertönen)
+— sieh zu, ob er <add>nicht</add> in Wahrheit wiederum die Stimme Gottes (ertönen)
 ließ, indem er wörtlich seinen armen Jüngern
 und lehret alle Völker.“ So aber mochten wahrscheinlich seine
 sagen, indem sie ihrem Meister antworteten: Wie können wir dies
@@ -8666,7 +9838,7 @@ sagen, indem sie ihrem Meister antworteten: Wie können wir dies
 reden? Welches Wort gegen die Griechen gebrauchen als Männer,
 nur in der syrischen Sprache erzogen sind? Wie sollen wir die Perser,
 Armenier, Chaldäer, Skythen, Inder und die andern (so) genannten
-überreden, sich von den Göttern ihrer Vorfahren abzuwenden und <note type="marginal">Σ205</note>
+überreden, sich von den Göttern ihrer Vorfahren abzuwenden und <milestone unit="altnumbering" n="205"/>
 <lb n="20"/> den Einen Schöpfer des Alls zu verehren? Auf welche
 der Worte aber sollen wir vertrauen und zu diesem (Werke) übergehen?
 Oder welche Hoffnung auf Sieg sollen wir haben, wenn wir wagen, allen
@@ -8676,13 +9848,13 @@ Gesetzen in betreff der Götter? Welche Kraft haben wir,
 Dies also sagten oder dachten die Jünger unsers Erlösers.
 Hinzufügen eines Wortes aber verbürgte ihr Meister eine
 der Verzweiflung, in der sie sich befanden, indem er sagte: Ihr
-werdet ,,in meinem Namen“ siegen. Denn er trug ihnen nicht
+werdet „in meinem Namen“ siegen. Denn er trug ihnen nicht
 <lb n="30"/> und unterschiedslos auf, alle Völker zu lehren, sondern mit der
-Hinzufügung, die lautet: ,,in meinem Namen.“ Denn da
-seines Namens so groß ist, daß der Apostel sagte: ,,Gott
+Hinzufügung, die lautet: „in meinem Namen.“ Denn da
+seines Namens so groß ist, daß der Apostel sagte: „Gott
 den Namen, der besser als alle Namen ist, damit in dem Namen Jesu
 <note type="footnote">12 29. 31 = Matth 28 19 32 = Phil 2 9 f.</note>
-<note type="footnote">2 κήρυκας ἀναδείξας τῆς αὐτοῦ διδασκαλίας D ,,und zeigte, daß sie
+<note type="footnote">2 κήρυκας ἀναδείξας τῆς αὐτοῦ διδασκαλίας D „und zeigte, daß sie
 . . . seien“ Σ 5 „besser“] διαφανῶν D | διανοηθείς D „gebrauchte“
 <foreign xml:lang="abbr">ABBREV</foreign> 8 ἐπάγγελμα D „Verheißung“ Σ 10 vgl. zu Z. 5 11 ὅρα εἰ
 μὴ D 1. <foreign xml:lang="abbr">ABBREV</foreign> 24 ἐπὶ ποίᾳ δὲ καὶ δυνάμει περιέσεσθαί ἐστι τοῦ
@@ -8701,15 +9873,17 @@ sie nicht aus den andern göttlichen Werken, die von ihm getan
 die Erfahrung der Wahrheit seiner Worte gemacht hatten? Denn du bist <lb n="10"/>
 zuzugeben gezwungen, daß sie ihm das glaubten, was er sagte, wenn
 überlegst. Denn als er befahl, weigerte sich niemand, sondern sie gehorchten
-&lt;und&gt; lehrten auf seinen Wink und nach seinen Anordnungen das ganze
+<add>und</add> lehrten auf seinen Wink und nach seinen Anordnungen das ganze
 Geschlecht der Menschen, brachen aus ihrem eigenen Lande zu allen
 Völkern auf und in kurzer Zeit waren seine Worte in Taten zu sehen. <lb n="15"/>
 Verkündet wurde also in kurzer Zeit sein Evangelium in der
 Welt zum Zeugnis für alle Vöker, und Barbaren und
 die Schriften über den gemeinsamen Erlöser aller in den
 ihrer Väter und in den Worten ihrer Vorfahren auf.</p>
-<p>XLVII. In Verlegenheit aber würde sich jemand geziemenderweise befinden
-<note type="marginal">Σ206</note> darüber), wie die Art der Lehre der Jünger unsers
+</div>
+<div type="textpart" subtype="chapter" n="47">
+<p>In Verlegenheit aber würde sich jemand geziemenderweise befinden
+<milestone unit="altnumbering" n="206"/> darüber), wie die Art der Lehre der Jünger unsers
 Gingen sie mitten in die Stadt, *standen dann auf dem Markte, erhoben
 eine laute Stimme und riefen die (zusammen), die zufällig kamen,
 redeten darauf mit dem Volke? Was war das Wort ihrer Volksrede, von
@@ -8736,7 +9910,11 @@ und philosophischen Lehren — auch so wäre die Rede nicht leicht
 <lb n="5"/> um die Zuhörer willig ihren Worten zustimmend zu
 weil ihr Wort fremd war und (weil) sie jetzt neue Reden hörten
 Menschen, die ihnen nichts Glaubwürdiges *brachten zum Zeugnis
-was von ihnen *gesagt wurde. ITL. Indessen aber würde ihnen das
+was von ihnen *gesagt wurde.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="48">
+<p>Indessen aber würde ihnen das
 glaubwürdiger erschienen sein. Jetzt (aber) verkündeten
 <lb n="10"/> daß der von ihnen Gepredigte Gott in einem menschlichen Leibe
 und nichts anderes seiner Natur nach sei, als der Logos Gottes,
@@ -8749,12 +9927,14 @@ so töricht gewesen in seinem Sinne, willig zu glauben denen, die
 *sie hätten ihn nach seinem Tode auferstanden von den Toten
 ihn, der nicht einmal, als er noch lebte, sich helfen konnte? Wer hätte
 <lb n="20"/> sich aber von jenenLaien und Geringen jemals überzeugen lassen, die sagten:
-Ihr müßt die Dinge eurer Väter verachten &lt;und&gt; die Torheit der Weisen <note type="marginal">Σ207</note>
+Ihr müßt die Dinge eurer Väter verachten <add>und</add> die Torheit der Weisen <milestone unit="altnumbering" n="207"/>
 von Ewigkeit her tadeln und euch nur von uns überzeugen lassen und
 von den Befehlen, die von dem Gekreuzigten ausgegeben sind. Denn
 er ist allein der geliebte und einzige Sohn des alleinigen, oberhalb von
 <lb n="25"/> allem (stehenden) Gottes.</p>
-<p>IL. Während ich also in Liebe zur Wahrheit das Wort *bei
+</div>
+<div type="textpart" subtype="chapter" n="49">
+<p>Während ich also in Liebe zur Wahrheit das Wort *bei
 prüfe, sehe ich keine überzeugende Kraft darin und nichts Großes
 nichts Glaubwürdiges und nicht einmal soviel Überzeugendes, daß
 auch nur Einen von den unkundigen, geschweige denn von den weisen
@@ -8781,17 +9961,20 @@ als (die der) Menschen, und durch die Hilfe dessen, der zu ihnen
 sagte: „Gehet hin und lehrt alle Völker in meinem Namen.“
 aber dies zu ihnen gesagt hatte, verband er damit die Verheißung, durch <lb n="10"/>
 die sie bereitet wurden, zu vertrauen und sich willig dem hinzugeben,
-was (ihnen) befohlen war. Er sagte ihnen nämlich: ,,Siehe ich bin
+was (ihnen) befohlen war. Er sagte ihnen nämlich: „Siehe ich bin
 euch alle Tage bis ans Ende der Welt.“ Es wird aber auch
 daß er ihnen den heiligen Geist eingehaucht und ihnen eine
 und wunderwirkende Kraft gegeben habe, indem er einmal sagt: „Nehmet <lb n="15"/>
 hin den heiligen Geist“, ein andermal aber spricht: „Heilet die
 reinigt die Aussätzigen, treibt die Dämonen aus. Umsonst habt
-empfangen und umsonst gebt es.“
-L. Du siehst also ebenfalls, wie ihr Wort stark geworden ist, da
+empfangen und umsonst gebt es.“</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="50">
+<p>Du siehst also ebenfalls, wie ihr Wort stark geworden ist, da
 auch die Schrift der Πραξεῖς dem Ahnliches und damit Übereinstimmendes <lb n="20"/>
 bezeugt, wie sie, indem sie über sich selbst erzählten, durch
-Σ208 Taten im Namen Jesu, die von ihnen getan wurden, diejenigen, die zugegen
+<milestone unit="altnumbering" n="208"/> Taten im Namen Jesu, die von ihnen getan wurden, diejenigen, die zugegen
 waren und es sahen, in Erstaunen setzten. In Erstaunen setzten
 sie aber, wie es natürlich ist, die Zuschauer zuerst durch Taten.
 machten sie sie (derart), daß sie wdllig fragten, wer der sei, durch dessen <lb n="25"/>
@@ -8813,14 +9996,20 @@ sie so waren, *so wurde fortan alles, was (die Jünger) über
 Erlöser verkündigten, sclinell und geziemend aufgenommen.
 von den Toten bezeugten sie nicht mit bloßen und
 Worten, sondern sie überzeugten eben durch *Taten, indem sie
-lebendige Werke zeigten. LI. Wenn sie aber ündigten, ß er
+lebendige Werke zeigten.</p>
+</div>
+
+<div type="textpart" subtype="chapter" n="51">
+<p>Wenn sie aber ündigten, ß er
 <lb n="5"/> Gott sei und der Sohn Gottes und vor seinem Kommen unter die
 Menschen beim Vater gewesen sei, wie sollten sie dem nicht (noch)
 mehr hinzufügen, indem sie meinten, daß das
 und unglaublich sei? Denn mit Recht erachteten sie, daß das,
 geschah, unmöglich für menschliche, sondern (nur)
 <lb n="10"/> Taten gehalten werden dürfe, auch wenn es vielleicht niemand sage.</p>
-<p>LII. Dies also war es und nichts anderes, was gefragt wurde,
+</div>
+<div type="textpart" subtype="chapter" n="52">
+<p>Dies also war es und nichts anderes, was gefragt wurde,
 durch welche Kraft die Jünger unsers Erlösers
 wurden, die von Anfang an hörten, und wie sie die Griechen
 und die Barbaren überzeugten, über ihn wie über den Logos Gottes zu
@@ -8830,7 +10019,7 @@ einrichteten.</p>
 <p>Und doch, wer sollte sich nicht wundern, indem er bei sich überlegt
 und betrachtet, daß dies nicht menschlich war, wie niemals
 <lb n="20"/> anderer Zeit früher viele Völker der ganzen Welt in der
-Macht, der Römer, waren als seit der Zeit unseres Erlöser. Denn sogleich <note type="marginal">Σ209</note>
+Macht, der Römer, waren als seit der Zeit unseres Erlöser. Denn sogleich <milestone unit="altnumbering" n="209"/>
 als er unter die Menschen ging, ereignete es sich, daß auch
 (Macht) der Römer wuchs, da in jener Zeit Augustus zuerst
 vieler Völker war und zu seiner Zeit Kleopatra gefangen
@@ -8871,7 +10060,7 @@ daß es durch das *Zugeständnis der Herrscher und nicht
 die Vorzüglichkeit VorzÜglichkeit der göttlichen Kraft stark sei,
 von den Tyrannen durch Bosheit hingerissen ward und sich vornahm
 mit dem Worte Christi zu streiten, so gestattete der Gott des Alls, daß <lb n="20"/>
-Σ210 sein Wille auch dies tue, einmal zum Erweis der Athleten in der Gottesfurcht,
+<milestone unit="altnumbering" n="210"/>sein Wille auch dies tue, einmal zum Erweis der Athleten in der Gottesfurcht,
 zumal aber damit von jedermann offenbar gesehen werde, daß
 das Bestehen des Wortes keineswegs eine Folge des menschlichen
 Willens, sondern der göttlichen Kraft sei. Wer wollte nicht
@@ -8897,11 +10086,12 @@ Zeit durch Versuchungen erprobt, zeigten die Reinheit und Lauterkeit
 ihrer Gesinnung und empfingen dann ihre eigene Freiheit Freiheit
 suchte Gott sie (gnädig) heim, während er durch sie alle
 den Erlóserlogos strahlen ließ.</p>
-<lb n="5"/> <p>Zu Ende ist das Schreiben der fünf Bücher des
-die genannt werden: die Theophanie.</p>
- <lb n="3"/> <p>εἰς μεῖζον ὁσημέραι δι’ αὐτῶν ἐκλάμποντος τοῦ σωτηρίου λόγου D</p>
+<note>Zu Ende ist das Schreiben der fünf Bücher des
+die genannt werden: die Theophanie.</note>
+<note type="footnote">3 εἰς μεῖζον ὁσημέραι δι’ αὐτῶν ἐκλάμποντος τοῦ σωτηρίου λόγου D</note>
 </div>
-	 </div>
+</div>
+</div>
 
  </body>
   </text>

--- a/data/tlg2018/tlg010/tlg2018.tlg010.opp-ger1.xml
+++ b/data/tlg2018/tlg010/tlg2018.tlg010.opp-ger1.xml
@@ -65,8 +65,9 @@
 <encodingDesc>
 <p>Text encoded in accordance with the latest EpiDoc standards (January 2014)</p>
   <refsDecl n="CTS">
-        <cRefPattern n="book" matchPattern="(.+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"/>
-      </refsDecl>
+    <cRefPattern n="chapter" matchPattern="(.+).(.+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']/tei:div[@n='$2'])"/>
+    <cRefPattern n="book" matchPattern="(.+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"/>
+  </refsDecl>
     </encodingDesc>
 <profileDesc>
 <langUsage>
@@ -76,17 +77,20 @@
 <revisionDesc>
   <change who="Jack Duff" when="2016-06-21">Corrected metadata, expanded pb, removed lat and grc tag and replaced with ger, added ref, corrected book numbering.</change>
   <change who="Jack Duff" when="2016-07-28">Completed chapter numbering, changed roman num. to arabic, OCR correction, encoding critical punctuation.</change>
+  <change who="Jack Duff" when="2016-07-29">Added chapter XPath, corrected more OCR, encoded corr and supplied.</change>
 </revisionDesc>
 </teiHeader>
   <text>
-    <body><div type="edition" n="urn:cts:greekLit:tlg2018.tlg010.opp-ger1">
-	 <div type="textpart" subtype="book" n="1">
+    <body>
+<div type="edition" n="urn:cts:greekLit:tlg2018.tlg010.opp-ger1">
 <pb n="v.3.pt.2.p.37"/>
 <head>DIE THEOPHANIE DES EUSEBIUS.</head>
 <head>(ÜBERSETZUNG)</head>
-
+        
+<div type="textpart" subtype="book" n="1">
 <pb n="v.3.pt.2.p.39"/>
 <head>Das erste Buch des Cäsareensers Eusebius über die Theophanie.</head>
+  
 <div type="textpart" subtype="chapter" n="1">
 <milestone unit="altnumbering" n="1"/> <p>Diejenigen, welche sagen von der Herstllung der ganzen weiten
 und schönen Welt und non dem manningachen und reich zusammengstetzten
@@ -94,7 +98,7 @@ Bestande Himmels und der Erden, daß sie keinen Anfang und <lb n="5"/>
 Keinen Verwalter habe, und daß sie ohne Herr und ohne Voersehung
 Planlos und aufs Geratewohl und durch einen unverständigen Zufall, der
 Sich grade ereignete, von selber entstand, sind vollkommen Frevler
-Und gottlose. Die daher aus (unsern) Göttlichen Versammlunge aus
+Und gottlose. Die daher aus <supplied reason="undefined" resp="#editor">unsern</supplied> Göttlichen Versammlunge aus
 Gestoßen und von unsern heiligen Tempeln ferngehalten warden sollen, <lb n="10"/>
 Geziemenderwiese, deswegen weil auch sie weder ein Haus herstellen
 Können ohne Überlegung und Fürsorge, noch ein Schiff schön zusammengepflockt
@@ -104,15 +108,15 @@ Die Wisheit des Baumeirsters nicht voerhanden ist. Indem sie dies zugestehen, <l
 Weiß ich nicht, in welchem Verstandeswahnsinn sie nicht achten
 Auf die Bahnen der Sonne, die nach ihrer Art, noch auf die Wechsel des
 Mondes, die nach iherer Ordnung, noch auf die Reigen der Sterne, die
-Nach ihere Regel (geschehen), noch auf das Kreisen der Himmelsgewölbe,
+Nach ihere Regel <supplied reason="undefined" resp="#editor">geschehen</supplied>, noch auf das Kreisen der Himmelsgewölbe,
 Noch auf die Wiederkehr der Perioden, noch auf den Wechsel der <lb n="20"/>
-(Jahres)zeiten, noch ferner überdies auf die Wageblken, die in gleichen
-Ausdehungsschwqankungen der Tage jund Nächte (sich befinden), noch 
+<supplied reason="undefined" resp="#editor">Jahres</supplied>zeiten, noch ferner überdies auf die Wageblken, die in gleichen
+Ausdehungsschwqankungen der Tage jund Nächte <supplied reason="undefined" resp="#editor">sich befinden</supplied>, noch 
 Auf die undbhinderte Geburt der Lebewesen, noch auf die für lange
 Ewigkeit unwandelbare Fortpflanzung, noch auf die Grwächse, die aus
 Der Erde sprossen, mit allerlei Blÿten, noch auf die Nahrungsmittel, <lb n="25"/>
-Die allen lebeesen entsprechend (sind), noch auf ihre eigenne Sinne,
-Noch auf die Formen des leibes, noch auf seine Glieder, die gut *an ihren
+Die allen lebeesen entsprechend <supplied reason="undefined" resp="#editor">sind</supplied>, noch auf ihre eigenne Sinne,
+Noch auf die Formen des leibes, noch auf seine Glieder, die gut <corr resp="#editor">an</corr> ihren
 <note type="footnote">11 ff. vgl. Praep. VII 33 17 ff. vgl. Dwm. IV 58 laus 206 27 ff.</note>
 <note type="footnote">1 Die Überschrift rührt kaum von Eusebius her 21 vgl. L 208 26 ἔαρ δὲ....
 ἰσορρόποις ταλαωτεύσας ζυγοῖς 23 <foreign xml:lang="abbr">ABBREV</foreign> 
@@ -125,31 +129,31 @@ Platz gestellt sind — mit ihren Augen sehen sie und mit ihren Händen
 tasten sie, was, wie man sagt, selbst den blinden klar ist, so daß sie <milestone unit="altnumbering" n="2"/>
 mit gottlosen Worten und im Frevel länsterlichen Sinnes wähnen, es
 gebe weder ein Werk der Weisheit, wie sie sagen, noch des Wortes
-<lb n="5"/> Gottes und der Vorsehung, sondern (nur) des unverständigen, zufälligen
-*Verhängnisses, das planlos und aufs Geratewohl von irgendwoher sich
+<lb n="5"/> Gottes und der Vorsehung, sondern <supplied reason="undefined" resp="#editor">nur</supplied> des unverständigen, zufälligen
+<corr resp="#editor">Verhängnisses</corr>, das planlos und aufs Geratewohl von irgendwoher sich
 ereigne. Eben diese also sollen als vollkommen Gottlose von dem
-Verkehr mit den Gottesfürchtigen und von dem Hören (des) göttlichen
-(Wortes) weit weggetriebe warden.</p></div>
+Verkehr mit den Gottesfürchtigen und von dem Hören <supplied reason="undefined" resp="#editor">des</supplied> göttlichen
+<supplied reason="undefined" resp="#editor">Wortes</supplied> weit weggetriebe warden.</p></div>
 	   
 <div type="textpart" subtype="chapter" n="2">
 <lb n="10"/><p>Die Menge der Polytheisten aber scheint mir auf der anderen
 Seite, die sich der ersten gegenü	berreiht, einen anderen Irrtum nach
 Art der Kinder in ihrem Denken begangen zu haben. Diejenigen, welche
 die Verehrung des Weltschöpfers und des Allenkers, des Gottes, der
-über alles (herrscht), mit den Dingen, die von ihm (geschaffen) wurden,
-<lb n="15"/> vertauscht und (statt seiner) die Sonne, den Mond und die übrigen Teile
+über alles <supplied reason="undefined" resp="#editor">herrscht</supplied>, mit den Dingen, die von ihm <supplied reason="undefined" resp="#editor">geschaffen</supplied> wurden,
+<lb n="15"/> vertauscht und <supplied reason="undefined" resp="#editor">statt seiner</supplied> die Sonne, den Mond und die übrigen Teile
 der Welt und die Ur-στοιχεῖα: Erde, Wasser, Luft und Feuer, mite ben
 dem gleichen Namen ihres Werkmeisters und Schöpfers geehrt und sie
-Götter genannt haben, (Dinge), die niemals wären, noch geworden wären,
+Götter genannt haben, <supplied reason="undefined" resp="#editor">Dinge</supplied>, die niemals wären, noch geworden wären,
 noch genannt würden, wenn nicht der Weltschöpfer, das Wort Gottes
-<lb n="20"/> (wäre), der ihr Werden wollte —, *sie scheinen mir nicht besser als
+<lb n="20"/> <supplied reason="undefined" resp="#editor">wäre</supplied>, der ihr Werden wollte —, <corr resp="#editor">sie</corr> scheinen mir nicht besser als
 diejenigen, welche den Baumeister der vorzüglichen Arbeiten in den
-Königshäusern außer acht lassen und (statt dessen) die *Dachbalken und die Wände und die *vielfarbigen und *vielblumigen Bilder, die an
-ihnen (hängen), und die goldbunten Schnitzwerke und die Steinskulpturen
-<lb n="25"/> anstaunen und eben diesen (Dingen) das Lob der Weisheit ihres Künstlers
-beilegen, während sie nicht diesen sichtbaren (gegenständen), sondern
+Königshäusern außer acht lassen und <supplied reason="undefined" resp="#editor">statt dessen</supplied> die <corr resp="#editor">Dachbalken</corr> und die Wände und die <corr resp="#editor">vielfarbigen</corr> und <corr resp="#editor">vielblumigen</corr> Bilder, die an
+ihnen <supplied reason="undefined" resp="#editor">hängen</supplied>, und die goldbunten Schnitzwerke und die Steinskulpturen
+<lb n="25"/> anstaunen und eben diesen <supplied reason="undefined" resp="#editor">Dingen</supplied> das Lob der Weisheit ihres Künstlers
+beilegen, während sie nicht diesen sichtbaren <supplied reason="undefined" resp="#editor">gegenständen</supplied>, sondern
 nur dem, der ihr Baumeister ist, die Ursache ihres Staunens zuschreiben
-und bekennen sollten, daß Werke der Weisheit die moisten seien, (daß)
+und bekennen sollten, daß Werke der Weisheit die moisten seien, <supplied reason="undefined" resp="#editor">daß</supplied>
 <note type="footnote">12—s. 48, 9 = Laus 225 27–232 3</note>
 <note type="footnote">6 <foreign xml:lang="abbr">ABBREV</foreign> wird hier wie Σ 15 51 Αdjektivum sein, also: „einen unverständigen
 Gegensatz des zufalls, der planlos“. . . Aber lies <foreign xml:lang="abbr">ABBREV</foreign> SchulthebB. Ber-
@@ -165,35 +169,35 @@ goldbunten Dächer“ Σ vermutlich = χρυςόφοφά τε ποικίλμ�
 <pb n="v.3.pt.2.p.41"/>
 Weise aber allein der sei, der den moisten Ursache gab, so zu werdeb.
 Von unmündigen Kindern also sind sie durchaus in nichts verschieden,
-Ebensowenig (wie) diejenigen, welche die siebensaitige Zither, eben das
+Ebensowenig <supplied reason="undefined" resp="#editor">wie</supplied> diejenigen, welche die siebensaitige Zither, eben das
 Musikinstrument, aber keineswegs den, der dessen Zusammensetzung erfunden
 Hat und dessen kundig ist, und seine Weisheit anstaunen, oder <lb n="5"/>
-(wie) diejenigen, welche den in Kriegen tapferen (Mann) außer acht
-Lassen, (wohl) aber seine Lanze und seinen Schild mit Siegeskränzen
-schmücken, oder (wie) diejenigen, welche in gleicher Weise wie den
-GroBkönig, der die Ursache für die groBe und königliche Stadt ist,
-(auch) die Märkte und StraBen, die Gebäude, die seelenlosen Tempel <lb n="10"/>
+<supplied reason="undefined" resp="#editor">wie</supplied> diejenigen, welche den in Kriegen tapferen <supplied reason="undefined" resp="#editor">Mann</supplied> außer acht
+Lassen, <supplied reason="undefined" resp="#editor">wohl</supplied> aber seine Lanze und seinen Schild mit Siegeskränzen
+schmücken, oder <supplied reason="undefined" resp="#editor">wie</supplied> diejenigen, welche in gleicher Weise wie den
+Großkönig, der die Ursache für die große und königliche Stadt ist,
+<supplied reason="undefined" resp="#editor">auch</supplied> die Märkte und Straßen, die Gebäude, die seelenlosen Tempel <lb n="10"/>
 <milestone unit="altnumbering" n="3"/> und Gymnasien ehren während sie nicht die Säulen noch die Steine,
-Sondern den groBen Schöpfer und Gesetzgeber dieser weisheitsreichen
+Sondern den großen Schöpfer und Gesetzgeber dieser weisheitsreichen
 Dinge anstaunen sollten.</p>
 </div>
 	   
 <div type="textpart" subtype="chapter" n="3">
-<p>DemgemäB aber dürfen wir auch als Ursache
+<p>Demgemäß aber dürfen wir auch als Ursache
 Von eben diesem Ganzen, das man mit leiblichen Augen sieht,
-Weder Sonne noch Mond noch ein anderes (Gestirn) von denen am <lb n="15"/>
-Himmel setzen, sondern wir müssen bekennen, daB sie alle Werke der
+Weder Sonne noch Mond noch ein anderes <supplied reason="undefined" resp="#editor">Gestirn</supplied> von denen am <lb n="15"/>
+Himmel setzen, sondern wir müssen bekennen, daß sie alle Werke der
 Weisheit sind. Aber nicht dürfen wir sie in ähnlicher Weise wie ihren
 Werkmeister und Schöpfer ehren und anbeten, vielmehr sollen wir infolge
-Der Betrachtung eben dieser (Dinge) ihn, nicht mehr mit leiblichen
+Der Betrachtung eben dieser <supplied reason="undefined" resp="#editor">Dinge</supplied> ihn, nicht mehr mit leiblichen
 Augen, sondern nur mit einem reinen und klaren Verstande erkannt <lb n="20"/>
 Wird, den König des Alls, das Wort Gottes mit ganzer Liebe der
 Seele preisen und verehren, deswegen weil auch niemals jemand den
 Leib eines weisen und verständigen Mannes: seine Augen oder seinen
-Kopf oder seine Hände oder seine FüBe oder sein übriges Flesich, geschweige
-Die äuBere Bedeckung seines. Gewandes *weise nennt, noch <lb n="25"/>
-Die Geräte im Hause weise, noch die GefäBe, die zum Dienst der Philosophen
-(bestimmt sind), sondern jeder, der Verstand hat, bewundert die
+Kopf oder seine Hände oder seine Füße oder sein übriges Flesich, geschweige
+Die äußere Bedeckung seines. Gewandes <corr resp="#editor">weise</corr> nennt, noch <lb n="25"/>
+Die Geräte im Hause weise, noch die Gefäße, die zum Dienst der Philosophen
+<supplied reason="undefined" resp="#editor">bestimmt sind</supplied>, sondern jeder, der Verstand hat, bewundert die
 Verborgene, unsichtbare Intelligenz, die in dem Menschen ist.</p>
 </div>
 	   
@@ -201,7 +205,7 @@ Verborgene, unsichtbare Intelligenz, die in dem Menschen ist.</p>
 <p>So sollen wir den auch vielmehr vor den sichtbaren Schmuckgegenständen
 Der ganzen Welt, die körperlich und au seiner ὕλη gemacht <lb n="30"/>
 sind, das verborgene, unsichtbare Wort, den Schöpfer und
-Schmuckwart der (Ur) bilder des Alls bewundern, (ihn), der der eingeborne
+Schmuckwart der <supplied reason="undefined" resp="#editor">Ur</supplied> bilder des Alls bewundern, <supplied reason="undefined" resp="#editor">ihn</supplied>, der der eingeborne
 Logos Gottes ist, den der jenseits von aller und über aller οὐσία
 <note type="footnote">5 ἐπιστήμονα τῆς σοφίας L. Streicht man das <foreign xml:lang="abbr">ABBREV</foreign> „und“ vor <foreign xml:lang="abbr">ABBREV</foreign>, so
 Kann man übersetzen, „wegen seiner Weisheit“ 23 επεὶ καὶ <add>ἐπὶ</add> ἀνθρώπου
@@ -211,17 +215,17 @@ Kann man übersetzen, „wegen seiner Weisheit“ 23 επεὶ καὶ <add>ἐ�
 Heikel möchte unter σκεύη die „Sklaven“ verstehen</note>
 
 <pb n="v.3.pt.2.p.42"/>
-(Stehende) Schöpfer des Alls aus sich wie einen Lichtstrahl aus seiner
+<supplied reason="undefined" resp="#editor">Stehende</supplied> Schöpfer des Alls aus sich wie einen Lichtstrahl aus seiner
 Gottheit gezeugt und zum Führer und Lenker dieses Alls eingesetzt hat.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="5">
 <p>Denn weil es unmöglich war, daß die flüssige οὐσία der Körper und
-die Natur der vernünftigen Wesen, die jetzt geworden *sind, sich dem
-<lb n="5"/> Allenker Gott nahte wegen der Größe (ihres) Mangels an Gutem —
-den er war ein Sein, das jenseits und oberhalb von allem (ist,), das
+die Natur der vernünftigen Wesen, die jetzt geworden <corr resp="#editor">sind</corr>, sich dem
+<lb n="5"/> Allenker Gott nahte wegen der Größe <supplied reason="undefined" resp="#editor">ihres</supplied> Mangels an Gutem —
+den er war ein Sein, das jenseits und oberhalb von allem <supplied reason="undefined" resp="#editor">ist,</supplied>, das
 unaussagbar, unerreichbar und unnahbar in stolzem Licht wohnt, des-
-gleichen es nicht gibt, wie die göttlichen Worte sagen; die (οὐσία)
+gleichen es nicht gibt, wie die göttlichen Worte sagen; die <supplied reason="undefined" resp="#editor">οὐσία</supplied>
 aber existierte nicht und aus dem Nichts brachte er sie hervor, sehr
 <lb n="10"/> verschieden und sehr weit entfernt von der Natur des Seins — so stellate
 daher mit Recht der an allem Guten reiche Gott des Alls zuvor ein Mittleres
@@ -230,20 +234,20 @@ auf: die göttliche kraft seines Eingebornen, die allem genügt, die vor-
 züglich genau and nah emit dem Nater redet und innerhalb von ihm
 <lb n="15"/> niedrigt und denen gleich wird an Gestalt, die von der Spitze fern
 bleiben. Denn auf andere Weise war es weder ehrbar noch gerecht,
-daß er, der jenseits von allem und höher als alles (ist), sich mit ver-
+daß er, der jenseits von allem und höher als alles <supplied reason="undefined" resp="#editor">ist</supplied>, sich mit ver-
 gänglicher ὕλη und mit einem Körper vermischte. Deswegen drange der
 göttliche Logos 9unvermerkt) dazwischen in das All ein, band die Zügel
-<lb n="20"/> des Alls zusammen und führt und trägt (es) dahin durch göttliche, un-
+<lb n="20"/> des Alls zusammen und führt und trägt <supplied reason="undefined" resp="#editor">es</supplied> dahin durch göttliche, un-
 körperliche Kraft, indem er es allweise lenkt, wie es ihm gut zu sein
 scheint.</p> 
 </div>
 
 <div type="textpart" subtype="chapter" n="6">
 <p>Der Beweis der Rede aber ist klar. Denn wenn für sich
-(existieren) die Teile der Welt, die wir gewohnt sind, die Ur-στοιχεῖα
-des Alls zu nennen: Erde, Wasser, Luft und Feuer, *die (ja) aus ver-
+<supplied reason="undefined" resp="#editor">existieren</supplied> die Teile der Welt, die wir gewohnt sind, die Ur-στοιχεῖα
+des Alls zu nennen: Erde, Wasser, Luft und Feuer, <corr resp="#editor">die</corr> <supplied reason="undefined" resp="#editor">ja</supplied> aus ver-
 <lb n="25"/> wirrter Natur bestehen, was wir auch mit unsern Augen sehen, und wenn
-es (ferner) Eine οὐσία des Alls gibt, welche *diejenigen, die hierin er-
+es <supplied reason="undefined" resp="#editor">ferner</supplied> Eine οὐσία des Alls gibt, welche <corr resp="#editor">diejenigen</corr>, die hierin er-
 fahren sind, „Aufnehmerin des Alls“, „Mutter“ und „Amme“ zu nennen
 <note type="footnote">1 vgl. Hebr 13 7 vgl. I Tim 616 11 „ein Mittleres — 16 fern bleiben“
 = Dem. IV 63 27 vgl. Platon Tim 51. 52</note>
@@ -254,14 +258,14 @@ gibt“] ἀπρόσιτον L 13 „und innerhalb von seiner Verborgenheit emp
 die Zügel des Alls zusammen mit göttlicher, unkörperlicher Kraft und führt und
 bringt indem“ . . . Σ ἡνίας τοῦ παντὸς ἐνδηςάμενος ἀσωμάτῳ καὶ θεϊκῇ δυνάμει
 ἄγετ καὶ φέρει L. Also gehört das <foreign xml:lang="abbr">ABBREV</foreign> vor <foreign xml:lang="abbr">ABBREV</foreign> statt vor <foreign xml:lang="abbr">ABBREV</foreign> 24 Statt
-<foreign xml:lang="abbr">ABBREV</foreign> „und aus“ lies <foreign xml:lang="abbr">ABBREV</foreign> SchultheB 25 εἰ μία τοῖς περὶ ταῦτα δεινοῖς ὀνομάζειν
+<foreign xml:lang="abbr">ABBREV</foreign> „und aus“ lies <foreign xml:lang="abbr">ABBREV</foreign> Schultheß 25 εἰ μία τοῖς περὶ ταῦτα δεινοῖς ὀνομάζειν
 φίλον L 26 lies <foreign xml:lang="abbr">ABBREV</foreign> statt <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.43"/>
-lieben, und (welche) ohne Gestalt und Aussehen und völlig Seele
-und Vernunft (ist) — woher, würde jemand sagen, hat sie (den) die
+lieben, und <supplied reason="undefined" resp="#editor">welche</supplied> ohne Gestalt und Aussehen und völlig Seele
+und Vernunft <supplied reason="undefined" resp="#editor">ist</supplied> — woher, würde jemand sagen, hat sie <supplied reason="undefined" resp="#editor">den</supplied> die
 Ordnung, die in ihr ist? Woher der Unterschied der στοιχεῖα? Woher
-der (Zusammen)lauf der gegensätzlichen (Elemente) zur Einheit? Wer
+der <supplied reason="undefined" resp="#editor">Zusammen</supplied>lauf der gegensätzlichen <supplied reason="undefined" resp="#editor">Elemente</supplied> zur Einheit? Wer
 hat befohlen, daß das schwere στοιχεῖον der Erde oben auf der feuchten <lb n="5"/>
 οὐσία reite?</p> 
 </div>
@@ -312,7 +316,7 @@ ihre Entstehung und ihren Wandel mit verborgener, unsichtbarer
 Kraft?</p>
 </div>
 <div type="textpart" subtype="chapter" n="15">
-<p>Aber als die Ursache aller dieser (Erscheinungen) wird mit
+<p>Aber als die Ursache aller dieser <supplied reason="undefined" resp="#editor">Erscheinungen</supplied> wird mit
 Recht der wundertätige Logos Gottes genannt. Denn der in Wahrheit
 allmächtige Logos Gottes erstreckte sich durch alles, breitete sich nach <lb n="25"/>
 oben zur Höhe und nach unten zur Tiefe unkörperlich aus, faßte die
@@ -333,9 +337,9 @@ und gestimmt.“ Σ hat falsch konstruiert und zu etymologisch übersetzt: τὴ
 
 <pb n="v.3.pt.2.p.44"/>
 οὐσία der Körper mit allweiser und vernünftiger Kraft an, indem er
-schön die (Tonleiter der) διάτονοι mit (derjenigen der) διεζευγμένα verbindet,
+schön die <supplied reason="undefined" resp="#editor">Tonleiter der</supplied> διάτονοι mit <supplied reason="undefined" resp="#editor">derjenigen der</supplied> διεζευγμένα verbindet,
 und lenkt die Sonne, den Mond und die leuchten am Himmel
-mit unaussprechlichen Worten und führt (sie) zum Nutzen des alls.</p>
+mit unaussprechlichen Worten und führt <supplied reason="undefined" resp="#editor">sie</supplied> zum Nutzen des alls.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="16">
@@ -346,21 +350,21 @@ schöner Pflanzen her.</p>
 
 <div type="textpart" subtype="chapter" n="17">
 <p>Eben dieser Logos Gottes tauchte
-auch bis auf die Tiefen des Meeres hinunter und ersann *die schwimmenden
+auch bis auf die Tiefen des Meeres hinunter und ersann <corr resp="#editor">die</corr> schwimmenden
 Naturen und wirkte auch hier wiederum ungezählte Myriaden
 <lb n="10"/> von Gestalten und allerlei verschiedene Tiere.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="18">
 <p>Eben dieser
-vollendet auch *das, was im Leibe getragen wird, innen in der *Kunstwerkstatt
+vollendet auch <corr resp="#editor">das</corr>, was im Leibe getragen wird, innen in der <corr resp="#editor">Kunstwerkstatt</corr>
 der Natur und bildet Leben. Dieser hebt auch leicht die
 flüssige und schwere Natur der feuchten οὐσία nach oben zur Höhe und
-wandelt sie dann in Süssigkeit. Nach (bestimmtem) Maß bringt er sie
-<lb n="15"/> aufs land und vollendet (so) zu bestimmten Zeiten seine Versorgung.
+wandelt sie dann in Süssigkeit. Nach <supplied reason="undefined" resp="#editor">bestimmtem</supplied> Maß bringt er sie
+<lb n="15"/> aufs land und vollendet <supplied reason="undefined" resp="#editor">so</supplied> zu bestimmten Zeiten seine Versorgung.
 Nachdem er nach Art eines vorzüglichen Landmannes den Acker gut
 bewässert und mit der Trackenheit die Feuchtigkeit vermengt hat, wandelt
-er (ihn) auf alle Art um, indem er bald durch die schöche Blüten, bald <milestone unit="altnumbering" n="6"/>
+er <supplied reason="undefined" resp="#editor">ihn</supplied> auf alle Art um, indem er bald durch die schöche Blüten, bald <milestone unit="altnumbering" n="6"/>
 durch allerlei Formen, bald durch angenehme Gerüche, bald durch die
 <lb n="20"/> wechselnden Unterschiede der Früchte und bald durch den Geschmack
 allerhand Genüsse gevährt.</p>
@@ -375,8 +379,8 @@ da es lkar ist, daß seine Energie jeden sterblichen Verstand weit übertrifft?<
 <div type="textpart" subtype="chapter" n="20">
 <p>Die einen also haben diesen Allnatur, die anderen Allseele, noch
 <lb n="25"/> andere Schicksal genannt. Andere aber haben gesagt, er sei der jenseits
-von allem (weilende) Gott, und haven ich weiß nicht wie unendlich
-weitgetrennte (Dinge) vermischt, indem sie den Alllenker, die höchste
+von allem <supplied reason="undefined" resp="#editor">weilende</supplied> Gott, und haven ich weiß nicht wie unendlich
+weitgetrennte <supplied reason="undefined" resp="#editor">Dinge</supplied> vermischt, indem sie den Alllenker, die höchste
 <note type="footnote">6 παντοδαπῶν γένη ζώων φυτῶν τε πολύμορφα κάλλη L 8 Statt <foreign xml:lang="abbr">ABBREV</foreign>
 lies <foreign xml:lang="abbr">ABBREV</foreign> ebenso Z. 11 11 „Kunst“ Σ. Aber statt <foreign xml:lang="abbr">ABBREV</foreign> lies <foreign xml:lang="abbr">ABBREV</foreign>
 <foreign xml:lang="abbr">ABBREV</foreign> Hoffmann: ἔνδον ἐν τῷ τῆς φύσεως ἐργαστηρίῳ L 12 „die feuchte
@@ -394,7 +398,7 @@ da er den Schluß übersetzt: „bald dem Geschmacke allerlei Genüsse gewährt�
 Kraft des Seins nach unten auf die Erde und in die Körper warfen
 <add>und</add> mit vergänglicher ὕλη verknüpften und vorgaben, er umkreise
 die Mitte der unvernünftigen und vernünftigen, sterblichen und unsdterblichen
-Lebewesen. Aber sie (behaupten) dies.</p>
+Lebewesen. Aber sie <supplied reason="undefined" resp="#editor">behaupten</supplied> dies.</p>
 </div>
 <div type="textpart" subtype="chapter" n="21">
 <p>Die göttliche Lehre aber sagt, daß das höchste  aller Güter, <lb n="5"/>
@@ -402,10 +406,10 @@ eben er, der die Ursache des Alls ist, jenseits von allem Begreifen sei.
 Deswegen sei er unsagbar, unaussprechlich, unnennber, und nicht nur
 höher als jedes   Wort, sondern auch als alle Vernnuft, weder an einem
 Orte greifbar noch in Körpern existierend, weder im Himmel noch im
-Äther noch in (irgend) einem der Teile  des Alls, sondern zugleich überall <lb n="10"/>
+Äther noch in <supplied reason="undefined" resp="#editor">irgend</supplied> einem der Teile  des Alls, sondern zugleich überall <lb n="10"/>
 und außerbalb von allem, auftbewahrt in her Tiefe des verborgenen
 Wissens. Diesen allein als wahren  Gott zu wissen, lehren die göttlichen
-Worte, (ihn,) der von jeder körperlichen οὑσία gesondert und jedem
+Worte, <supplied reason="undefined" resp="#editor">ihn,</supplied> der von jeder körperlichen οὑσία gesondert und jedem
 Verwaltungsdienst fremd ist. Deswegen ist uns überliefert, daß alles
 von ihm, aber keineswegs  durch ihn sei.</p>
 </div>
@@ -413,17 +417,17 @@ von ihm, aber keineswegs  durch ihn sei.</p>
 <div type="textpart" subtype="chapter" n="22">
 <p>Sondern er  sitzt nach <lb n="15"/>
 Art eines Königs drinnen in der Verborgenheit und Verstecktheit und
-Unxugänglichkeit in der Höhe des Blickes und lenkt und ordnet (alles)
+Unxugänglichkeit in der Höhe des Blickes und lenkt und ordnet <supplied reason="undefined" resp="#editor">alles</supplied>
 nur durch die  Kraft  seines Willens. Denn wenn er will, so existiert
 das, was da existiert, und wenn er nicht will, so existiert es nicht. Er
 will aber alles Gute, deswegen weil auch er gut ist in seiner οὐσία.</p>
 </div> <lb n="20"/>
 	   
 <div type="textpart" subtype="chapter" n="23">
-<milestone unit="altnumbering" n="7"/><p>Er aber, durch den alles (ist), der Logosgott *regnet von
+<milestone unit="altnumbering" n="7"/><p>Er aber, durch den alles <supplied reason="undefined" resp="#editor">ist</supplied>, der Logosgott <corr resp="#editor">regnet</corr> von
 oben aus seinem guten Vater wie aus  einer unendlichen, immer fließenden
 Quelle <add>und</add> geht durch unaussprechliche Worte nach Art eines Flusses
-hervor, indem er ganz und gar (zum Überfließen) voll ist für die gesamte Erlösung des Alls. Wie aber nach dem in unserer Weise (gewählten) 25
+hervor, indem er ganz und gar <supplied reason="undefined" resp="#editor">zum Überfließen</supplied> voll ist für die gesamte Erlösung des Alls. Wie aber nach dem in unserer Weise <supplied reason="undefined" resp="#editor">gewählten</supplied> 25
 Beispiel der verborgene und unsichtbare Verstand, der in uns
 <note type="footnote">14 vgl. I Kor 8 6 16 vgl. I Tim 7 16 25—S 46, 20 =  1. Bruchstück
 der griech. Theoph. 25 ff. vgl. I Kor 2 11. 16 Joh 1 18</note>
@@ -433,7 +437,7 @@ der griech. Theoph. 25 ff. vgl. I Kor 2 11. 16 Joh 1 18</note>
 2 „umkreise” Σ (dem Sinne nach = er stehe ungefähr in der Mitte) εἰλεῖσθαι  Hkl
 εἰλίσθαι, εἱλῆσθαι L 16 εἴσω που ἐν ἀρρήτοις (ἀπορρήτοις Σ) καὶ ἀδύτοις καὶ
 ἀβάτοις φῶς οἰκῶν ἀπρόσιτον L „in der . . . Verstecktheit, wo er unzugänglich
-(ist) in (resp. „wegen”) der Höhe seines Anblicks” Σ. Τeils scheint er anders teils
+<supplied reason="undefined" resp="#editor">ist</supplied> in (resp. „wegen”) der Höhe seines Anblicks” Σ. Τeils scheint er anders teils
 falsch gelesen teils falsch verstanden (das Pronomen!) zu  haben, etwa: καὶ ἄβατος 
 (1. ἀβάτοις) τὰ μετέωρα οἰκῶν τῆς ὄψεως 21 „und regnet” (= fließt, Σ aber
 = läßt regnen?) Das <foreign xml:lang="abbr">ABBREV</foreign> „und“ steht besser vor <foreign xml:lang="abbr">ABBREV</foreign>. ἀνομβρῶν λόγοις ἀρρήτοις ποταμοῦ
@@ -441,14 +445,14 @@ falsch gelesen teils falsch verstanden (das Pronomen!) zu  haben, etwa: καὶ 
 
 <pb n="v.3.pt.2.p.46"/>
 ist, von dem niemals einer der Menschen erkannt hat, wie er und was
-er seinem Wesen nach ist, *gleich einem Könige in der Verborgenheit
-drinnen in seinen Gemächern sitzt und die *Taten beschließt, (wie) aber
-(ferner) das einzigartige Wort aus ihm hervorgeht, gleichwie von einem
-<lb n="5"/> Vater in versteckter Verborgenheit gezeugt, und (wie) es zuerst allen
+er seinem Wesen nach ist, <corr resp="#editor">gleich</corr> einem Könige in der Verborgenheit
+drinnen in seinen Gemächern sitzt und die <corr resp="#editor">Taten</corr> beschließt, <supplied reason="undefined" resp="#editor">wie</supplied> aber
+<supplied reason="undefined" resp="#editor">ferner</supplied> das einzigartige Wort aus ihm hervorgeht, gleichwie von einem
+<lb n="5"/> Vater in versteckter Verborgenheit gezeugt, und <supplied reason="undefined" resp="#editor">wie</supplied> es zuerst allen
 ein Bote für die Gedanken seines Vaters ist und offen das verkündigt,
 was sein Vater in der Verborgenheit beschlossen hat, und die Beschlüsse
-durch Taten vollführt, indem es in die Ohren aller eingeht, (und wie)
-dann diese den Nutzen vom Worte empfangen, (wie) aber niemals einer
+durch Taten vollführt, indem es in die Ohren aller eingeht, <supplied reason="undefined" resp="#editor">und wie</supplied>
+dann diese den Nutzen vom Worte empfangen, <supplied reason="undefined" resp="#editor">wie</supplied> aber niemals einer
 <lb n="10"/> den verborgenen, unsichtbaren Verstand, eben den Vater des Wortes,
 mit Augen gesehen hat, — demgemäß also, das heißt vielmehr über alle Beispiele
 und Bilder hinaus ist das vollkommene Wort des Allkönigs Gott,
@@ -456,15 +460,15 @@ wie der einzigartige Sohn seines Vaters, keineswegs entstanden durch
 eine sich äußernde Kraft, noch seiner Natur nach aus Silben von Namen
 <lb n="15"/> und Worten geschaffen, noch wird er mit einem Wort, das durch die
 Luft schlägt, bezeichnet, sondern er ist das lebendige und wirksame
-Wort des über alles (herrschenden) Gottes und ist seinem Wesen nach
+Wort des über alles <supplied reason="undefined" resp="#editor">herrschenden</supplied> Gottes und ist seinem Wesen nach
 die Kraft Gottes und die Weisheit Gottes, und geht aus der Gottheit
 und dem Königreich seines Vaters hervor und ist der gute Sprößling
 <lb n="20"/> eines guten Vaters und der gemeinsame Erlöser aller, und tränkt alles
 <add>und</add> läßt allem Leben, Vernunft, Weisheit, Licht und alles Gute aus
 seiner eigenen Fülle zufließen. Er tränkt aber keineswegs nur das, was
-vor ihm (liegt) und ihm am nächsten (ist), sondern auch das weit Entfernte
+vor ihm <supplied reason="undefined" resp="#editor">liegt</supplied> und ihm am nächsten <supplied reason="undefined" resp="#editor">ist</supplied>, sondern auch das weit Entfernte
 zu Lande und zu Wasser und wenn es irgend einen anderen Teil
-<lb n="25"/> (als diese) im Seienden gibt. Für alle zugleich ordnet er Grenzen, Gebiete,
+<lb n="25"/> <supplied reason="undefined" resp="#editor">als diese</supplied> im Seienden gibt. Für alle zugleich ordnet er Grenzen, Gebiete,
 GEsetze und Erbteile mit Gerechtigkeit, und mit königlicher Vollmacht
 teilt er einem jeden  ͌ u und gibt ihm das, dessen er würdig ist, und
 sondert ab für die einen, daß sie die überweltlichen Gewölbe, für die
@@ -484,22 +488,22 @@ anderen, daß sie den Himmel selber bewohnen, für andere die atherischen
 Wohnstatten, für  andere die Luft und fur andere die Erde, und dann,
 <milestone unit="altnumbering" n="8"/> indem er sie non hier wieder anderswohin verlegt, unterscheidet er sehr
 wohl die Lebensfuhrungen aller, pflanzt Gewohnheiten und Sitten unterschiedlich 
-fort und sorgt fur leben *und Nahrung keineswegs der Vernunftigen <lb n="5"/>
+fort und sorgt fur leben <corr resp="#editor">und</corr> Nahrung keineswegs der Vernunftigen <lb n="5"/>
 allein, sondern auch der unvernunftigen Tiere zum Gebrauch
-der vernunftigen (Menschen).</p>
+der vernunftigen <supplied reason="undefined" resp="#editor">Menschen</supplied>.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="24">
 <p>Und den einen gewahrt er den Genuß
 des sterblichen und zeitlichen Lebens, den andern aber das Teilhaben
-an der Unsterblichkeit. Alles aber wirkt er als der Logos Gottes, *indem
+an der Unsterblichkeit. Alles aber wirkt er als der Logos Gottes, <corr resp="#editor">indem</corr>
 er allem nahe ist und alles mit vernunftiger Kraft durcheilt, nach <lb n="10"/>
 oben seinen Vater anblickt und gemaß seinen Winken das Untere und
 ihm nachfolgend wie ein Erloser aller lenkt, indem er so in der 
 Mitte befindet, der das Getrennte zusammenfesselt und nicht zuläbt, daß <lb n="15 "/>
 ist und die gewordene οὐσία dem Sein annahert.</p>
 <p>Eine unzerreißbare Fessel ist der Logos Gottes, der sich in der 
-es weit (auseinander) fallt. Er ist die uber alles (waltende) Vorsehung,
+es weit <supplied reason="undefined" resp="#editor">auseinander</supplied> fallt. Er ist die uber alles <supplied reason="undefined" resp="#editor">waltende</supplied> Vorsehung,
 er ist der Pfleger und Lenker des Alls, er ist die Kraft Gottes und die
 Weisheit Gottes, er ist der Eingeborne, der Sohn Gottes, der Gott aus
 Gott Gezeugte, das Wort. „Denn im Anfang war das Wort und das
@@ -509,7 +513,7 @@ gottlicher manner.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="25">
-<p>Er ist der gemeinsame *Pflanzer aller, um
+<p>Er ist der gemeinsame <corr resp="#editor">Pflanzer</corr> aller, um
 deswillen die οὐσία des Alls wachst und bluht, von seinem Tau zu jeder
 Zeit getrankt, fur immer verjungt in ihrer Blute und einen schonen
 Anblick jederzeit gewahrend. Er aber halt ihre Zugel und fuhrt sie <lb n="25 "/>
@@ -529,15 +533,15 @@ erwartet <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.48"/>
 Vaters  den großen Nachen der gesamten Welt. Diesenschönkÿnstlerischen
-eihgebornen Sohn zeugte der *jenseits von allem(stehende) Gott,
-wie ein gutter Vater eine gute Frucht, und gab (ihn)dieser Welt als das vorzÿglichste Geschek wie eine Seele für denseelenlosen Leib, und
+eihgebornen Sohn zeugte der <corr resp="#editor">jenseits</corr> von allem<supplied reason="undefined" resp="#editor">stehende</supplied> Gott,
+wie ein gutter Vater eine gute Frucht, und gab <supplied reason="undefined" resp="#editor">ihn</supplied>dieser Welt als das vorzÿglichste Geschek wie eine Seele für denseelenlosen Leib, und
 <lb n="5"/> warf in die unvernünftige Natur der Körper seine Vernunft and erleuchtete
 und belebte die form- und gestaltlose,seelen- und artlose οὐσία
 mit der Kraft des göttlichen Logos, den auch wir kennen und verehren müssen, während er der ὕλη und den στοιχεῖα der Körper allezeit nahekommt,
-und der (selber) ohne Hyle und ohne Körper ist und weise, <milestone unit="altnumbering" n="9"/>
-<lb n="10"/> nicht als ob er von anderen weise gemacht worden ware, sondern er ist die Weisheit, das Leben und das Licht (selber), ein verständiger Sprößling unsagbaren Lichtes und Einer seiner οὐσία nach, wie er von Einem Vater ist, aber er besitzt viele Kräfte in sich.</p>
+und der <supplied reason="undefined" resp="#editor">selber</supplied> ohne Hyle und ohne Körper ist und weise, <milestone unit="altnumbering" n="9"/>
+<lb n="10"/> nicht als ob er von anderen weise gemacht worden ware, sondern er ist die Weisheit, das Leben und das Licht <supplied reason="undefined" resp="#editor">selber</supplied>, ein verständiger Sprößling unsagbaren Lichtes und Einer seiner οὐσία nach, wie er von Einem Vater ist, aber er besitzt viele Kräfte in sich.</p>
 <p>Denn nicht dÿrfen wir, weil es viele Teile der Welt gibt, deswegen 
-<lb n="15"/> (auch) meinen, daß es viele Kräfte gebe; ebensoweig dürfen wir, weil
+<lb n="15"/> <supplied reason="undefined" resp="#editor">auch</supplied> meinen, daß es viele Kräfte gebe; ebensoweig dürfen wir, weil
 es viele Werke gibt, deswegen auch viele Götter hinstellen.</p>
 </div>
 
@@ -545,13 +549,13 @@ es viele Werke gibt, deswegen auch viele Götter hinstellen.</p>
 <p>Einen
 gewaltigen Irrtum aber haen, unmündig an ihrer Seele, polytheistische
 Männer begangen, die die Teile des Alls zu Göttern machten und die 
-Eine Welt in viele (Stücke) teilten, gleich wie wenn jemand, der von 
+Eine Welt in viele <supplied reason="undefined" resp="#editor">Stücke</supplied> teilten, gleich wie wenn jemand, der von 
 <lb n="20"/> dem Bestande Eines menschen die Augen besonders nimmt und sagt, sie 
 seien ien Mensch und die Ohren wiederum ein anderer mensch, und 
-(der) ebenso wiederum den Kopf, und den Nachken, die Brust, den Rücken,
+<supplied reason="undefined" resp="#editor">der</supplied> ebenso wiederum den Kopf, und den Nachken, die Brust, den Rücken,
 die Hände und die Füßε und die übrigen Glieder einzeln abschneidet und
 die Kräfte der sinne teilt und von dem Einem Menschen sagt, daß es
-<lb n="25"/> uorgeblich sehr viele seien, sich weiter nichts als ein Gelächter über (seine)
+<lb n="25"/> uorgeblich sehr viele seien, sich weiter nichts als ein Gelächter über <supplied reason="undefined" resp="#editor">seine</supplied>
 Torheit bei den Weisen erwirkt. Demgemäß ist auch der, der sich myriadenGötter aus den Teilen der Einen Welt aufstellt und die Körper,
 die durchweg aus flüssiger und zerstiebbarer natur und aus Einer ὕλη gemacht sind, zerschneidet und sie sich wiederum vorgeblich zu Göttern
 <lb n="30"/> macht.</p>
@@ -582,8 +586,8 @@ einfach und nicht zusammengesetzt. Das Zusammengesetzte aber ist
 aus Unähnlichem zusammengesetzt. Das Unähnliche aber ist an sich <lb n="10"/>
 <milestone unit="altnumbering" n="10"/> etwas Schlechteres gegenüber dem Besseren. Denn wenn es ganz gut
 ware, so ware es gleich und ähnlich, und wenn es so ware, so ware es
-durchweg und in jedem (Teil) sich selbst gleich und ware daher von
-*eindfacher (und) ungeteilter οὐσία. Aber keineswegs zeigt sich diese
+durchweg und in jedem <supplied reason="undefined" resp="#editor">Teil</supplied> sich selbst gleich und ware daher von
+<corr resp="#editor">eindfacher</corr> <supplied reason="undefined" resp="#editor">und</supplied> ungeteilter οὐσία. Aber keineswegs zeigt sich diese
 Natur der sichtbaren Welt des Alls. Denn sie ist wahrnehmbar und beseht <lb n="15"/>
 aus Myriaden Teilen und ist zusammengesetzt, sodaß sie eben in
 Myriaden Teile sich wandelt, und so nimmt sie, da sie so ist, auch die
@@ -611,12 +615,12 @@ und Unvernünftigen und an der . . . . οὐσία“ Σ, allein er las wohl δ
 κοινωνεῖ Stud. 60</note>
 
 <pb n="v.3.pt.2.p.50"/>
-Stammnater des Logos,  der allein die Ursahe aller ist, * wird mit Recht
+Stammnater des Logos,  der allein die Ursahe aller ist, <corr resp="#editor">wird</corr> mit Recht
 der vater seines eingebornen Logos genannt, er selbst aber erkennt
-keine ander, höhere Ursache als sich selbst an. Deswegen ist Er (auch)
-allein Gott (selber), der Eingeborne  aber geht aus ihm hernor nach verborgenem,
+keine ander, höhere Ursache als sich selbst an. Deswegen ist Er <supplied reason="undefined" resp="#editor">auch</supplied>
+allein Gott <supplied reason="undefined" resp="#editor">selber</supplied>, der Eingeborne  aber geht aus ihm hernor nach verborgenem,
 <lb n="5"/> unaussprechlichem Ratschluß, der Erlöser aller, Ein Logos
-Gottes, der durch alles (waltet).</p>
+Gottes, der durch alles <supplied reason="undefined" resp="#editor">waltet</supplied>.</p>
 </div>
 	   
 <div type="textpart" subtype="chapter" n="28">
@@ -634,9 +638,9 @@ des Gottes des Alls.</p>
 <p>Der göttliche Logos aber besteht keinessondern
 <lb n="15"/> ist ohne Teil und ohne Zusammensetzung und schlägt schön und
 weise das All an und leistet seinem Vater und dem Könige des Alls den
-ihm schuldigen end gebührenden Lob(estribut). Wie an Einem Leibe <milestone unit="altnumbering" n="11"/>
-(wie) aber eine unsichtbare Seele sich durch alles erstrecht und Ein
-<lb n="20"/> unteilbarer, unkörperlicher Vedrstand, so auch bei diesem (All): Aus
+ihm schuldigen end gebührenden Lob<supplied reason="undefined" resp="#editor">estribut</supplied>. Wie an Einem Leibe <milestone unit="altnumbering" n="11"/>
+<supplied reason="undefined" resp="#editor">wie</supplied> aber eine unsichtbare Seele sich durch alles erstrecht und Ein
+<lb n="20"/> unteilbarer, unkörperlicher Vedrstand, so auch bei diesem <supplied reason="undefined" resp="#editor">All</supplied>: Aus
 vielen Teilen besteht Eine Welt und ebenso erstreckt sich Ein Logos Gottes,
 reich an Kräften und mächtig in allem, durch alles und verbreitet sich
 unsichtbar über alles und ist die Ursache von allem, was darin ist.</p>
@@ -645,10 +649,10 @@ unsichtbar über alles und ist die Ursache von allem, was darin ist.</p>
 <div type="textpart" subtype="chapter" n="30">
 <p>Siehst du nicht mit deinen Augen, daß Ein Himmel die
 <lb n="25"/> ganze Welt umgibt, während Myriaden Reihen von Sternen an ihm
-züglichkeit ihres Lichtes die Strahlen aller (Gestirne) verbirgt? So also,
-da der Vater einer ist, muß auch der Logos dieses (Wesens) Einer
+züglichkeit ihres Lichtes die Strahlen aller <supplied reason="undefined" resp="#editor">Gestirne</supplied> verbirgt? So also,
+da der Vater einer ist, muß auch der Logos dieses <supplied reason="undefined" resp="#editor">Wesens</supplied> Einer
 sein: der gute Sprößling eines guten Vaters. Wenn aber jemand tadelh
-<lb n="30"/> wollte, warum nicht mehr Söhne (da seien), so geziemt es sich für diese,
+<lb n="30"/> wollte, warum nicht mehr Söhne <supplied reason="undefined" resp="#editor">da seien</supplied>, so geziemt es sich für diese,
 auch den Vorwurf zu erheben, warum er nicht mehr Sonnen, Monde,
 <note type="footnote">6 vgl. Eph 46 24 – S. 51,4 „erleuchete” = Dem. IV 514 – 61 κόσμον</note>
 <note type="footnote">1 „und wird“ Σ streiche <foreign xml:lang="abbr">ABBREV</foreign> 10 „und Kälte zumal und Wärme, die ihr
@@ -661,27 +665,27 @@ stimmt er sich seinem Vater “Σ 26 „und durch“ Σ. Str. <foreign xml:lang=
 <pb n="v.3.pt.2.p.51"/>
 Welten und Myriaden Anderes herstellte, indem er nach Art eines
 Rasenden das zu verdrehen sucht, was recht und schön ist von Natur.
-Aber wie bei den sichtbaren (Dingen) Eine Sonne die ganze wahrnehmbare
-Welt erleuchtet, so durchstrahlt auch bei den geistigen (Dingen),
+Aber wie bei den sichtbaren <supplied reason="undefined" resp="#editor">Dingen</supplied> Eine Sonne die ganze wahrnehmbare
+Welt erleuchtet, so durchstrahlt auch bei den geistigen <supplied reason="undefined" resp="#editor">Dingen</supplied>,
 uns verborgen und unsichtbar, Ein allmächtiger Logos Gottes das All. <lb n="5"/>
 Denn was wären viele Sonnen nötig, da Eine genügt zur Vollendung
 des Alls? Was wären ferner viele Söhne Gottes nötig, da Ein Eingeborner
 genügt zur Vollendung der Ratschlüsse seines Vaters? Denn
 wenn viele wären, so wären sie entweder ählich oder unähnlich. wenn
-sie ähnlich (wären), so (wäre) ihre Vielheit unnütz, da Ein Vollkommener <lb n="10"/>
+sie ähnlich <supplied reason="undefined" resp="#editor">wären</supplied>, so <supplied reason="undefined" resp="#editor">wäre</supplied> ihre Vielheit unnütz, da Ein Vollkommener <lb n="10"/>
 und Allmächtiger zur Schöpfung und Herrichtung des Alls genügt.
 Denn der Logos Gottes und die Weisheit Gottes und das Licht und das
-Leben und die ganze Fülle des Guten, (er) der seinem Wesen nach Einer
+Leben und die ganze Fülle des Guten, <supplied reason="undefined" resp="#editor">er</supplied> der seinem Wesen nach Einer
 ist, macht eben die Zahl ihere Vielheit unnütz, da sie eitel und unschön
-an ähnlicher Kraft teil hätten. Wenn sie aber unähnlich (wären), so <lb n="15"/>
+an ähnlicher Kraft teil hätten. Wenn sie aber unähnlich <supplied reason="undefined" resp="#editor">wären</supplied>, so <lb n="15"/>
 mübten sie werden. Und was gibt es für Unähnliches, das werden
-(könnte) gegenüber dem Vollkommenen und Allgenügenden als das, was
+<supplied reason="undefined" resp="#editor">könnte</supplied> gegenüber dem Vollkommenen und Allgenügenden als das, was
 unvollkommen und seiner Natur nach mangelhaft ist? Aber es gibt
 keinen unvollkommenen Spröbling Gottes. Vollkommen also ist der
 Eingeborne Gottes, und keineswegs gibts es vieles Logoi Gottes, sondern: <lb n="20"/>
 <milestone unit="altnumbering" n="12"/> Gott aus Gott, allem genügend und allmächtig, Ein Bild des Lichtes
 seines Wesens, wie die göttlichen worte überliefern, der zum Nutzen
-der Wiederherstellung und Heilung aller gewordenen (Wesen) notwendig
+der Wiederherstellung und Heilung aller gewordenen <supplied reason="undefined" resp="#editor">Wesen</supplied> notwendig
 geschaffen ist, seinem Wesen nach Einer, aber mannigfach in seinen
 Kräften, der allein zun Schmucke des Alls genügt.</p>
 </div>
@@ -689,12 +693,12 @@ Kräften, der allein zun Schmucke des Alls genügt.</p>
 <div type="textpart" subtype="chapter" n="31">
 <p>Denn auch <lb n="25"/>
 im Menschen ist Eine Seele und Eine vernünftige Kraft, und sie ist
-zugleich die Fertigerin der vielen (Künste), wenn eben dieselbe, um das
-Land zu bearbeiten, * Schiffe herzustellen und sie zu lenken und um zu
-bauen, * viele Dinge lernt und tut; und Ein Verstand und (Eine) Überlegung
-im Menschen * empfängt bisweilen Myriaden Lehren, und eben <lb n="30"/>
+zugleich die Fertigerin der vielen <supplied reason="undefined" resp="#editor">Künste</supplied>, wenn eben dieselbe, um das
+Land zu bearbeiten, <corr resp="#editor">Schiffe</corr> herzustellen und sie zu lenken und um zu
+bauen, <corr resp="#editor">viele</corr> Dinge lernt und tut; und Ein Verstand und <supplied reason="undefined" resp="#editor">Eine</supplied> Überlegung
+im Menschen <corr resp="#editor">empfängt</corr> bisweilen Myriaden Lehren, und eben <lb n="30"/>
 derselbe mibt das Land, beobachte den Lauf der Sterne, überliefert
-Worte der Grammatik und der * Rhetoren, wird ein Führer der Heilkunde
+Worte der Grammatik und der <corr resp="#editor">Rhetoren</corr>, wird ein Führer der Heilkunde
 in Lehren und in Werken der Hände, und bis jetzt hat noch
 niemals jemand geglaubt, dab es vieles Seelen in Einem Leibe gebe,
 8 vgl. De Xenophane, Zen. Gorg. c. 3; Dem. IV 31 ff. 21 vgl. Hebr 1  3
@@ -706,13 +710,13 @@ viele“ str. <foreign xml:lang="abbr">ABBREV</foreign> 30 „und empfängt“ s
 <pb n="v.3.pt.2.p.52"/>
 noch auch mit Verwunderung erwartet, da? es viele ο?σ?αι im Menschen
 gebe wegen des Empfanges vieler Lehren. Wenn aber jemand eine gestaltlose
-Scholle Lehm findet, sie dann mit seinen Handen *knetet und ihr
+Scholle Lehm findet, sie dann mit seinen Handen <corr resp="#editor">knetet</corr> und ihr
 die Gestalt eines Lebewesens gibt, <add>und</add> durch die Eine Form einen Kopf,
 <lb n="5"/> durch die andere Hande und Fu?e, durch eine andere ferner die Augen
-und die Wangen *ebenso und die Ohren und den Mund und Nase,
-Brust und Rucken durch die Kunst der Plastik abbildet, *so ist es
-(dennoch) keineswegs richtig, weil viele Formen, <add>Teile</add> und Glieder
-an Einem Leibe gschaffen sind, (deshalb) zu meinen, da? ebenso auch
+und die Wangen <corr resp="#editor">ebenso</corr> und die Ohren und den Mund und Nase,
+Brust und Rucken durch die Kunst der Plastik abbildet, <corr resp="#editor">so</corr> ist es
+<supplied reason="undefined" resp="#editor">dennoch</supplied> keineswegs richtig, weil viele Formen, <add>Teile</add> und Glieder
+an Einem Leibe gschaffen sind, <supplied reason="undefined" resp="#editor">deshalb</supplied> zu meinen, da? ebenso auch
 <lb n="10"/> viele Schopfer seien, sondern Einen allein, den volligen Schopfer des
 Alls zu loben, der durch Eine Uberlegung und Eine Kraft das All hergestellt
 hat.</p>
@@ -721,7 +725,7 @@ hat.</p>
 <div type="textpart" subtype="chapter" n="32">
 <p>So durfen wir auch uber diese ganze Welt, die
 Eine ist, aber aus vielen Teilen besteht, nicht viele schaffende Krafte
-setzen noch viele Gotter nennen, sondern (nur) die Wine allweise und
+setzen noch viele Gotter nennen, sondern <supplied reason="undefined" resp="#editor">nur</supplied> die Wine allweise und
 <lb n="15"/> allharmonische, in Wahrheit gottliche Kraft und gottliche Weisheit
 segnen, die mit Einer Kraft und Einer Tuchtigkeit durch alles hindurchgeht,
 durch die ganze Welt wallt, alles einrichtet und lebendig macht
@@ -747,7 +751,7 @@ alles erstreckt, in allem und tritt an alles heran, das im Himmel und
 <lb n="30"/> auf Erden ist, lenkt das Unsichtbare und das Sichtbare, regiert eben die
 Sonne, den Himmel und die ganze Welt mit unaussprechlichen Kraften,
 indem er mit tatiger Kraft allem nahe ist und durch alles waltet, la?t
-(ferner) ebven der Sonne, dem Monde und den Sternen aus seiner eigenen
+<supplied reason="undefined" resp="#editor">ferner</supplied> ebven der Sonne, dem Monde und den Sternen aus seiner eigenen
 <note type="footnote">8-15 "Weisheit" vgl. Praep. III 136. 7 15 vgl. I Kor 1 24</note>
 <note type="footnote">3 "Scholle"] ὕλην L D | "zusammensetzt" Σ ἁπαλύνας L D l. <foreign xml:lang="abbr">ABBREV</foreign>
 4"und" &lt;Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 6 ὡσαύτως L D 1. <foreign xml:lang="abbr">ABBREV</foreign> 7 "und so" Σ str. <foreign xml:lang="abbr">ABBREV</foreign>
@@ -758,9 +762,9 @@ indem er mit tatiger Kraft allem nahe ist und durch alles waltet, la?t
 <pb n="v.3.pt.2.p.53"/>
 Quelle unversiegliches Licht regnen, hat den Himmel als das ähnlichste
 Bild der eigenen Größe eingertichtet und halt ihn in Ewigkeit fest, und
-füllt *die jenseits des Himmels und der Welt (existierenden) Kräfte der
-Engel und der Gutn aus den bei ihm (aufbewahrten) Schätzen, &lt;und&lt; durch Eine und <lb n="5"/>
-dieselbe Kunst der Schöpfertätigkeit *ermangelt er niemals, den Elementen
+füllt <corr resp="#editor">die</corr> jenseits des Himmels und der Welt <supplied reason="undefined" resp="#editor">existierenden</supplied> Kräfte der
+Engel und der Gutn aus den bei ihm <supplied reason="undefined" resp="#editor">aufbewahrten</supplied> Schätzen, &lt;und&lt; durch Eine und <lb n="5"/>
+dieselbe Kunst der Schöpfertätigkeit <corr resp="#editor">ermangelt</corr> er niemals, den Elementen
 gestalt, Aussehen und Form, und Variiert Myriaden Eigenschaften in den
 Lebewesen und Pflanzen und in den vernünftigen und unvernünftigen <lb n="10"/>
 Seelen bald so bald anders, gewährt allen zumal alles mit Einer Kraft
@@ -778,17 +782,17 @@ als bis er sich selbst in den letzten Zeiiten offenbarte dfenen, die in der
 <milestone unit="altnumbering" n="14"/> Finsternis des Bösen gehalten sind. Aber daß der Schöpfer der ganzen
 Welt, der der gemeinsame Erlöser aller ist, derart ist und diesem All <lb n="20"/>
 eine so so großε Unterstützung gewährt, ist von uns mit Recht gezeigt
-worden. (Jetzt) aber müssen wir in Kürze sagen, welche Natur der οὐσία
+worden. <supplied reason="undefined" resp="#editor">Jetzt</supplied> aber müssen wir in Kürze sagen, welche Natur der οὐσία
 eben die Welt des alls erlangt hat, die von einem κυβερνήτης gelenkt.
-wird (und) die aus Himmel, aus Erde und dem, was darauf ist, besteeht.</p>
+wird <supplied reason="undefined" resp="#editor">und</supplied> die aus Himmel, aus Erde und dem, was darauf ist, besteeht.</p>
 </div>
 <div type="textpart" subtype="chapter" n="36">
 <p>Zwei Naturen also vereinigt sie: die die bessere und dem <lb n="25"/>
 göttlichen Logos verwandte oὐσία, die, selb er verständig und vernünftig,
 mit dem Verstande gesejem und mit der vernunft wahrgenommen wird,
 und von der all das gegriffen warden kann, was basser als Körper ist —
-und (zweitens) diejenige (οὐσία), die zum Gebrauch der (ersten) notwendig
-*bestimmt wurde, die ὕλη, die Urquelle der Körper, „die mit &lt;un&lt; vernünftigem
+und <supplied reason="undefined" resp="#editor">zweitens</supplied> diejenige <supplied reason="undefined" resp="#editor">οὐσία</supplied>, die zum Gebrauch der <supplied reason="undefined" resp="#editor">ersten</supplied> notwendig
+<corr resp="#editor">bestimmt</corr> wurde, die ὕλη, die Urquelle der Körper, „die mit &lt;un&lt; vernünftigem
 Sinne vorgestellt wird, die wird und vergeht, aber durchaus
 <note type="footnote">6 vgl. Kol 23 16= Joh 110 30= Platon Timaios 27 D</note>
 <note type="footnote">3 lies Abbrav statt Abbrav 4 „und die οὐσίαι der verständigen und
@@ -803,12 +807,12 @@ geben“ Σ καὶ στοικείοις οὐσίας οὔποτε διαλι�
 <pb n="v.3.pt.2.p.54"/>
 Niemals ist“, wie meines Erachtens schön gesagt ist. Aber das, was
 Mit leiblichem Sinne gesehen wird, zeigt Eine Welt an: eben die, die
-*allen sichtbar (ist). Aber auch das Unsichtbare, so hat man schön gesagt,
-Ist Eine Familie vernünftiger, geschaffener (Wesen). Wie in dem Sichtbaren
+<corr resp="#editor">allen</corr> sichtbar <supplied reason="undefined" resp="#editor">ist</supplied>. Aber auch das Unsichtbare, so hat man schön gesagt,
+Ist Eine Familie vernünftiger, geschaffener <supplied reason="undefined" resp="#editor">Wesen</supplied>. Wie in dem Sichtbaren
 <lb n="5"/> Eines die Natur der Körper ist, zu welcher eben gehören teils
-Die (Dinge), die im Himmel und im Äther (sind), und das, was (sich)
-Gesondert in ihnen (befindet), teils die (Dinge), die in der Luft und auf
-Erden (sind), und die darauf sichtbaren Lebewesen und Pflanzen, so
+Die <supplied reason="undefined" resp="#editor">Dinge</supplied>, die im Himmel und im Äther <supplied reason="undefined" resp="#editor">sind</supplied>, und das, was <supplied reason="undefined" resp="#editor">sich</supplied>
+Gesondert in ihnen <supplied reason="undefined" resp="#editor">befindet</supplied>, teils die <supplied reason="undefined" resp="#editor">Dinge</supplied>, die in der Luft und auf
+Erden <supplied reason="undefined" resp="#editor">sind</supplied>, und die darauf sichtbaren Lebewesen und Pflanzen, so
 Ist auch in der verständigen, unsichtbaren οὐσία Eine gemeinsame Art
 <lb n="10"/> aller und verständigen
 Kräfte, während Myriaden mannigfacher unterschiede dabei vorhanden
@@ -820,39 +824,39 @@ Sind.</p>
 Ist, das wir sinnliche Welt zu nennen gewohnt sind, und das aus
 Himmel und Erde Und dem, was darin ist, besteht, — mag verglichen
 <lb n="15"/> werden einer königlichen Stadt, in der Myriaden Bürger leben in der
-Teils königliche Paläste abgesondert sind: *die königlichen Gemächer
+Teils königliche Paläste abgesondert sind: <corr resp="#editor">die</corr> königlichen Gemächer
 Im Innern, in welche die moisten nicht eingehen noch sie betreten,
-Teils äuBere (Häuser) als Plätze für die Leibwächter, teils wiederum
-(solche) in der Ferne und vom Hof getrennt, den Geringen und Massen
+Teils äußere <supplied reason="undefined" resp="#editor">Häuser</supplied> als Plätze für die Leibwächter, teils wiederum
+<supplied reason="undefined" resp="#editor">solche</supplied> in der Ferne und vom Hof getrennt, den Geringen und Massen
 <lb n="20"/> überlassen. Zahlreich sind die Plätze im Himmel und zalreich die
 Unterhalb derselben: im Äther und in der Luft über der Erde, während
 Der Wohnitz auf Erden für die, welche auf ihr wandeln, weit ist, er, der <milestone unit="altnumbering" n="15"/>
-Uns allen bekannt ist. *Diejenigen aber, die jenseits des Himmels (wohnen),
-Sind hoher als alles Denken sie, *die ebenfalls drinnen im göttlichen
-<lb n="25"/> Königspalast *abgesondert sind, um den König des Alls kreisen, neben
-Seinem göttlichen Logos tanzen, aus den Strahlen, die von ihm (ausgehen),
+Uns allen bekannt ist. <corr resp="#editor">Diejenigen</corr> aber, die jenseits des Himmels <supplied reason="undefined" resp="#editor">wohnen</supplied>,
+Sind hoher als alles Denken sie, <corr resp="#editor">die</corr> ebenfalls drinnen im göttlichen
+<lb n="25"/> Königspalast <corr resp="#editor">abgesondert</corr> sind, um den König des Alls kreisen, neben
+Seinem göttlichen Logos tanzen, aus den Strahlen, die von ihm <supplied reason="undefined" resp="#editor">ausgehen</supplied>,
 Wie aus unversieglichen Lichtquellen schöpfen, erleuchtet sind
 Und voller Licht bestehen. Alle Lichter und Scharen und Reihen unkörperlichen
 Lichtes, die die Plaätze jenseits des Himmels inne haben,
-<lb n="30"/> *ehren Gott, den König des Alls, mit den höchsten, Gott geziemenden
-Lobliedern. In der Mitte aber ist dem groBen Himmel (um) geworfen
-Ein zyanenfarbiger Vorhang, der die auBerhalb der königlichen Paläste
+<lb n="30"/> <corr resp="#editor">ehren</corr> Gott, den König des Alls, mit den höchsten, Gott geziemenden
+Lobliedern. In der Mitte aber ist dem großen Himmel <supplied reason="undefined" resp="#editor">um</supplied> geworfen
+Ein zyanenfarbiger Vorhang, der die außerhalb der königlichen Paläste
 <note type="footnote">3 stoisch? vgl. Praep. XIII 13 27 14 vgl. Praep. XV 15 3 ff. (Arius Didymus)
 26 „aus den Strahlen“ — S. 55, 6 = Laus 196 26 – 197 6</note>
 <note type="footnote">3 1. <foreign xml:lang="abbr">ABBREV</foreign> mit HS 16 „und die“ str. <foreign xml:lang="abbr">ABBREV</foreign> 23. 24 1. <foreign xml:lang="abbr">ABBREV</foreign> 25 1.
-<foreign xml:lang="abbr">ABBREV</foreign> 30  „und ehren“ str. <foreign xml:lang="abbr">ABBREV</foreign>  32 „der auBerhalb der königlichen
+<foreign xml:lang="abbr">ABBREV</foreign> 30  „und ehren“ str. <foreign xml:lang="abbr">ABBREV</foreign>  32 „der außerhalb der königlichen
 Paläste fernhält und die Leibwächter um diesen kreisen“ Σ, aber lies das
 <foreign xml:lang="abbr">ABBREV</foreign> vor <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> statt vor <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> Vgl. τοὺς ἐκτὸς τῶν εἴσω βασιλικῶν
 Οἴκων διεῖργον L + δορυφόρους Σ</note>
 
 <pb n="v.3.pt.2.p.55"/>
-(befindlichen) leibwächter fernhält. Um diesen kreisen, gleichsam auberhalb
+<supplied reason="undefined" resp="#editor">befindlichen</supplied> leibwächter fernhält. Um diesen kreisen, gleichsam auberhalb
 der Tore, Fackeln tragend Sonne und Mond und die lichtbekleideten 
-(Gestirne) am Himmel, ehren den jenseits des Alls (waltenden)
-König des Alls und zünden auf seinen Wink und auf sein Wort denen,die den finstern Ort auBerhalb des Himmels erlanght haben, die unverlöschlichen <lb n="5"/>
-Lichtfackeln an. Eben diesen (finstern Ort) haben die
-den leiblichen Augen unsichtbaren Kräfte der Luft (die Dämonen)
-erlangt und (ebenso) die irdischen Lebewesen, unter anderen auch der
+<supplied reason="undefined" resp="#editor">Gestirne</supplied> am Himmel, ehren den jenseits des Alls <supplied reason="undefined" resp="#editor">waltenden</supplied>
+König des Alls und zünden auf seinen Wink und auf sein Wort denen,die den finstern Ort außerhalb des Himmels erlanght haben, die unverlöschlichen <lb n="5"/>
+Lichtfackeln an. Eben diesen <supplied reason="undefined" resp="#editor">finstern Ort</supplied> haben die
+den leiblichen Augen unsichtbaren Kräfte der Luft <supplied reason="undefined" resp="#editor">die Dämonen</supplied>
+erlangt und <supplied reason="undefined" resp="#editor">ebenso</supplied> die irdischen Lebewesen, unter anderen auch der
 Mensch, das Haupt aller, dessen Geschlecht keineswegs der verständigen
 und vernÿnftigen, unsichtbaren οὐσία fremd ist. Dieser eben wurde <lb n="10"/>
 geschaffen, um die Gottheit, die die Ursache des Alls ist, und ihr Reic 
@@ -860,31 +864,31 @@ auf Erden zu preisen. Gleichwie aber auf Erden Ein und dasselbe Menschengeschlec
  sich über den ganzen Erdkreis erstreckt und Myriaden Völker
 auf Erden zu preisen. Gleichwie aber auf Erden Ein und dasselber menschengeschlecht
 sich über den ganzen Erdkreis erstreckt und Myriaden Völker
-aus ihm entstanden sind und (wie) allerlei Lebensarten und mannigfache
-Moden (σχήματα),  Gewohnheiten und Sitten keineswegs nur der  Barbaren <lb n="15"/>
+aus ihm entstanden sind und <supplied reason="undefined" resp="#editor">wie</supplied> allerlei Lebensarten und mannigfache
+Moden <supplied reason="undefined" resp="#editor">σχήματα</supplied>,  Gewohnheiten und Sitten keineswegs nur der  Barbaren <lb n="15"/>
 und Wilden, sondern auch der friendfertigen, wohlanständigen und
-weisen Menschen (vorhanden sind), und (wie) unter ihnen sklaven und
+weisen Menschen <supplied reason="undefined" resp="#editor">vorhanden sind</supplied>, und <supplied reason="undefined" resp="#editor">wie</supplied> unter ihnen sklaven und
 Freie, Arme und Reiche existieren und solche, die selbst in ihrer 
-(Haut) farbe variieren, wie (ferner) die Skythen * diejenigen (sind), die
-(das Los) erlangt haben, auBerhalb im Norden zu wohnen, die Inder, <lb n="20"/>
+<supplied reason="undefined" resp="#editor">Haut</supplied> farbe variieren, wie <supplied reason="undefined" resp="#editor">ferner</supplied> die Skythen <corr resp="#editor">diejenigen</corr> <supplied reason="undefined" resp="#editor">sind</supplied>, die
+<supplied reason="undefined" resp="#editor">das Los</supplied> erlangt haben, außerhalb im Norden zu wohnen, die Inder, <lb n="20"/>
 die im Sonnenaufgang, die Kuschiten, die im Sonnenuntergang, und die
 Griechen und andere, denen es zu teil geworden ist, in der Mitte der
-(welt) enden zu wohnen, und (wie) ferner unter diesen allen die einen
+<supplied reason="undefined" resp="#editor">welt</supplied> enden zu wohnen, und <supplied reason="undefined" resp="#editor">wie</supplied> ferner unter diesen allen die einen
 über Teile der Völker herrschen, die anderen aber das Unterwerfen
-vollenden, und (wie) beim Grobkönig aller (diese Nationen) einige 25
-<milestone unit="altnumbering" n="16"/> (sind, die) als Freunde geachtet warden, andere, die zu vielen Würden
+vollenden, und <supplied reason="undefined" resp="#editor">wie</supplied> beim Grobkönig aller <supplied reason="undefined" resp="#editor">diese Nationen</supplied> einige 25
+<milestone unit="altnumbering" n="16"/> <supplied reason="undefined" resp="#editor">sind, die</supplied> als Freunde geachtet warden, andere, die zu vielen Würden
 emporsteigen, andere, die wegen ihrer vorzüglichen Taten geehrt warden,
 andere, die den Rang der Sklaven ausfüllen, andere, die Lanzen
 tragen und mit Schilden sich umgürten, und ferner solche, die in
 Städten στρατηγοί sind, und solche, die die Funktionen der Stadtmagistrate <lb n="30"/>
-verrichten, (wie endlich) den einen die Lose der Plebs
+verrichten, <supplied reason="undefined" resp="#editor">wie endlich</supplied> den einen die Lose der Plebs
 bescheert  sind, die anderen aber für Feinde und Bösewichter erachtet
 warden, — so sind dennoch aber alle Menschen und ist
 Eines das gemeinsame Geschlecht aller. Über ihnen allen giebt es
 Einen König, eine einzigartige Macht, die mit eigner, allerhöchster <lb n="35"/>
 Machtvollkommenheit bekleidet ist. Diesem entspricht das königliche
 Gesetz und Wort und von oben schreibt es allein der Vater und Gesetz-
-<note type="footnote">8 „und andere und“ Σ =τά τε ἄλλα καί 19 „die selbst in ihrer (Haut)farbe 
+<note type="footnote">8 „und andere und“ Σ =τά τε ἄλλα καί 19 „die selbst in ihrer <supplied reason="undefined" resp="#editor">Haut</supplied>farbe 
 variieren wie die Skythen, und diejenigen, die“Σ. Aber das <foreign xml:lang="abbr">ABBREV</foreign> vor <foreign xml:lang="abbr">ABBREV</foreign>
 gehört vor <foreign xml:lang="abbr">ABBREV</foreign> 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
@@ -899,37 +903,37 @@ steigne, den andern aber vergilt er, wie sie es verdienen.</p>
 <p>Demgemäß
 <lb n="5"/> aber existiert Eine höchste, Zeugende, verständige und vernünftige
 οὐσία, und shcön hat man gesagt, daß Eines auch das Geschlecht dieser
-(Menschen) ist und (daß) sie in nichts sich unterscheiden von Brüdern,
+<supplied reason="undefined" resp="#editor">Menschen</supplied> ist und <supplied reason="undefined" resp="#editor">daß</supplied> sie in nichts sich unterscheiden von Brüdern,
 die alle von Einem, gleichsam von eben dem Vater des Wortes Gottes,
-geschaffen sind. Es gibt aber Myriaden Völker und Geschlechter *von
-<lb n="10"/> gutem und dem entgegengesetzten (schlechten) Anteil und mannigfache,
-unzählbare Unterschiede im Denken und Moden und Lebersweisen *von
-(einander) entgegengesetztem Zustand, aber keineswegs von (entgegengesetzter)
+geschaffen sind. Es gibt aber Myriaden Völker und Geschlechter <corr resp="#editor">von</corr>
+<lb n="10"/> gutem und dem entgegengesetzten <supplied reason="undefined" resp="#editor">schlechten</supplied> Anteil und mannigfache,
+unzählbare Unterschiede im Denken und Moden und Lebersweisen <corr resp="#editor">von</corr>
+<supplied reason="undefined" resp="#editor">einander</supplied> entgegengesetztem Zustand, aber keineswegs von <supplied reason="undefined" resp="#editor">entgegengesetzter</supplied>
 Natur; den die Natur aller ist Eine und das Geschlecht ist Eines
 und dasselbe. Infolge der Verschiedenheit ihres Willens vielmehr haben sie
 <lb n="15"/> viele Moden und verschiedene Lebensweisen gefunder: daher die Scharen
 der Engel, der Geister und der leiblosen und unsichtbaren Kräfte, die
 teils leuchten und funkeln, erleuchtet von den Strahlen des göttlichen
-Logos, die teils finsterer und schwärzer als alle Kuschiten (sind), ausgelöscht
-(und beraubt) jedes vernünftigen Lichtes. Gar sehr aber verdient
-<lb n="20"/> dieses Geschlecht (der Menschen) den mittleren Teil (der Welt),
+Logos, die teils finsterer und schwärzer als alle Kuschiten <supplied reason="undefined" resp="#editor">sind</supplied>, ausgelöscht
+<supplied reason="undefined" resp="#editor">und beraubt</supplied> jedes vernünftigen Lichtes. Gar sehr aber verdient
+<lb n="20"/> dieses Geschlecht <supplied reason="undefined" resp="#editor">der Menschen</supplied> den mittleren Teil <supplied reason="undefined" resp="#editor">der Welt</supplied>,
 da ihm die Fülle des Bösen zumal und des Guten zu teil wurde. Ein
 König aber, Eine einzigartige Macht, der Gott, der höher als alles, was
-im Himmel und über dem Himmel (ist), * er ist es, der die (Dinge) der
+im Himmel und über dem Himmel <supplied reason="undefined" resp="#editor">ist</supplied>, <corr resp="#editor">er</corr> ist es, der die <supplied reason="undefined" resp="#editor">Dinge</supplied> der
 Luft, die auf Erden und unter der Erde, der alles in allem durch <milestone unit="altnumbering" n="17"/>
 <lb n="25"/> königliches Gesetz und Wort beherrscht. Gesetz und Wort aber ist
-Einer: der in allem Lebendige, das wirksame Wort Gottes, (wirksam)
-keineswegs wie das sterbliche (Gesetz und Wort), das aus dem Munde
+Einer: der in allem Lebendige, das wirksame Wort Gottes, <supplied reason="undefined" resp="#editor">wirksam</supplied>
+keineswegs wie das sterbliche <supplied reason="undefined" resp="#editor">Gesetz und Wort</supplied>, das aus dem Munde
 der Sterblichen in die Luft verweht wird, sondern sie uns jetzt klar
 ist aus dem, was er imstande war zu schaffen — alles mi taller Kraft
-<lb n="30"/> un Weisheit lenkend, er, der als Logos * Gottes durchaus gerecht allen
+<lb n="30"/> un Weisheit lenkend, er, der als Logos <corr resp="#editor">Gottes</corr> durchaus gerecht allen
 die ihnen passenden Lose zuteilt und die einem jeden von ihnen zukommenden
-Plätze anweist: die nächstgelegenen gibt er der (Schar der)
+Plätze anweist: die nächstgelegenen gibt er der <supplied reason="undefined" resp="#editor">Schar der</supplied>
 Glückseligkeit, die entgegengesetzten aber denen, die vom Besseren abgefallen
 sind, wie sie es verdienen, und alle zumal läßt er um neben
 <note type="footnote">7 vgl. Platon Politeia 415; Clemens Alex. Stromateis 705; Praep. XIII 13 18</note>
 <note type="footnote">9 „und von “Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 11 „und einen entgegengesetzten Zustand“ Σ, aber
-1.	<foreign xml:lang="abbr">ABBREV</foreign> 23 „und er“ Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 30 lies <foreign xml:lang="abbr">ABBREV</foreign> statt <foreign xml:lang="abbr">ABBREV</foreign> (Druckfehler)</note>
+1.	<foreign xml:lang="abbr">ABBREV</foreign> 23 „und er“ Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 30 lies <foreign xml:lang="abbr">ABBREV</foreign> statt <foreign xml:lang="abbr">ABBREV</foreign> <supplied reason="undefined" resp="#editor">Druckfehler</supplied></note>
 
 <pb n="v.3.pt.2.p.57"/> 
 dem Himmelreich zu frohlocken, die anderen, um draußen Wache zu
@@ -943,19 +947,19 @@ Worte mystisch lehren.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="39">
-<p>Eben seiner Ehre haben *allzumal 
+<p>Eben seiner Ehre haben <corr resp="#editor">allzumal</corr> 
 alle Herrscher und Untertanen inallen Häusern und in allen
-Städten angehangen. Keineswegs (wie) mit seelenlosen, bunten Farben <lb n="10"/>
+Städten angehangen. Keineswegs <supplied reason="undefined" resp="#editor">wie</supplied> mit seelenlosen, bunten Farben <lb n="10"/>
 auf Bildern, sondern drinnen in den Herzen mit ihrer vernünftigen
 Kraft ist wie auf geistigen Tafeln die Verehrung der Gotteit verzeichnet.
 So verehren von denen, die sich selber als Feinde und Bösewichter 
 betrachten: den bösen Dämonen und frevlen Geistern und den <lb n="15"/>
 Fürsten, den Herrschern dieser Welt, die sich das Bild des falschen
-Reiches angeeignet und andere Schriften anstatt der anderen (überlieferten)
+Reiches angeeignet und andere Schriften anstatt der anderen <supplied reason="undefined" resp="#editor">überlieferten</supplied>
 herausgegeben haben, das heißt aber Myriaden betrügerischer
 Schriftwerke, &lt;und&lt; die jenen gefürchteten Namen und jene Bezeichnung,
 die im Gesetz mit einbegriffen, dennoch aber mehr ist als das <lb n="20 "/>
-Gesetz (d. h. den Namen Gottes) an sichgerissen haben, so daß sie (ihn)
+Gesetz <supplied reason="undefined" resp="#editor">d. h. den Namen Gottes</supplied> an sichgerissen haben, so daß sie <supplied reason="undefined" resp="#editor">ihn</supplied>
 für das Geschlecht der sterblichen Menschen unten auf die Erde in 
 Körper, στοιχεῖα und Weltteile warfen, weswegen die Menschen die 
 <milestone unit="altnumbering" n="18"/>Geschöpfe mehr fürchteten und bedienten als ihren Schöpfer.</p>
@@ -963,18 +967,18 @@ Körper, στοιχεῖα und Weltteile warfen, weswegen die Menschen die
 
 <div type="textpart" subtype="chapter" n="40">
 <p>Ferner
-aber nannten sie auch eben die (dämonischen) Kräfte, die mit Gott <lb n="25"/>
-straiten und widerspenstig sind, die durch ihre eigene * Verkehrtheit so
+aber nannten sie auch eben die <supplied reason="undefined" resp="#editor">dämonischen</supplied> Kräfte, die mit Gott <lb n="25"/>
+straiten und widerspenstig sind, die durch ihre eigene <corr resp="#editor">Verkehrtheit</corr> so
 wurden, Götter — sie, die niemals sind! Aber mit Recht sind auch
-diese als Feinde und * Bösewichter betrachtet worden, vor denen zu
+diese als Feinde und <corr resp="#editor">Bösewichter</corr> betrachtet worden, vor denen zu
 fliehen uns das wahre Gesetz befohlen hat, vielmehr nur unsere Zuflucht
 zu nehmen zu dem, der der erlösende Logos aller ist, der auch den <lb n="30"/>
-von ihm (stammenden) Samen keineswegs nur auf die Plätze des Himmels,
-sondern auch auf die Erde geworfen hat, um zu *sprossen.Einen und denselben
-Artanteil hat er den (Wesen) im HImmel und denen auf dem
+von ihm <supplied reason="undefined" resp="#editor">stammenden</supplied> Samen keineswegs nur auf die Plätze des Himmels,
+sondern auch auf die Erde geworfen hat, um zu <corr resp="#editor">sprossen</corr>.Einen und denselben
+Artanteil hat er den <supplied reason="undefined" resp="#editor">Wesen</supplied> im HImmel und denen auf dem
 αροιχεῖον der Erde zu teil warden lassen, wo der logische Verstand
 in den Menschen, der von der körperlosen, geistigen οὐσία und von <lb n="35"/>
-der Art des göttlichen Logos herrührt (und) der auf Erden durchweg
+der Art des göttlichen Logos herrührt <supplied reason="undefined" resp="#editor">und</supplied> der auf Erden durchweg
 <note type="footnote">7 vgl. Kol 1 15 15 vgl. Joh 12 31 Praep. VII 16 10 Dem III 3 19 24 vgl. Röm 1 25</note>
 <note type="footnote">8 „und allzumal“ Σ str. (??) 19 „und“  Σ 26 1. (??)
 28 1. (??) Lee 32 1. (??) Bernstein 36 „auf Erden großgezogen wird“ Σ</note>
@@ -982,10 +986,10 @@ der Art des göttlichen Logos herrührt (und) der auf Erden durchweg
 <pb n="v.3.pt.2.p.58"/>
 noch Kind ist, durch seine Fürsorge großgezogen und für die Umwandlung
 von hier zum Besseren vorher erzogen und vorher geübt
-wird und seine Umwandlung zu dem ihm verwandten (geistigen Sein)
-vorbereiten lernt, so daß (der Mensch) eben hierdurch vollständig um
+wird und seine Umwandlung zu dem ihm verwandten <supplied reason="undefined" resp="#editor">geistigen Sein</supplied>
+vorbereiten lernt, so daß <supplied reason="undefined" resp="#editor">der Mensch</supplied> eben hierdurch vollständig um
 <lb n="5"/> seiner Gemeinschaft mit dem göttlichen Logos willen, und zwar er allein
-von den (Wesen) auf Erden, des Namens der Vernünftigkeit würdig ist.
+von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden, des Namens der Vernünftigkeit würdig ist.
 Der Verstand aber nnd die vernünftige Seele erlangten notwendig einen
 Platz auf Erden, so daß nach dem kurz zuvor erwähnten Beispiel ein
 kleines Abbild der göttlichen Hauptstadt auf Erden besteht und daß
@@ -994,8 +998,8 @@ Anteils beraubt ist. Denn es ziemte sich für den Logos, den gemeinsamen
 Vater aller, in allen Teilen der Welt von seinem Erzeugnis
 gepriesen zu warden, so daß daher nicht einmal das στοιχεῖον der Erde
 von dem Beharren eines Stüches Vernunft beraubt ist, sodaß nicht nur
-<lb n="15"/> von denen, die jenseits der Welt und im Himmel (wohnen), und (von)
-den vernünftigen (Wesen), die in der Luft (fliegen), sondern auch von
+<lb n="15"/> von denen, die jenseits der Welt und im Himmel <supplied reason="undefined" resp="#editor">wohnen</supplied>, und <supplied reason="undefined" resp="#editor">von</supplied>
+den vernünftigen <supplied reason="undefined" resp="#editor">Wesen</supplied>, die in der Luft <supplied reason="undefined" resp="#editor">fliegen</supplied>, sondern auch von
 denen, die auf Erden leben, der Lobpreis, der dem Schöpfer und
 Vater des Alls gebührt, emporgesandt wird, was ja das göttliche
 Wort lehrt, indem es so jedermann aufträgt, einen gottgeziemenden
@@ -1003,8 +1007,8 @@ Wort lehrt, indem es so jedermann aufträgt, einen gottgeziemenden
 Höhe, preist ihn, ihr, alle seine Engel, preist ihn, ihr alle seine
 Kräfte, preist ihn, Sonne und Mond, preist ihn, all ihr Sterne
 und du, Licht, preist ihn, ihr Himmel der Himmel!“ Nach diesen
-(Dingen) zählt er (der Psalmist) *die (Wesen) auf Erden so auf: <milestone unit="altnumbering" n="19"/>
-<lb n="25"/> „Preist Gott von der Erde“ (usw.), unter anderen auch das vor allem
+<supplied reason="undefined" resp="#editor">Dingen</supplied> zählt er <supplied reason="undefined" resp="#editor">der Psalmist</supplied> <corr resp="#editor">die</corr> <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden so auf: <milestone unit="altnumbering" n="19"/>
+<lb n="25"/> „Preist Gott von der Erde“ <supplied reason="undefined" resp="#editor">usw.</supplied>, unter anderen auch das vor allem
 vernünftige Geschlecht der Menschen, welches er auch in besonderen
 Anzahlen von Ordnungen in folgender Weise abteilt: „Preist ihn, ihr
 Könige der Erde und all ihr Völker, ihr Großen und all ihr Richter 
@@ -1015,9 +1019,9 @@ Lob auf Erden und im Himmel ist.“</p>
 
 <div type="textpart" subtype="chapter" n="41">
 <p>Mit den Scharen also, die
-im Himmel (sind), führte er auch die auf Erden xusammen zum Lobe
-des Köhigs des Alls in diesen (Worten). Denn ihn allein in Wahrheit
-und keinen anderen Gott, der jenseits von allem (waltet), ehren die
+im Himmel <supplied reason="undefined" resp="#editor">sind</supplied>, führte er auch die auf Erden xusammen zum Lobe
+des Köhigs des Alls in diesen <supplied reason="undefined" resp="#editor">Worten</supplied>. Denn ihn allein in Wahrheit
+und keinen anderen Gott, der jenseits von allem <supplied reason="undefined" resp="#editor">waltet</supplied>, ehren die
 <note type="footnote">20 = Psalm 148 1–4 25 = ebd. 7 27 ebd. 11–13 34–S. 59,3 = 
 Laus 198 16–18</note>
 <note type="footnote">24 1. (??) 25 „das andere und“ = τά τε ἄλλα καί 31 „Gegen die
@@ -1026,7 +1030,7 @@ Scharen . . . führte er auch die auf Erden mit ihnen zum Lobe“ Σ, vermutlich
 
 <pb n="v.3.pt.2.p.59"/>
 Himmel von oben und die Scharen, die höher als die Himmelsgewölbe
-(sind). Es preisen mit unaussprechlichen Hymnen die Heere der Engel,
+<supplied reason="undefined" resp="#editor">sind</supplied>. Es preisen mit unaussprechlichen Hymnen die Heere der Engel,
 und die Geister, die Kinder des geistigen Lichtes, segnen ihren Vater.
 Ihn umlaufen auch Sonne und Mond und die Sterne in den Kreisen
 weiter Welten mit langem Laufe &lt;und&lt; durcheilen die Kampfplätze <lb n="5"/>
@@ -1037,7 +1041,7 @@ Lobpreis.</p>
 
 <div type="textpart" subtype="chapter" n="42">
 <p>Wie also sollte überdies nur das στοιχεῖον der Erde
-der Versorgung durchweg ermangeln und die (irdische) Natur, die alle
+der Versorgung durchweg ermangeln und die <supplied reason="undefined" resp="#editor">irdische</supplied> Natur, die alle
 diese Früchte hervorgebracht hat, vereinzelt dem Lobe fernstehen und <lb n="10"/>
 die alle Früchte tragende Wohnstatt auf Erden der vernünftigen Lebewesen
 entbehren? Aber nicht schien dies gut zu sein dem allweisen
@@ -1050,18 +1054,18 @@ daß mit den göttlichen und vern ünftigen Scharen und den Reihen
 der Engel der Mensch, der nach dem Bilde Gottes wurde, den Logos,
 seinen Vater, mit Hymnen und Lobpreisen ehrte. Sein Denken ging <lb n="20"/>
 nicht ire in der Herstellung seelenloser Götzen noch in trügerischen
-(und) dämonischen Halluzinationen, noch in den irrigen Mythen der Polytheisten.
-<milestone unit="altnumbering" n="20"/> Denn diese (Dinge) sind erst nach (einiger) Zeit neu entdeckt
+<supplied reason="undefined" resp="#editor">und</supplied> dämonischen Halluzinationen, noch in den irrigen Mythen der Polytheisten.
+<milestone unit="altnumbering" n="20"/> Denn diese <supplied reason="undefined" resp="#editor">Dinge</supplied> sind erst nach <supplied reason="undefined" resp="#editor">einiger</supplied> Zeit neu entdeckt
 worden durch das Poetengefasel. Jene ersten alten Häupter unseres Geschlechts
 aber, die die Künste noch nicht gelernt hatten: Malerei, Tischlerei, <lb n="25"/>
-Schnitzarbeit und (noch) nicht die letzte: die Schmiedekunst zu bösen
+Schnitzarbeit und <supplied reason="undefined" resp="#editor">noch</supplied> nicht die letzte: die Schmiedekunst zu bösen
 Werken benutzten, riefen in der Einfalt ihrer Seele und in ihrem natürlichen
 Denken den Schöpfer der ganzen Welt und ihren Herrn an und
 bekannten allein ihn, den Herrn und Gott des Alls in der Lehre ihres
-Geistes. Demgemäß handelte unser Stammeshaupt und (ebenso) auch das <lb n="30"/>
+Geistes. Demgemäß handelte unser Stammeshaupt und <supplied reason="undefined" resp="#editor">ebenso</supplied> auch das <lb n="30"/>
 einst Gott liebende Geschlecht der Hebräer, das wie ein Sohn von
-seinem Vater das gute Erbe frommer Lebensführung empfing. *Die
-aber ehrten nichts, abgesehen von dem Einen über allem (stehenden)
+seinem Vater das gute Erbe frommer Lebensführung empfing. <corr resp="#editor">Die</corr>
+aber ehrten nichts, abgesehen von dem Einen über allem <supplied reason="undefined" resp="#editor">stehenden</supplied>
 <note type="footnote">4—6 = Laus 1988—10 6—8= Laus 198 13—14 19 vgl. Gen 1 27
 25 vgl. Praep. I 9 13 äth. Hen. 8 1 69 6 ovid. Metam. I 89 ff.</note>
 <note type="footnote">5 μακρῶν αἰώνων κύκλοις δολιχὸν ἐξανύοντες δρόμον αἰθερίων σταδίων δϋππεύουσιν
@@ -1083,26 +1087,26 @@ Himmel und dasz στοιχεῖον der Erde mit seimen Samen geistiger und
 vernünftiger οὐσία. Der auf die Erde fallends Same aber der geistigen
 und vernünftigen Pflanze war das Wissen des Menschen, das jetzt in 
 vielem Schilf und Gras des irdischen und vergänglichen Fleisches eingeschlossen 
-<lb n="10"/> ist, und das viele *Dornen des sterblichen Lebens umgeben.
-Wenn ihm aber zuverlässige Pflege zu teil wird und (wenn) er von der
+<lb n="10"/> ist, und das viele <corr resp="#editor">Dornen</corr> des sterblichen Lebens umgeben.
+Wenn ihm aber zuverlässige Pflege zu teil wird und <supplied reason="undefined" resp="#editor">wenn</supplied> er von der
 ὕλη, die ihn schädigt, gerinigt wird und den Säemann, den oberhalb
-des Himmels (waltenden) Logos, kennen lernt und ihn fortan preist und
+des Himmels <supplied reason="undefined" resp="#editor">waltenden</supplied> Logos, kennen lernt und ihn fortan preist und
 wie ein Kind über seine erste Lehre nachsinnt und zu rechter Zeit die
 <lb n="15"/> Ähren seiner Vorzüglichkeit und die vollendete Frucht seiner vernünftigen
-Natur sprossen läßt, (dann) wird er nach Art der Erntezeit eben
-im Tode des sterblichen Lebens die überflüssigen (Dinge) des äußeren
+Natur sprossen läßt, <supplied reason="undefined" resp="#editor">dann</supplied> wird er nach Art der Erntezeit eben
+im Tode des sterblichen Lebens die überflüssigen <supplied reason="undefined" resp="#editor">Dinge</supplied> des äußeren
 Schilfes und das irdische und vergängliche Gewand des Leibes ablegen,
-die er jetzt schön zum Gebrauche des *Sprossens der vollendeten Frucht
-<lb n="20"/> benutzt hat. Wenn er diesen (Leib) zu rechter Zeit schön ausgezogen
-hat, so *wird er wie einer, der vorzüglich geworden ist und die Kräfte
-seiner Vorzüglichkeit gesammelt hat, die (ihm) im Schat͌ hause des Guten
+die er jetzt schön zum Gebrauche des <corr resp="#editor">Sprossens</corr> der vollendeten Frucht
+<lb n="20"/> benutzt hat. Wenn er diesen <supplied reason="undefined" resp="#editor">Leib</supplied> zu rechter Zeit schön ausgezogen
+hat, so <corr resp="#editor">wird</corr> er wie einer, der vorzüglich geworden ist und die Kräfte
+seiner Vorzüglichkeit gesammelt hat, die <supplied reason="undefined" resp="#editor">ihm</supplied> im Schat͌ hause des Guten
 aufbewahrt sind, vollendet mit Vollendeten leben. Ihm aber, dem Säemann
 des Alls und dem Pfleger, läßt er die vollkommene Frucht des
 <lb n="25"/> gottgeziemenden Lobes sprossen, deswegen weil er ihn allein, seinen <milestone unit="altnumbering" n="21"/>
 Vater, König nnd Herrn in diesem Leben erkannt und ihn allein, Gott
 seinen Werkmeister und Schöper, in den ihm verwandten und verschwisterten
-(geistigen Dingen) bekannt hat, so daß er ihn auch an dem
-(himmlischen) Ort des Verkehres der Besseren preist und ehrt mit der
+<supplied reason="undefined" resp="#editor">geistigen Dingen</supplied> bekannt hat, so daß er ihn auch an dem
+<supplied reason="undefined" resp="#editor">himmlischen</supplied> Ort des Verkehres der Besseren preist und ehrt mit der
 <lb n="30"/> ihm zukommenden und gebührenden Ehre. Nicht aber nennt er Gott
 irgend etwas anderes, das nicht wert ist, Gott genannt zu warden,
 <note type="footnote">22 vgl. Syr. Baruch 1412</note>
@@ -1129,28 +1133,28 @@ und alles, was aus ihnen besteht, einer großen Stadt gleichend, ist  von
 den  seelenlosen  στοιχεῖα in seinen Teilen: der Erde, dem Wasser, der Luft
 und dem Feuer in nichts unterschieden seiner Natur nach. Man darf
 aber nicht meinen, daß dei Bürger der großeb Stadt aus eben der ὕλη <lb n="10"/>
-(beständen). Ebensowenig dürfen wir sagen, daß der Same  der vernünftigen
+<supplied reason="undefined" resp="#editor">beständen</supplied>. Ebensowenig dürfen wir sagen, daß der Same  der vernünftigen
 Seele und des vergänglichen Leibes ein und derselbe sei.
 Denn der Verstand und die Vernunft und die vernünftige Seele und
-die ganze geistige Natur sind, so hat man genau (und) schön gesagt,
+die ganze geistige Natur sind, so hat man genau <supplied reason="undefined" resp="#editor">und</supplied> schön gesagt,
 Same des allschaffenden Logosgottes, aber keineswegs Teile von der <lb n="15"/>
 Erde und von der Luft, auch nicht von der kalten und warmen οὐσία,
 sondern von den vorzüglichen Kräften, die daher der Gemeinschaft mit
-der Vorzüglichkeit wert sind, dewegen weil die ersten (Dinge) Ursachen
-wurden für die nach ihnen. Die ersten (Dinge) aber sind die Sprößlinge
+der Vorzüglichkeit wert sind, dewegen weil die ersten <supplied reason="undefined" resp="#editor">Dinge</supplied> Ursachen
+wurden für die nach ihnen. Die ersten <supplied reason="undefined" resp="#editor">Dinge</supplied> aber sind die Sprößlinge
 der Vernunft, die aber nach ihnen: die der Unvernunft, und nach <lb n="20"/>
-den ersten οὐσίαι (sind) die letzten diejenigen, die nach Ursachen (wurden).
-Aber die ersten (Dinge) und der Ursprung der Zeugung liegt in den
+den ersten οὐσίαι <supplied reason="undefined" resp="#editor">sind</supplied> die letzten diejenigen, die nach Ursachen <supplied reason="undefined" resp="#editor">wurden</supplied>.
+Aber die ersten <supplied reason="undefined" resp="#editor">Dinge</supplied> und der Ursprung der Zeugung liegt in den
 geistigen Seelen, um derentwillen auch der Same der leidensfähigen
 Körper bereitet wurde. Denn für die Einwohner mußte ein ihnen genügendes
-Haus hergerichtet werden. Deswegen *erschien zuerst der <lb n="25"/>
+Haus hergerichtet werden. Deswegen <corr resp="#editor">erschien</corr> zuerst der <lb n="25"/>
 Himmel als ein geeigneter Platz für die Bürger über ihm und in ihm,
 und die Gewölbe im Innern des HImmels wurden abgesondert für die
 Einwohner, die ihm entsprechen. Als die Bürger auf Erden aber würdest
-<milestone unit="altnumbering" n="22"/> du, (liebe) Seele, weder je die wilden Tiere noch das Geschlecht der giftsprühenden
-Schlangen nennen, noch *alle die, welche an der Natur und <lb n="30"/>
+<milestone unit="altnumbering" n="22"/> du, <supplied reason="undefined" resp="#editor">liebe</supplied> Seele, weder je die wilden Tiere noch das Geschlecht der giftsprühenden
+Schlangen nennen, noch <corr resp="#editor">alle</corr> die, welche an der Natur und <lb n="30"/>
 dem Namen der Unvernunft teil haben. Denn sie sind deine Sklaven, die
-durch Naturgesetz unterworfen werden und den vernünftigen (Wsen)
+durch Naturgesetz unterworfen werden und den vernünftigen <supplied reason="undefined" resp="#editor">Wsen</supplied>
 als ihren Herren notwendig die gebührende Bedienung verrichten. Denn
 der Ochse, de Pflüger für die Menschen, wirft freiwillig zum Pflügen
 den Nacken ins Joch; der Esel bekennt, wenn er trägt, seine Natur; <lb n="35"/>
@@ -1167,18 +1171,18 @@ auch <foreign xml:lang="abbr">ABBREV</foreign> Singular 30 Lies <foreign xml:lan
 <pb n="v.3.pt.2.p.62"/> 
 für die Tapferkeit. Eben sie töten und unterwerfen wir und auch die
 Vögel, die in der Höhe fliegen, fangen wir mit Hülfe der Vernunft, und
-die (Fische), die unten in den Tiefen des Meeres und in seiner Mitte
-(schwimmen), bringen wir herauf. Offenbar lehrt die Natur, daß alle
-<lb n="5"/> diese (Dinge) um des Menschen willen bestehen. Der Mensch aber ist
-ein Sprößling der göttlichen Vernunft, (ist) nicht um etwas anderen,
+die <supplied reason="undefined" resp="#editor">Fische</supplied>, die unten in den Tiefen des Meeres und in seiner Mitte
+<supplied reason="undefined" resp="#editor">schwimmen</supplied>, bringen wir herauf. Offenbar lehrt die Natur, daß alle
+<lb n="5"/> diese <supplied reason="undefined" resp="#editor">Dinge</supplied> um des Menschen willen bestehen. Der Mensch aber ist
+ein Sprößling der göttlichen Vernunft, <supplied reason="undefined" resp="#editor">ist</supplied> nicht um etwas anderen,
 sondern um seines Vaters willen Vernunft, damit er sehe und durch
 sein Wissen beurteile die ganze Weisheit seines Vaters, die in jedem 
-Geschöpf der Schöpfertätigkeit (sichtbar) erscheint, und damit er eben
+Geschöpf der Schöpfertätigkeit <supplied reason="undefined" resp="#editor">sichtbar</supplied> erscheint, und damit er eben
 <lb n="10"/> ihr, solange er noch jung ist, sich anähnele und in jedwedem seinem
 Vater nacheifere: in Gesetz, Vernunft, Wissen und Weisheit, und damit
 er lebe, wie ihm als einem Bilde der Vorzüglichkeit gelehrt ist, und
 damit er lerne, zumal mit den Scharen im Himmel auch von der Erde
-nach Art der Propheten und *Priester die Lobpreise emporsenden,
+nach Art der Propheten und <corr resp="#editor">Priester</corr> die Lobpreise emporsenden,
 <lb n="15"/> die dem König des Alls und Gott, der Ursache des Alls gebühren.</p>
 </div>
 
@@ -1188,7 +1192,7 @@ ganzen Natur, indem er sich wundert über die veränderliche Natur der
 Vorzüglichkeit in den menschen, in göttlichen Lobgesängen aus und sagt:
 Was ist der Mensch, daß du sein gedenkest, und der Mensch, daß du
 <lb n="20"/> “ihn heimsuchst! Du hast ihn ein wenig unter die Eugel erniedrigt,
-mit Ehre und Ruhm ihn bekleidet, *du hast ihn zum Herrscher über
+mit Ehre und Ruhm ihn bekleidet, <corr resp="#editor">du</corr> hast ihn zum Herrscher über
 das Werk deiner Hände gemacht und hast alles unter seine Füße gelegt,
 alle Schafe und Rinder, selbst die Tiere der Wüste, die Vögel unter
 dem Himmel und die Fische des Meeres, die in den Pfaden der Wasser
@@ -1204,9 +1208,9 @@ nach unserm Bilde und nach unserer Ähnlichkeit, und sie sollen herrschen
 <lb n="30"/> über die Fische im Meere, über die Vögel des Himmels, über das Vieh,
 über die ganze Erde und über alles Gewürm, das auf Erden kriecht“.
 Und mit dem Worte verband er auch die Tat: „Und Gott machte den
-Menschen“ und er (der Prophet) spricht: „Nach dem Bilde Gottes hat
+Menschen“ und er <supplied reason="undefined" resp="#editor">der Prophet</supplied> spricht: „Nach dem Bilde Gottes hat
 er ihn gemacht“. Und ferner noch mehr, er stellte das Bild der göttlichen
-<lb n="35"/> Ähnlichkeit aus dem göttlichen Odem her, indem er (der Prophet)
+<lb n="35"/> Ähnlichkeit aus dem göttlichen Odem her, indem er <supplied reason="undefined" resp="#editor">der Prophet</supplied>
 <note type="footnote">19 = Psalam 85–9 28 = Gen 1 26 32. 33 = Gen 1 27
 14 1. <foreign xml:lang="abbr">ABBREV</foreign> (Druckfehler) 16 Statt: „in solchen Bildern“ ist vielleicht
 zu übersetzen: „Demgemäß“ = <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> 21 <foreign xml:lang="abbr">ABBREV</foreign> HS
@@ -1216,27 +1220,27 @@ zu übersetzen: „Demgemäß“ = <foreign xml:lang="abbr">ABBREV</foreign> <fo
 sagt: „Und er blies ihm den Atem des Lebens ins Gesicht, da  wurde
 der Mensch zur lebendigen Seele“. Er lehrt, daß er ihmm die vorzüglichste
 Herrschaft und Königswürde gab, in  den Worten,   die er spricht:
-„Sie sollen herrschen über alles, das auf Erden (ist), über das Vieh, die
+„Sie sollen herrschen über alles, das auf Erden <supplied reason="undefined" resp="#editor">ist</supplied>, über das Vieh, die
 Vögel,  das Gewürm und die Tiere“. Über alle diese Worte legt die <lb n="5"/>
 Natur Zeugnis ab, die alles unter seine Hand getan und alles diesem
 vernünftigen Lebewesen unterworfen hat. Wenn aber die göttlichen
-Worte von dir nicht gehört (und anerkannt) warden, so glaube ich
+Worte von dir nicht gehört <supplied reason="undefined" resp="#editor">und anerkannt</supplied> warden, so glaube ich
 dennoch nicht, daß dein Denken so große Finsternis sei, daß du nicht
 im Geiste bei dir überlegst, wie eben die Vorzüglichkeit des Körpers <lb n="10"/>
 und des Leibes beschaffen sei oder eines anderen göttlichen Etwas,
-welches den Leib bewegt. Ich meine (aber) dies, daß wir verstehen,
+welches den Leib bewegt. Ich meine <supplied reason="undefined" resp="#editor">aber</supplied> dies, daß wir verstehen,
 den kritischen Verstand auf die οὐσία dieses Etwas, das existiert, anzuwenden,
-(ferner) dies, daß wir durch das Gedächtnis eine Lehre überliefern,
-(endlich) dies, daß wir zu einer Theorie über das All fortschreiten. <lb n="15"/>
+<supplied reason="undefined" resp="#editor">ferner</supplied> dies, daß wir durch das Gedächtnis eine Lehre überliefern,
+<supplied reason="undefined" resp="#editor">endlich</supplied> dies, daß wir zu einer Theorie über das All fortschreiten. <lb n="15"/>
 Geh in dich und frage, ob die Natur des Leibes erkennen kann den
 Bestand der Welt, die Wirkung der Wandel der Zeiten, den Umlauf
-der Jahre, die Reihenfolge der Sterne und so viele andere (Dinge), die
-rechnung der Arithmetik ersonnen haben. Da diese (Dinge) unkörperlich <lb n="20"/>
-und die Theorien (über sie) vernünftig sind, so ware e seine undendlich
+der Jahre, die Reihenfolge der Sterne und so viele andere <supplied reason="undefined" resp="#editor">Dinge</supplied>, die
+rechnung der Arithmetik ersonnen haben. Da diese <supplied reason="undefined" resp="#editor">Dinge</supplied> unkörperlich <lb n="20"/>
+und die Theorien <supplied reason="undefined" resp="#editor">über sie</supplied> vernünftig sind, so ware e seine undendlich
 große Torheit,  sie an Körper und Fleisch und Blut anzuheften.
 Mit Recht warden diejenigen, die so meinen, gggefragt: weil alle Kräfte
 des Leibes in die fünf Sinne zusammengefaßt warden, welcher von ihnene <lb n="25"/>
-ist (den so) beschaffen, daß er den Menschen Theorie *und Lehre
+ist <supplied reason="undefined" resp="#editor">den so</supplied> beschaffen, daß er den Menschen Theorie <corr resp="#editor">und</corr> Lehre
 nur die Unterscheidungsfähigkeit von Farben und Formen. Wenn du
 <milestone unit="altnumbering" n="24"/> aber das Gehör nennst, so nennst du das Organ, das die hellen und
 dumpfen Klänge, aber keineswegs die vernddünftige Theorie aufnimmt. <lb n="30"/>
@@ -1256,27 +1260,27 @@ und Tastsinn? Aber keins von ihnen ist der Übung des Vernunftvermögens
 nahe gekommen, weil keineswegs Sache des Körpers und
 des unvernünftigen Sinnes sind die Lehren, welche die Philosophie
 <lb n="5"/> allein aufnimmt und die Vorzüglichkeit der vernünftigen Seele allein,
-die besser ist als die leibliche Natur (und) die allein im Menschegeschlecht 
-wohnt. Und dennoch, wenn jemand unverschämt bie (seinem)
+die besser ist als die leibliche Natur <supplied reason="undefined" resp="#editor">und</supplied> die allein im Menschegeschlecht 
+wohnt. Und dennoch, wenn jemand unverschämt bie <supplied reason="undefined" resp="#editor">seinem</supplied>
 Worte verharren Tiere gebe, da wir nach Art jener gebroen und vernichtet
 <lb n="10"/> werden, deswegen weil auch Eines die Nahrung unser aller von
 der Erde ist, und die leidensfähige Natur des Leibes ein und dieselbe
 ist, und der Sinn in nichts besser ist, und ferner Arbeit und Rube ebenso
 eine und die gleiche für uns alle ist, und die Vernichtung des Leibes
-und die Auflösung in seine στοιχεῖα (in derselben Weise erfolgt), — so
-<lb n="15"/> gehst du dennoch nicht soweit zu sagen, deß (eines) von * diesen (Tieren)
+und die Auflösung in seine στοιχεῖα <supplied reason="undefined" resp="#editor">in derselben Weise erfolgt</supplied>, — so
+<lb n="15"/> gehst du dennoch nicht soweit zu sagen, deß <supplied reason="undefined" resp="#editor">eines</supplied> von <corr resp="#editor">diesen</corr> <supplied reason="undefined" resp="#editor">Tieren</supplied>
 nach Art des vernünftigen Lebewesens den unkörnerlichen Theorien
 nahe gekommen sei und vernünftige Lehre davon getragen und Wissenschaft 
 in sein Gedächtnis aufgenommen und Worte über das Bessere
-und Schlechtere ersonnen habe, noch auch (daß) die Philosophie jemals
+und Schlechtere ersonnen habe, noch auch <supplied reason="undefined" resp="#editor">daß</supplied> die Philosophie jemals
 <lb n="20"/> ihm in den Sinn kam. Aber all dies will ich übergehen, weil nicht
-einmal alle Menschen es besitzen, indem ich (nur) dies deine vernunft
-frage: ob jemals eine Stadt gebaut is von den unvernünftigen (Tieren),
+einmal alle Menschen es besitzen, indem ich <supplied reason="undefined" resp="#editor">nur</supplied> dies deine vernunft
+frage: ob jemals eine Stadt gebaut is von den unvernünftigen <supplied reason="undefined" resp="#editor">Tieren</supplied>,
 ode rob sie das Denken besitzen für ein Zimmermannswek oder für
 ein Gebäude oder für ein Erzeugnis der Webkunst oder für den Ackerbau,
 <lb n="25"/> oder ob jemals von ihnen ein Schiff genagelt ist, ode rob die wunderbare
 Kunst der Steuerung ihnen auch nur in den Sinn gekommen ist, obwohl
-die (Dinge) des Leibes bei ihnen eine viel größere Vorzüglichkeit
+die <supplied reason="undefined" resp="#editor">Dinge</supplied> des Leibes bei ihnen eine viel größere Vorzüglichkeit
 haben als bei uns, deswegen weil „schwach ist das Geschlecht der
 Mednschen“, wie die Poeten singen, und das kleinste von allen Lebewesen.
 <lb n="30"/> Man kann nicht sagen, wie viel kleiner der Mensch ist an Leibesgröße 
@@ -1296,50 +1300,50 @@ nach dem Geruch ihrer Nase zu gehen verstehen, und wer, der besser
 sähe als alle Gazellen, die eben um ihres Sehens willen in der griechi-
 schen Sprache den Namen „Seher“ erhielten? Ist es ferner nötig zu
 sagen, wie viel schwächer in seiner Natur der Leib des Menschen ist <lb n="5"/>
-als der der Bären, Löwen, Panther und Myriaden anderer (Tiere), und
-(wie) leicht er bezwungen wird von den Tieren, die ihn überfallen, und
-(wie) gering an Hinterlist? Indessen aber, eben dieser kleine (Mensch)
-unterwirft alle die genannten (Tiere), sobald er will, keineswegs durch
+als der der Bären, Löwen, Panther und Myriaden anderer <supplied reason="undefined" resp="#editor">Tiere</supplied>, und
+<supplied reason="undefined" resp="#editor">wie</supplied> leicht er bezwungen wird von den Tieren, die ihn überfallen, und
+<supplied reason="undefined" resp="#editor">wie</supplied> gering an Hinterlist? Indessen aber, eben dieser kleine <supplied reason="undefined" resp="#editor">Mensch</supplied>
+unterwirft alle die genannten <supplied reason="undefined" resp="#editor">Tiere</supplied>, sobald er will, keineswegs durch
 die Kraft des Leibes und des Körpers. Denn dieser ist zu klein und <lb n="10"/>
 ungenügend, um auch nur den Bauch Eines Bären zu füllen. Sondern
 es gibt in ihm irgend eine Natur, die besser ist als der Leib: die Kraft
-des Verstandes und der verständigen Seele, und (eben) durch die Vor-
-züglichkeit der Weisheit ersinnt er alle diese staunenswerten (Dinge). 
-Durch diese (Dinge) bist du als der geliebte Sohn von Gott geehrt. <lb n="15"/>
+des Verstandes und der verständigen Seele, und <supplied reason="undefined" resp="#editor">eben</supplied> durch die Vor-
+züglichkeit der Weisheit ersinnt er alle diese staunenswerten <supplied reason="undefined" resp="#editor">Dinge</supplied>. 
+Durch diese <supplied reason="undefined" resp="#editor">Dinge</supplied> bist du als der geliebte Sohn von Gott geehrt. <lb n="15"/>
 Warum verkleinerst du deine Größe, indem du meinst, dein ganzes Du
 sei Fleisch und Leib, und indem du das göttliche und vernünftige Wissen
-in dir *den unvernünftigen (Wesen) und solchen, die ganz zugrunde gehen,
+in dir <corr resp="#editor">den</corr> unvernünftigen <supplied reason="undefined" resp="#editor">Wesen</supplied> und solchen, die ganz zugrunde gehen,
 vergleichst? Überzeugt dich weder die Natur der unvernunftigen Lebe-
 wesen noch der gemeinsame Name der Unvernunft noch die offenbare <lb n="20"/>
-(und) nützliche Bedienung, in der sie sich niemals davon freigemacht haben,
-(Lasten) zu tragen und (das Land) zu bestellen, weil Gott dir die Voll-
+<supplied reason="undefined" resp="#editor">und</supplied> nützliche Bedienung, in der sie sich niemals davon freigemacht haben,
+<supplied reason="undefined" resp="#editor">Lasten</supplied> zu tragen und <supplied reason="undefined" resp="#editor">das Land</supplied> zu bestellen, weil Gott dir die Voll-
 macht und die Königsherrschaft über alle diese gab?</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="48">
 <p>Der
-Mensch also allein von den (Wesen) auf Erden, der nach dem Bilde
+Mensch also allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden, der nach dem Bilde
 Gottes wurde, führt und bringt die Tiere, wohin er will, bald die lenkend, <lb n="25"/>
 die zum Laufe passend sind, bald als Herden weidend, die hierzu ge- 
 schaffen sind, bald die Jochtiere zur Bedienung benutzend, indem er die
 wilde Natur zahm und friedlich macht: bald indem er zum frieden über-
-windet, was ihm gehorcht, bald indem er (es) auf manningfache Weise
-der Vernunft sammelt und ins Haus einschließt. Und nicht nur (dies), <lb n="30"/>
+windet, was ihm gehorcht, bald indem er <supplied reason="undefined" resp="#editor">es</supplied> auf manningfache Weise
+der Vernunft sammelt und ins Haus einschließt. Und nicht nur <supplied reason="undefined" resp="#editor">dies</supplied>, <lb n="30"/>
 sondern auch das schädliche Gewürm nimmt er in seine Hand und spielt
 damit und sie, die Tod atmen und Gift sprühen, macht er zum Spiel
 <milestone unit="altnumbering" n="26"/> für sich.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="49">
-<p>Der Mensch allein von den (Wesen) auf Erden ließ sich
-nicht überreden, in der Wüste in Höhlen und (Sand) hügeln zu wohnen,
+<p>Der Mensch allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden ließ sich
+nicht überreden, in der Wüste in Höhlen und <supplied reason="undefined" resp="#editor">Sand</supplied> hügeln zu wohnen,
 sondern baute Städte mit Mauern und schmückte sie mit Straßen, Burgen, <note type="marginal">35</note>
 Wohnhäusern und andern Gebäuden.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="50">
-<p>Der Mensch allein von den (Wesen)
-auf Erden verschaffte sich, keineswegs in (derselben) unwandelbaren Art,
+<p>Der Mensch allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied>
+auf Erden verschaffte sich, keineswegs in <supplied reason="undefined" resp="#editor">derselben</supplied> unwandelbaren Art,
 <note type="footnote">8 vgl. Praep. VII 184 24 vgl. Gen 1 27</note>
 <note type="footnote">4 „Seher“ = δορκάδες von δέρκομαι 18 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
@@ -1357,15 +1361,15 @@ schafft dies zur Heilung des Leibers herbei.</p>
 
 <div type="textpart" subtype="chapter" n="51">
 <p>Er allein von den
-<lb n="10"/> (Wesen) auf Erden fand durch Gesetz und Vernunft eine geordnete
+<lb n="10"/> <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden fand durch Gesetz und Vernunft eine geordnete
 Lebensfühung, wird ein στραηγός, mach ἆθλοι und bringt die Berufswissenschaften und die gewaltigen Lehrkünste durch die vernünftige
 Vorzüglichkeit hervor.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="52">
-<p>Er allein von den (Wesen) auf Erden hat,
+<p>Er allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden hat,
 indem er das Bild der Vorzüglichkeit bewahrte, die richtige Wage,
-<lb n="15"/> die Gewichte, Maße und Winkel(maße) ersonnen und unterscheidet,
+<lb n="15"/> die Gewichte, Maße und Winkel<supplied reason="undefined" resp="#editor">maße</supplied> ersonnen und unterscheidet,
 indem er durch die Vernunft gelenkt wird, das, was geschehen soll
 und was nicht, und weiß jedermann zu geben, wie er es verdient.
 „Denn die Fische, wie es heißt, Vögel und Tiere fressen einander, deswegen
@@ -1376,7 +1380,7 @@ Meinung nach sehr schön Einer von den Poeten.</p>
 
 <div type="textpart" subtype="chapter" n="53">
 <p>Er allein von
-den (Wesen) auf Erden, der das Bild der göttlichen Vernunft in sich
+den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden, der das Bild der göttlichen Vernunft in sich
 zeigt, hat ein Gerichtsgebäude in die Höhe gerichtet, handelt nach Art
 des gerechten Gerichtes Gottes und entscheidet Leben und Tod, indem
 <lb n="25"/> er den einen das Leben zutilt, den andern aber den Tod gibt.</p>
@@ -1384,7 +1388,7 @@ des gerechten Gerichtes Gottes und entscheidet Leben und Tod, indem
 
 <div type="textpart" subtype="chapter" n="54">
 <p>Er
-allein von den (Wesen) auf Erden vertraut dem kleinen Stück eines
+allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden vertraut dem kleinen Stück eines
 Baumes sein Leben an, hat die Weisheit der Schiffahrtskunst erfunden, <milestone unit="altnumbering" n="27"/>
 lenkt das Schiff auf dem Rüchen des Meeres, überläßt sich
 der Tiefe der feuchten οὐσία und stößt den Tod zurück, der ihm zur
@@ -1394,39 +1398,39 @@ das Ziel der Rettung für die Fahrenden knüpft.</p>
 
 <div type="textpart" subtype="chapter" n="55">
 <p>Der Mensch
-allein von den (Wesen) auf Erden hat die Lehre vom Laufe der Sterne
-gefunden; obwohl er (hier) unten im Leibe wandelt undmit der
+allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden hat die Lehre vom Laufe der Sterne
+gefunden; obwohl er <supplied reason="undefined" resp="#editor">hier</supplied> unten im Leibe wandelt undmit der
 Schwere des Sterblichen bekleidet ist, steigt er doch in seinem Geiste
-<lb n="35"/> nach oben und läßt die *Sonne selber, Mond und Sterne kreisen und
+<lb n="35"/> nach oben und läßt die <corr resp="#editor">Sonne</corr> selber, Mond und Sterne kreisen und
 <note type="footnote">18 = Hesiod ἔργα καὶ ἡμέραι 227 ff. 26 vgl. Weish. Sal. 145</note>
 <note type="footnote">1 wörtlich „ entsprechend dem Gebrauche der unvernünftigen Tiere“ 11 „ Berufswissenschaften“] wörtlich „die mittleren Künste“= αἱ μέσαι τέχναι vgl. Praep.
 15 7 15 „ Winkelmaße“] wohl = γωνίαι Schultheß 35 „Himmel“ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> Lee</note>
 
 <pb n="v.3.pt.2.p.67"/>
-kundigt *im Vorherwissen der kunftigen (Erscheinung durch die Theorie)
+kundigt <corr resp="#editor">im</corr> Vorherwissen der kunftigen <supplied reason="undefined" resp="#editor">Erscheinung durch die Theorie</supplied>
 sogar die Eklipse des Mondes an und sagt den Wandel der Perioden
-und den Wechsel der (Jahres-)zeiten voraus.</p>
+und den Wechsel der <supplied reason="undefined" resp="#editor">Jahres-</supplied>zeiten voraus.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="56">
 <p>Der Mensch allein
-von den (Wesen) auf Erden hat sich als Unterstutzer der Natur erwiesen
+von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden hat sich als Unterstutzer der Natur erwiesen
 und eine Methode der Heilung gefunden, hat die Kraft der Wurzeln <lb n="5"/>
-und Gifte und (ihre) Vermischund und Vermengung nach Gewicht und
-nach entsprechendem (Ma?e) in seinem Geist *beobachtet und (so) den
+und Gifte und <supplied reason="undefined" resp="#editor">ihre</supplied> Vermischund und Vermengung nach Gewicht und
+nach entsprechendem <supplied reason="undefined" resp="#editor">Ma?e</supplied> in seinem Geist <corr resp="#editor">beobachtet</corr> und <supplied reason="undefined" resp="#editor">so</supplied> den
 kranken Leibern eine Heilung, dem Leben der Menschen eine Hulfe ersonnen.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="57">
-<p>Er allein von den (Wesen) auf Erden, der keineswegs
-zu einem Leben der Grasfresser gekommen ist, *folgte gut der Natur: <lb n="10"/>
+<p>Er allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden, der keineswegs
+zu einem Leben der Grasfresser gekommen ist, <corr resp="#editor">folgte</corr> gut der Natur: <lb n="10"/>
 In der Zeit des Winters wirft er den Samen in die Erde und setzt die
-Muhe seines Schwei?es an die Bearbeitung (des Bodens), im Sommer aber
+Muhe seines Schwei?es an die Bearbeitung <supplied reason="undefined" resp="#editor">des Bodens</supplied>, im Sommer aber
 erntet er die Fruchte seiner Arbeit.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="58">
-<p>Er allein von den (Wesen)
+<p>Er allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied>
 auf Erden fuhrte durch vernunftige Wissenschaft eine Lehre des Alls,
 eine Disziplin und Komposition der Musik und eine Prufung durch Disputationen <lb n="15"/>
 herbei, ging dem Leben und Namen der Philosophie nach, pflegte
@@ -1435,20 +1439,20 @@ des Leibes, sondern die Kraft des Wissens und den Antrieb der Vernunft.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="59">
-<p>Der Mensch allein von den (Wesen) auf Erden trug in
+<p>Der Mensch allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden trug in
 seinem Gedachtnis Geschichten von dem, was fruher in Urzeiten geschehen <lb n="20"/>
-ist, verkehrt mit denen, die nicht (mehr) sind wie mit den Gegenwartigen,
+ist, verkehrt mit denen, die nicht <supplied reason="undefined" resp="#editor">mehr</supplied> sind wie mit den Gegenwartigen,
 erforscht die Gedanken der Weisen, die je existierten, empfangt
-von ihnen mehr Unterstutzung als von denen, die mit ihm (leben), und
+von ihnen mehr Unterstutzung als von denen, die mit ihm <supplied reason="undefined" resp="#editor">leben</supplied>, und
 <milestone unit="altnumbering" n="28"/> ist durch die Kraft des Wortes, das dem Denken verwandt ist, mit denen
 zusammen, die fruher zugrunde gingen.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="60">
-<p>Er allein von den (Wesen) <lb n="25"/>
+<p>Er allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied> <lb n="25"/>
 auf Erden hat schon den artikulierten Laut mit einzelnen Artikulationsstellen
 geschaffen, durch die Kunst der Grammatik die ursprunglichen Buchstaben
-(des Alphabets) abgetrennt, die Teile und die kraft des Satzes
+<supplied reason="undefined" resp="#editor">des Alphabets</supplied> abgetrennt, die Teile und die kraft des Satzes
 gefunden und die Zusamensetzung der Verba und Nomina und die Lehre
 der Rhetorik und Grammatik ersonnen. Alles dieses vereinigt und bewahrt <lb n="30"/>
 er im Gedachtnis und bringt gleichsam zu einem Haufen Worte
@@ -1460,46 +1464,46 @@ Ohren aller gegenwartigen uberflie?en.</p>
 
 <div type="textpart" subtype="chapter" n="61">
 <p>Der Mensch allein von <lb n="35"/>
-den (Wesen) auf Erden ahnelt sich durch seine Taten dem uber alles
-(waltenden) Gott an und jeder, der will, bildet Leben, indem er die
+den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden ahnelt sich durch seine Taten dem uber alles
+<supplied reason="undefined" resp="#editor">waltenden</supplied> Gott an und jeder, der will, bildet Leben, indem er die
 <note type="footnote">1 1. <foreign xml:lang="abbr">ABBREV</foreign> mit HS 2 "und" Σ=κα? 7 "verbunden" l.
 <foreign xml:lang="abbr">ABBREV</foreign> Schulthe? 10 <foreign xml:lang="abbr">ABBREV</foreign> "und" str. 16 "eilt" Σ=σπε?δει 28 "des Satzes"]
 wortlich "des Wortes" 29 "Verba und Nomina" wortlich: ῥήματα καὶ ὀνόματα</note>
 
 <pb n="v.3.pt.2.p.68"/>
 Seelenlose Hyle in Gestalten und Bilder umwandelt und Formen von
-Allerlei Lebwesen in die flüssige ( bildsame) Natur wirft, dem Allschöpfer
-Mit vernünftiger Kraft nacheifernd. (So) scjafft der Mensch den Menschen
-bald in Stein und bald in Holz, bald in Farbenschmelz und (bald)
+Allerlei Lebwesen in die flüssige <supplied reason="undefined" resp="#editor">bildsame</supplied> Natur wirft, dem Allschöpfer
+Mit vernünftiger Kraft nacheifernd. <supplied reason="undefined" resp="#editor">So</supplied> scjafft der Mensch den Menschen
+bald in Stein und bald in Holz, bald in Farbenschmelz und <supplied reason="undefined" resp="#editor">bald</supplied>
 <lb n="5"/> in unveränderliche Bilder, und gestaltet alle arten der Tier und Pflanzen
-Auf dieselbe Weise und zeigt durch seine Taten vollkommen (deutlich)
+Auf dieselbe Weise und zeigt durch seine Taten vollkommen <supplied reason="undefined" resp="#editor">deutlich</supplied>
 Die Kraft des Bildes Gottes.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="62">
-<p>Er allein von den (Wesen) auf Erden
+<p>Er allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden
 Bildete auf der Erde, auf der er wandelt, das Gewölbe des Himmels
 Nach, groub das Bild eben des Himmels in die  ὔλη des Erzes, befestigte
 <lb n="10"/> daran ein Abbild der Planeten und Fixsterne, ordnete die Fristen der
 Perioden und Zeiten durch die bildende Kunst, umgab es außen rings
-Mit Tierfiguren und bildete (so) das Himmelsgewölbe durch die Größe
-Des Wissens nach Art der geschauten Dinge. (Dies) ließ er (dann), wie
+Mit Tierfiguren und bildete <supplied reason="undefined" resp="#editor">so</supplied> das Himmelsgewölbe durch die Größe
+Des Wissens nach Art der geschauten Dinge. <supplied reason="undefined" resp="#editor">Dies</supplied> ließ er <supplied reason="undefined" resp="#editor">dann</supplied>, wie
 Der got des Himmels, auf der  Erde seine Drehung mit dem All vollziehen.
-<lb n="15"/> (So) kreist es sich in unendlichem Wunder und mit *den (wirklichen Dingen)
-Am Himmel *kreisen sich die auf Erden (befindlichen)
+<lb n="15"/> <supplied reason="undefined" resp="#editor">So</supplied> kreist es sich in unendlichem Wunder und mit <corr resp="#editor">den</corr> <supplied reason="undefined" resp="#editor">wirklichen Dingen</supplied>
+Am Himmel <corr resp="#editor">kreisen</corr> sich die auf Erden <supplied reason="undefined" resp="#editor">befindlichen</supplied>
 Irdisch-hylischen Abbilder. Mit lauter Stimme ruft der Engel der Hore n
 Allzumal warden sie in Einem Augenblick bewegt, die Türen öffnen sich
 Non selbst beim Kommen der Horen, die seelenlosen Bilder der Vögel,
-<lb n="20"/> die rings umher *angebracht sind, *rufen zirpend; der Mond, auf Erden
-(abgbldet), läuft mit dem am Hmmel, das Erz wandelt von selbst <milestone unit="altnumbering" n="29"/>
-ihm(ausgehende) Licht bald halb bald abnehmend bald voll, und die Bilder der
-Horen entsprechen den Horen der Natur, und so wetteifert die (durch)
-<lb n="25"/> menschliche (Kunst konstruierte) Welt mit der Schöpfertätigkeit des göttlichen
+<lb n="20"/> die rings umher <corr resp="#editor">angebracht</corr> sind, <corr resp="#editor">rufen</corr> zirpend; der Mond, auf Erden
+<supplied reason="undefined" resp="#editor">abgbldet</supplied>, läuft mit dem am Hmmel, das Erz wandelt von selbst <milestone unit="altnumbering" n="29"/>
+ihm<supplied reason="undefined" resp="#editor">ausgehende</supplied> Licht bald halb bald abnehmend bald voll, und die Bilder der
+Horen entsprechen den Horen der Natur, und so wetteifert die <supplied reason="undefined" resp="#editor">durch</supplied>
+<lb n="25"/> menschliche <supplied reason="undefined" resp="#editor">Kunst konstruierte</supplied> Welt mit der Schöpfertätigkeit des göttlichen
 Logos.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="63">
-<p>Der Mensch allein von den (Wesen) auf Erden
+<p>Der Mensch allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden
 Ist imstande, durch unaussprechliche Worte, durch Gebete, die von Gott
 Geliebt  warden, und durch die Kraft eines gottesfürchtigen Wortes und
 Wandels die Natur der verborgenen, unsichtbaren Dämonen in die Ferne
@@ -1507,7 +1511,7 @@ Wandels die Natur der verborgenen, unsichtbaren Dämonen in die Ferne
 Mächtig geworden, daß er das durch die luft fliegende Geschlecht durch
 Abgesänge und Besprechungen unterwarf, und ferner schleppt er durch
 Das Mittle des Zwanges und durch die bezauberung physischer Knoten
-*die leiblosen, um die Erde gleich fliegenden Vögeln fliegenden Kräfte
+<corr resp="#editor">die</corr> leiblosen, um die Erde gleich fliegenden Vögeln fliegenden Kräfte
 <note type="footnote">7 vgl. Gen 1 27</note>
 <note type="footnote">4 „Farbenschmelz“ wötlich „die Blüte der Farben“, wohl ἄνθος χρωμάτων
 15 Statt <foreign xml:lang="abbr">ABBREV</foreign> lies <foreign xml:lang="abbr">ABBREV</foreign> 16 Statt <foreign xml:lang="abbr">ABBREV</foreign> lies <foreign xml:lang="abbr">ABBREV</foreign> entsprechend
@@ -1516,7 +1520,7 @@ Das Mittle des Zwanges und durch die bezauberung physischer Knoten
 
 <pb n="v.3.pt.2.p.69"/>
 und zerrt und fesselt sie, woe r will, und läßt sie auf sie auf Bildern wohnen,
-(und  so) zeigt (der,) der (sich) Götter macht, eben durch seine Taten,
+<supplied reason="undefined" resp="#editor">und  so</supplied> zeigt <supplied reason="undefined" resp="#editor">der,</supplied> der <supplied reason="undefined" resp="#editor">sich</supplied> Götter macht, eben durch seine Taten,
 daß seine eigene Kraft besser ist als die von ihm verfertigte Gottheit.</p>
 </div>
 
@@ -1524,10 +1528,10 @@ daß seine eigene Kraft besser ist als die von ihm verfertigte Gottheit.</p>
 <p>Der Mensch allein zeigt, wie groß die Vorzüglichkeit des geistigen,
 unkörperlichen Seins ist, beweist, daß seine  Kraft weder unterjocht <lb n="5"/>
 noch vermindert wird vom Bösen, bietet seinen Leib dem Feuer, dem
-Eisen, den wilden Tieren und der Tiefe des Meeres dar und nähert (ihn)
+Eisen, den wilden Tieren und der Tiefe des Meeres dar und nähert <supplied reason="undefined" resp="#editor">ihn</supplied>
 jeder Art von Qualen. Er weiß, daß eben seine  Natur eiligst zugrunde
-geht, flüssig (d. h. vergäuglich) ist und aufgelöst wird, während er das,
-was drinnen sitzt (d.h. die Seele), nicht preisgibt. Daß dies ein anderes <lb n="10"/>
+geht, flüssig <supplied reason="undefined" resp="#editor">d. h. vergäuglich</supplied> ist und aufgelöst wird, während er das,
+was drinnen sitzt <supplied reason="undefined" resp="#editor">d.h. die Seele</supplied>, nicht preisgibt. Daß dies ein anderes <lb n="10"/>
 ist als das, was geschlagen wird, beweist, er, indem er ausruft: „Schlage,
 schlage den Schafspelz; den mich schlägst du nicht“. Ein anderer
 wiederum ruft freimütig aus: ütig aus: „Verbrenne und röste den Leib! Sättige
@@ -1537,19 +1541,19 @@ ehe ein schmeichelndes Wort von mir dir begegnet“. Und Einer der
 Gottliebenden brachte, als er Böses ertrug, folgende  Worte vor: „Wer
 will mich scheiden von der Liebe Gottes? Betrübnis oder  Drangsal oder
 Verfolgung oder Hunger oder Blöße oder Kälte oder Schwert?“ Auch
-ich aber habe jüngst (Leute) gesehen, teils mit herausgerissenen Augen, <lb n="20"/>
+ich aber habe jüngst <supplied reason="undefined" resp="#editor">Leute</supplied> gesehen, teils mit herausgerissenen Augen, <lb n="20"/>
 teils durch Brenneisen ihrer Füße beraubt, teils gekreuzigt. Ihr ganzer
 Leib verging und ihre sterbliche Natur ward zuschanden gemacht, aber 
 <milestone unit="altnumbering" n="30"/> das gottliebende Wissen, das in ihnen wohnt, wurde nicht bewegt noch
-unterworfen und nicht einmal (in) jenen schwersten (Stunden) preisgegeben,
-indem sie denen, die den Geist nicht *zugrunde richten, <lb n="25"/>
+unterworfen und nicht einmal <supplied reason="undefined" resp="#editor">in</supplied> jenen schwersten <supplied reason="undefined" resp="#editor">Stunden</supplied> preisgegeben,
+indem sie denen, die den Geist nicht <corr resp="#editor">zugrunde</corr> richten, <lb n="25"/>
 deutlich zeigten, daß die Kraft ihrer Vorzüglichkeit etwas anderes als
 das Vergängliche sei.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="65">
 <p>Er allein von den Lebewesen auf Erden
-ist des göttlichen Hauches teilhaftig geworden und des *Anblicks
+ist des göttlichen Hauches teilhaftig geworden und des <corr resp="#editor">Anblicks</corr>
 Gottes gewürdigt, redet mit den Engeln Gottes und hat das Vorauswissen
 des Zukünftigen erreicht bald durch Träume im Schlafe, 30
 bald freilich durch göttliche Kraft so geistbekleidet, daß er sogar
@@ -1558,19 +1562,19 @@ eine Prophezeiung des Zukünftigen sagt und seine Gemeinschaft
 17 = Röm 8 35</note>
 <note type="footnote">1 vll. <foreign xml:lang="abbr">ABBREV</foreign> „wie er will“ zu lessen 2 Man erartet ein <foreign xml:lang="abbr">ABBREV</foreign> vor <foreign xml:lang="abbr">ABBREV</foreign>
 12 <foreign xml:lang="abbr">ABBREV</foreign> θύλακον Anxarchl. Nicht zu korrigieren; vgl. den 1. Brief des
-Euagriow Pontikos (unediert) 25 „deren Geist nicht zugrunde richtet“ oder „gerichtet
+Euagriow Pontikos <supplied reason="undefined" resp="#editor">unediert</supplied> 25 „deren Geist nicht zugrunde richtet“ oder „gerichtet
 wird“ Σ, besser liest man <foreign xml:lang="abbr">ABBREV</foreign> statt <foreign xml:lang="abbr">ABBREV</foreign> 28 <foreign xml:lang="abbr">ABBREV</foreign> ist nichts,
 lies <foreign xml:lang="abbr">ABBREV</foreign> des lies <foreign xml:lang="abbr">ABBREV</foreign> des „Anblicks“ mit HS. PSm will <foreign xml:lang="abbr">ABBREV</foreign> der „Oftenbarung“</note>
 
 <pb n="v.3.pt.2.p.70"/>
-mit der Gottheit durch Kundtun * solcher Thaten bestätigt.</p>
+mit der Gottheit durch Kundtun <corr resp="#editor">solcher</corr> Thaten bestätigt.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="66">
 <p>Er
-allein kennt das, was durchweg gröBer und besser ist als alles Sichtbare:
+allein kennt das, was durchweg größer und besser ist als alles Sichtbare:
 das, was mit den Augen nicht gesehen, durchs Tasten nicht wahrgenommen
-wird, noch mit Einem (andern) von den Sinnen des Leibes,
+wird, noch mit Einem <supplied reason="undefined" resp="#editor">andern</supplied> von den Sinnen des Leibes,
 <lb n="5"/> sondern von dem Verstande und Geiste allein gesehen wird. Er hat es
 durch seine eigene lehre und durch die Belehrung seiner Natur bekannt
 und Gott genannt, hat es gelobt und seine Vervandtschaft mit der
@@ -1580,7 +1584,7 @@ Gottheit durch sieses Wissen gezeigt.</p>
 <div type="textpart" subtype="chapter" n="67">
 <p>Er allein stand da als
 Zuschauer der gewaltigen Taten des göttlichen Logos und ward würdig,
-<lb n="10"/> den oberhallo des Himmels (wohnenden) Vater mit gottgeziemenden
+<lb n="10"/> den oberhallo des Himmels <supplied reason="undefined" resp="#editor">wohnenden</supplied> Vater mit gottgeziemenden
 Lobgesängen zu loben und sich der Schar der Engel im Himmel anzuähneln,
 weil er allein  von den Lebewesen auf Erden Diese Vorzüglichkeit
 erlangte und durch sie ihn, der die Ursanche alles Guten ist, infolge
@@ -1590,27 +1594,27 @@ schuldigen Tribut darzubrigen.</p>
 </div>
 	   
 <div type="textpart" subtype="chapter" n="68">
-<p>Die Zeugnisse aller dieser (Dinge) bestätgt das Wort
+<p>Die Zeugnisse aller dieser <supplied reason="undefined" resp="#editor">Dinge</supplied> bestätgt das Wort
 göttlicher Lehre und Wissenschaft,  dab von unsterblicher und den
-Himmelsbürgern verwandter Natur er allein von den (Wesen) auf Erden
+Himmelsbürgern verwandter Natur er allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden
 <lb n="20"/> existiert <add>wegen</add> dieser geistigen und vernünftigen οὐσία in den Menschen,
 und dab er das geliebte Kind des göttlichen Logos ist, des gemeinsamen
-Erlösers aller, der (ihn) nach dem Bilde and der Ähnlichkeit
+Erlösers aller, der <supplied reason="undefined" resp="#editor">ihn</supplied> nach dem Bilde and der Ähnlichkeit
 seines eigenen Vaters in seiner Natur vollendet.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="69">
 <p>Wenn also
 dies    vernünftige Lebewesen, er, der an so  grober Vorzüglichkeit teil <milestone unit="altnumbering" n="31"/>
-<lb n="25"/> hat, er, der allein von den (Wesen) auf Erden nach dem Bilde
-Gottes (geschaffen ist), der Bruder der göttlichen Kräfte und der
+<lb n="25"/> hat, er, der allein von den <supplied reason="undefined" resp="#editor">Wesen</supplied> auf Erden nach dem Bilde
+Gottes <supplied reason="undefined" resp="#editor">geschaffen ist</supplied>, der Bruder der göttlichen Kräfte und der
 Engel im Himmel, in seiner Natur geziemend gelebt hätte und
 dem göttlichen Gesetz früher gefolgt wäre, so wäre er vielleicht
-von dem irdischen und vergänglichen * Leben befreit, * obwohl er sich
+von dem irdischen und vergänglichen <corr resp="#editor">Leben</corr> befreit, <corr resp="#editor">obwohl</corr> er sich
 <lb n="30"/> in irdischem Umgang befand, gleichsam durch Umwanderung. Wenn
-er s ich zuvor um    die göttlichen (Dinge) bekümmert  hätte, so hätte er
+er s ich zuvor um    die göttlichen <supplied reason="undefined" resp="#editor">Dinge</supplied> bekümmert  hätte, so hätte er
 vielleicht seine Wegwanderung von hier in das Seine vollzogen und
-wäre unter die * vollkommenen Menschen geschrieben trotz seiner Kleinheit 
+wäre unter die <corr resp="#editor">vollkommenen</corr> Menschen geschrieben trotz seiner Kleinheit 
 und des Zustandes seiner Kindlichkeit. So also zog der  vergängliche
 <lb n="35"/> und auflösbare Mensch notwendig einen Leib an durch das Mitleid
 seines Vaters, auf dab ihm nicht auf ewig das Böse anhafte und
@@ -1623,33 +1627,33 @@ mit HS <foreign xml:lang="abbr">ABBREV</foreign> Man erwartet auch <foreign xml:
 er ohne Ende an das Vergängliche gebunden sie, sondern damit das
 Vergägliche bald aufgelöst werde und er die Gemeinschaft der Unvergänglichen
 empfange. Denn wie das, was im Leibe empfangen ist,
-mit dem Gewande seines Ortes bekleidet ist, und (wie) der, der geboren
+mit dem Gewande seines Ortes bekleidet ist, und <supplied reason="undefined" resp="#editor">wie</supplied> der, der geboren
 wird, eben dies auszieht, sobald die bestimte Zeit der Monate <lb n="5"/>
-kommt, und (wie) er dann zum Lichte hervorgeht und frischen Atem
+kommt, und <supplied reason="undefined" resp="#editor">wie</supplied> er dann zum Lichte hervorgeht und frischen Atem
 schöpft und fortan unter die Natur der Menschen gerechnet wird, demgemäb
 ist auch das scheinbar vollkommene Geschlecht der Menschen
-gegenüber dem (noch) besseren (im Himmel) ein Kind und noch auf
-Erden (im Leibe) empfangen und mit dieser vergänglichen Haut bekleidet. <lb n="10"/>
+gegenüber dem <supplied reason="undefined" resp="#editor">noch</supplied> besseren <supplied reason="undefined" resp="#editor">im Himmel</supplied> ein Kind und noch auf
+Erden <supplied reason="undefined" resp="#editor">im Leibe</supplied> empfangen und mit dieser vergänglichen Haut bekleidet. <lb n="10"/>
 Eben sie mub er notwendig durch die Güte des groben Geschenkes
 Gottes ausziehen, damit er nicht auf ewig durch diese minderwertigen
-(Dinge) aufgerieben werde, sondern bald zum Lichte hervorgehe
+<supplied reason="undefined" resp="#editor">Dinge</supplied> aufgerieben werde, sondern bald zum Lichte hervorgehe
 und zu einem unvergänglichen Leben fortwandere. Deswegen seufzten
 mit Recht die Shcaren weiser und gottliebender Männer über das Teilhaben <lb n="15"/>
 an den vergäglichen Leibern ud begehrten die Umwandlung
-zum Besseren und jagten den oberen (himmlischen) Verwandten und
+zum Besseren und jagten den oberen <supplied reason="undefined" resp="#editor">himmlischen</supplied> Verwandten und
 Bürgern nach, wie derjenige war, der mit göttlichem Worte sagte: „Ich
 armer Mensch, wer wird mich befreien von diesem Todesleibe?“ Und
 ferner: „Selbst wenn wir im Leibe lebten, so dienen wir doch nicht nach <lb n="20"/>
 dem Fleische. “Und: „ Wir sind hinzugekommen zur Stadt des lebendigen
 Gottes Im Himmel und zu der Schar von Myriaden Engeln und zu einer
-Gemeinde von Erstgebornen, die im Himmel verzeichnet sind.“ Dies (sind)
+Gemeinde von Erstgebornen, die im Himmel verzeichnet sind.“ Dies <supplied reason="undefined" resp="#editor">sind</supplied>
 <milestone unit="altnumbering" n="32"/> Worte von bekannten und gottliebenden Männern.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="70">
 <p>Wenn aber viele <lb n="25"/>
-Toren die (Dinge) der hiesigen (irdischen) Lust *lieben „solche die bis
-jetzt (noch) in ihrem Denken unmündig sind, was besagyt dies gegenüber
+Toren die <supplied reason="undefined" resp="#editor">Dinge</supplied> der hiesigen <supplied reason="undefined" resp="#editor">irdischen</supplied> Lust <corr resp="#editor">lieben</corr> „solche die bis
+jetzt <supplied reason="undefined" resp="#editor">noch</supplied> in ihrem Denken unmündig sind, was besagyt dies gegenüber
 dem wahren Wort? Denn der, der im Leibe empfangen ist, freut
 sich über seinen gewohnten Ort, fürchtet sich vor der Veränderung
 und dab er der inneren Finsternis entrinne, und weint, sobald er zum <lb n="30"/>
@@ -1667,7 +1671,7 @@ an der Nahrung der Brust, darauf kommt es“?</note>
 <pb n="v.3.pt.2.p.72"/>
 in die Hand der Amme und wird den Erziehern, Pädagogen und Lehrern
 übergeben, bis er zum vollkommenen Manne hervorgeht. Dann aber
-kommt in Blüte ein besseres und preiswürdigeres Leben durch groBen
+kommt in Blüte ein besseres und preiswürdigeres Leben durch großen
 Reichtum, vielen Besitz, durch Vollmacht, Herrschaft und andere Stufen.
 <lb n="5"/> Das, was infolge seiner guten Geburt, und das, was infolge der Erziehung
 zur Entfaltung gebracht ist, und Myriaden anderes legt den Grund zu
@@ -1678,7 +1682,7 @@ einem Leben von angenehmen Dasein.</p>
 <p>Wenn sich aber eine
 unnatürliche Umkehrung ereignet dessen, der im Leibe empfangen ist,
 was habe ich nötig das, was ihm bei seinem Hervorgehen, bei seiner
-<lb n="10"/> Goburt folgt, zu sagen? DaB das innen umgekehrte Kind sich weigert,
+<lb n="10"/> Goburt folgt, zu sagen? Daß das innen umgekehrte Kind sich weigert,
 zum Lichte hervorzugehen und eine unnatürliche Umkehrung erleidet
 durch die eisernen Instrumente, die, für die Geburtshilfe bereitet, notwendig
 und mit Zwang an es herangebracht warden, und da Bes nicht
@@ -1689,37 +1693,37 @@ sondern auch des Namens beraubt ist?</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="72">
-<p>DemgemäB also ist auch
+<p>Demgemäß also ist auch
 der, welcher ein menschliches Leben auf Erden führt, in nichts von einem
 unvernünftigen und unwissenden Säugling oder dem, der noch im Leib
-<lb n="20"/> getragen wird, unterschieden und ist, unvergleichbar mit den äuBeren
+<lb n="20"/> getragen wird, unterschieden und ist, unvergleichbar mit den äußeren
 Körpern der Engel und göttlichen Geister, sogar ein unwissendes Kind.
-Wegen der GröBe siner Kindlichkeit frut er sich über die Bekleidung
+Wegen der Größe siner Kindlichkeit frut er sich über die Bekleidung
 Des Leibes, der ihn umgiebt, und liebt seinen Bauch, ohne zu kennen
 Den „Ort rings um ihn, wo Mord und Groll und die anderen Arten des <milestone unit="altnumbering" n="33"/>
 <lb n="25"/> Schicksals wie auf Wiesen des Bösen in der Finsternis weiden,“ sagt
-Einer von den Alten, indem er zeigt, daB die feuchte und dunkle Luft
-Auf Erden aus vielen Mischungen von Myriaden aus der Erde (aufsteigenden)
-Dünsten besteht, (wie) aber jemand meint, daB sie ist, selbst
+Einer von den Alten, indem er zeigt, daß die feuchte und dunkle Luft
+Auf Erden aus vielen Mischungen von Myriaden aus der Erde <supplied reason="undefined" resp="#editor">aufsteigenden</supplied>
+Dünsten besteht, <supplied reason="undefined" resp="#editor">wie</supplied> aber jemand meint, daß sie ist, selbst
 Wenn er ein kleines Kind ist. Indessen aber. Wenn er das hiesige
-<lb n="30"/> (irdische) Leben, wie es seiner Natur entspricht, durchmacht und ein
-Dasein dem Gesetz seiner Natur gemäB hervorbringt, so daB er nicht
-Über das MaB seiner Reife hinausstrebt, noch wider die Natur löckt,
-Die ihn nach Art einer Mutter trägt, noch ferner seinen Vater vergiBt,
+<lb n="30"/> <supplied reason="undefined" resp="#editor">irdische</supplied> Leben, wie es seiner Natur entspricht, durchmacht und ein
+Dasein dem Gesetz seiner Natur gemäß hervorbringt, so daß er nicht
+Über das Maß seiner Reife hinausstrebt, noch wider die Natur löckt,
+Die ihn nach Art einer Mutter trägt, noch ferner seinen Vater vergißt,
 Vielmehr seinen eigenen Vater im Himmel, den gemeinsamen Erlöser
 <lb n="35"/> aller, kennt und ihm den Lobgesang des Bekenntnisses darbringt, des-
 <note type="footnote">24 Empedokles fr. 121 Diels</note>
-<note type="footnote">6 <foreign xml:lang="abbr">ABBREV</foreign> „wirft“ = καταβάλλω? 10 wörtlich: „daB das Kind innen umgekehrt
+<note type="footnote">6 <foreign xml:lang="abbr">ABBREV</foreign> „wirft“ = καταβάλλω? 10 wörtlich: „daß das Kind innen umgekehrt
 Ist und sich weigert“ 24 κότος Empedokles „Finsternis“ Σ = σκότος
 25 „und Finsternis“ Σ. Man erwartet <foreign xml:lang="abbr">ABBREV</foreign> κατὰ σκότος Empedokles</note>
 
 <pb n="v.3.pt.2.p.73"/>
-wegen, weil er ihn hat teilnehmen lassen am Guten, und (wenn) er in der Zucht
+wegen, weil er ihn hat teilnehmen lassen am Guten, und <supplied reason="undefined" resp="#editor">wenn</supplied> er in der Zucht
 der Gerechtigkeit aufwächst und sich vorher in dem Verkehr auf Erden um
 das himmlische Leben kümmert, — so warden schön, sobald er aus dem
 sterblichen Leben fortwandert und den Leib auszieht, die Engel Gottes ihm
 zur Geburt verhelfen, &lt;undx003E; sobald er zu einem anderen Leben geboren <lb n="5"/>
-ist, *warden ihn die guten Kräfte nach Art einer Amme aufnehmen,
+ist, <corr resp="#editor">warden</corr> ihn die guten Kräfte nach Art einer Amme aufnehmen,
 die göttlichen Heerscharen warden ihn erziehen, und der Logos Gottes,
 der Lehrer des Umgangs im Himmel, wird ihn wie einen geliebten
 Sohn zur Vollendung des Guten führen, ihn in der Lehre des Himmelreiches
@@ -1727,16 +1731,16 @@ unterrichten und ihn, sobald er ihn vollkommen und weise <lb n="10"/>
 gemacht hat, seinem Vater, dem König des Alls, übergeben und ein unaussprechliches
 Lichtgewand um seinen Leib und seine unvergängliche
 Seele legen, auf daß er fortan auch allen eine gemeinsame Hilfe werde.
-Aber das Ende dieses (Menschen) ist derart. Wer dagegen wider den Lauf
+Aber das Ende dieses <supplied reason="undefined" resp="#editor">Menschen</supplied> ist derart. Wer dagegen wider den Lauf
 seiner Natur tobt und an unschöner Verkehrung teil hat und die Erde, <lb n="15"/>
 den Logos Gottes, den gemeinsamen Erlöser aller, nicht kennt, Myriaden
 Väter aber, die nicht existieren, anstatt des Einen, der existiert, annimmt
 und diejenigen, die niemals existieren, Götter nennt anstatt des Einen, der
-allein *in Wahrheit existiert, und (wer) ferner überdies in die lüsternen, <lb n="20"/>
+allein <corr resp="#editor">in</corr> Wahrheit existiert, und <supplied reason="undefined" resp="#editor">wer</supplied> ferner überdies in die lüsternen, <lb n="20"/>
 ungesetzlichen Begierden dieser feuchten und vergänglichen οὐσία ganz
 und gar eintaucht und das keineswegs wie das Kind unfreiwillig, sondern
-freiwillig und auf den Rat seiner Freiheit, (wer) sich diese bösen
-(Dinge) erwählt und tut, wie sollte sein Ende offenkundig ein Abbild
+freiwillig und auf den Rat seiner Freiheit, <supplied reason="undefined" resp="#editor">wer</supplied> sich diese bösen
+<supplied reason="undefined" resp="#editor">Dinge</supplied> erwählt und tut, wie sollte sein Ende offenkundig ein Abbild
 des gezeigten Beispiels sein? Denn nicht warden ihn die fröhlichen <lb n="25"/>
 <milestone unit="altnumbering" n="34"/> Gesichter und das Lachen gutter Engel sehen, noch warden ihn, sobald er
 zum Lichte hervorgeht, die Kräfte Gottes als Ammen aufnehmen, sondern
@@ -1761,24 +1765,24 @@ Gesetze entsprach, obwohl er konnte.</p>
 
 <div type="textpart" subtype="chapter" n="73">
 <p>Denn das nach
-dem (gewählten) Beispiel (im Leibe) empfangene Kind ist in allem gering
+dem <supplied reason="undefined" resp="#editor">gewählten</supplied> Beispiel <supplied reason="undefined" resp="#editor">im Leibe</supplied> empfangene Kind ist in allem gering
 und ermangelt in allem der Draft, so daß es sich noch nicht einmal
 <lb n="5"/> des Denkens der Seele noch der Sinne des Leibes bedient. Der aber
-noch kndliche Verstand in den Menschen ist *gleichsam in prüfender
-Vergleichung mit den körperlosen, göttlichen &lt;und&lt; vernünftigen (Wesen)
+noch kndliche Verstand in den Menschen ist <corr resp="#editor">gleichsam</corr> in prüfender
+Vergleichung mit den körperlosen, göttlichen &lt;und&lt; vernünftigen <supplied reason="undefined" resp="#editor">Wesen</supplied>
 im Himmel mit Recht ganz und gar „kindlich” genannt worden. Und
 selbst wenn es „der Weiseste ist von allen Menschen” und selbst wenn
 <lb n="10"/> es der Vollkommenste ist von denen auf Erden, so ist er nichts besser
-als ein Kind, wenn er an sich selber mit seiner (späteren) Vollkommenheit
+als ein Kind, wenn er an sich selber mit seiner <supplied reason="undefined" resp="#editor">späteren</supplied> Vollkommenheit
 verglichen wird. Wie er aber in seiner Vorzüglichkeit wird, sobeald
-er zum Manne(salter) gekommen ist, ist leicht so zu prüfen: Denn wen er, bis jetzt noch Kind und in die feste Mauer der irdischen und
-<lb n="15"/> vergänglichen οὐσία eingeschlossen, solche Kraft der Vorzüglichkeit (in
-sich) trägt, daß  er keinswegs nur die (Dinge) auf Erden kennt und
-künstlerisch schafft, sondern (wenn er) sich auch dem Leben im Himmel,
-eben Gott, vorher anähnelt und, sobald er will, Abbilder der (Dinge)
+er zum Manne<supplied reason="undefined" resp="#editor">salter</supplied> gekommen ist, ist leicht so zu prüfen: Denn wen er, bis jetzt noch Kind und in die feste Mauer der irdischen und
+<lb n="15"/> vergänglichen οὐσία eingeschlossen, solche Kraft der Vorzüglichkeit <supplied reason="undefined" resp="#editor">in
+sich</supplied> trägt, daß  er keinswegs nur die <supplied reason="undefined" resp="#editor">Dinge</supplied> auf Erden kennt und
+künstlerisch schafft, sondern <supplied reason="undefined" resp="#editor">wenn er</supplied> sich auch dem Leben im Himmel,
+eben Gott, vorher anähnelt und, sobald er will, Abbilder der <supplied reason="undefined" resp="#editor">Dinge</supplied>
 im Himmel und auf Erden schafft &lt;und alles das, was kürzlich aufgezählt
 <lb n="20"/> ist, ebenso wirken kann, während er in den Kot des Leibes
-und Blutes getaucht ist, *wie müssen wir glauben, daß er (erst) wirken
+und Blutes getaucht ist, <corr resp="#editor">wie</corr> müssen wir glauben, daß er <supplied reason="undefined" resp="#editor">erst</supplied> wirken
 kann, sobald er Zum vollkommenen Maße der Reife des Mannes hervorgegangen
 ist und aus den schädlichen und vergänglichen, den flüssigen
 und feuchten Fesseln des Leibes gelöst ist und teil hat an dem unvergänglichen
@@ -1798,12 +1802,12 @@ der Pflanzer alles Guten seinen eigenen Samen empfängt und auf den
 
 <pb n="v.3.pt.2.p.75"/>
 seine eigene Pflanze tränkt und zur  Vollkommenheit aufzieht und zur
-Blüte von gewaltigen guten (Dingen) bringt.</p>
+Blüte von gewaltigen guten <supplied reason="undefined" resp="#editor">Dingen</supplied> bringt.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="74">
 <p>Du wirst aber
-die Größe der vorzüglichen Vollkommenheit des Menschen (im Unterschied)
+die Größe der vorzüglichen Vollkommenheit des Menschen <supplied reason="undefined" resp="#editor">im Unterschied</supplied>
 von dem hiesigne Wandel und sein Wachstum erkennen, wenn
 dul bedenkst, daß das eben geborne Kind nichts Besseres ist als ein <lb n="5"/>
 Wurm, da es nicht einmal  nach Art des unvernünftigen Tieres die Sinne
@@ -1820,16 +1824,16 @@ die ganze Welt betrachtet <add>und</add> der alle die Dinge auf Erden unterwirft
 Wenn aber jemand gleichsam durch einen Vergleich der Kraft
 Gottes und der Engle mit der des eben ggebornen Kindes in die Mitte
 den vollkommenen Mann stellen wollte, so ist eine völlige Übereinoder
-(des Verhältnisses) des Kindes zu dem  vollkommenen Mann <lb n="20"/>
-da das Wesen des Kindes viel mangelhafter ist als (das des) vollkommenen
+<supplied reason="undefined" resp="#editor">des Verhältnisses</supplied> des Kindes zu dem  vollkommenen Mann <lb n="20"/>
+da das Wesen des Kindes viel mangelhafter ist als <supplied reason="undefined" resp="#editor">das des</supplied> vollkommenen
 von der Kraft der engel. Denn das eben geborne menschliche
 Kind gleicht in seinem Wesen nicht einmal den eben gebornen unvernünftigen <lb n="25"/>
 Tieren. Wer aber zum vollkommenen Gemeinschaft mit dem
 göttlichen Geiste, redet mit den Engeln, gewinnt Zuneigung und Liebe
 <milestone unit="altnumbering" n="36"/> für den himmlischen verkehr und bereitet sich durch ein keusches und
 gottesfürchtiges Leben vorher vor für die  keineswegs in weiter Zeitferne <lb n="30"/>
-(liegende) Übereinstimmung mit den engeln, und wird an (ihrem) Leben
-und an (ihrer) Vorzüglichkeit teil haben, was auch der göttliche Logos
+<supplied reason="undefined" resp="#editor">liegende</supplied> Übereinstimmung mit den engeln, und wird an <supplied reason="undefined" resp="#editor">ihrem</supplied> Leben
+und an <supplied reason="undefined" resp="#editor">ihrer</supplied> Vorzüglichkeit teil haben, was auch der göttliche Logos
 zeigt,  indem er sagt: „ Was ist der Mensch, daß du sein wenig unter die
 Engel erniedrigt, hast ihn mit Ehre und Preis bekleide“.</p>
 </div>
@@ -1842,24 +1846,24 @@ zu der ihm gebührenden Nahrung und Erziehung gelangt, einen so
 <note type="footnote">16 „und“ &lt; lies <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.76"/>
-großen Wndel und Wechsel eingeht, und (wenn) niemand seinen Wanel
+großen Wndel und Wechsel eingeht, und <supplied reason="undefined" resp="#editor">wenn</supplied> niemand seinen Wanel
 bezeifeln kann wegen der Klarheit der Erfarung, wei dürfen wir uns
 da wundern, wenn auch der vollkommene Verstand im Menschen, der
-(schon) derart ist, solange er noch Kind ist im vergleich zu der Vollendung
+<supplied reason="undefined" resp="#editor">schon</supplied> derart ist, solange er noch Kind ist im vergleich zu der Vollendung
 <lb n="5"/> seiner vorzüglichen Größe, mit den Engeln übereinstimmend
 wird, sobald er zur Vollendung des Wachstums seiner ihm eigenen Gestalt
 vorankommt? Aber wir sehen, daß im Tode die Natur des Menschen
-aufgelöst wird. Doch was (bedeutet) dies? Werden wir darum
-nicht umsomehr (in dem Glauben) betreffs der unsterblichen Seele bestärkt?
+aufgelöst wird. Doch was <supplied reason="undefined" resp="#editor">bedeutet</supplied> dies? Werden wir darum
+nicht umsomehr <supplied reason="undefined" resp="#editor">in dem Glauben</supplied> betreffs der unsterblichen Seele bestärkt?
 <lb n="10"/> Denn wenn sie, während sie in den vergänglichen und sterblichen
 Leib getaucht ist, so große Kraft der Vorzüglichkeit beweist —
 was unser Sermon vorher gezeigt hat —, wie sollte sie nicht dann,
 wenn sie von der Gemeinschaft des Vergänglichen abgesondert ist und
 das Sterbliche wie eine Fessel abgelegt hat, mehr als jetzt mit ihrer
 <lb n="15"/> ngehinderten Kraft wirken? Siehst du nicht, daß sie solange böse
-handelt, als sie Liebe zum Leibe besitzt, (dann) aber, wenn sie seine
+handelt, als sie Liebe zum Leibe besitzt, <supplied reason="undefined" resp="#editor">dann</supplied> aber, wenn sie seine
 Gemeinschaft verleugnet, für sich selbst existiert? Daraus kann ihre
-eigene οὐσία klar erkannt warden, daß *sie keineswegs Körper ist. Denn
+eigene οὐσία klar erkannt warden, daß <corr resp="#editor">sie</corr> keineswegs Körper ist. Denn
 wie kann das, was dem Leibe entgegengesetzt ist, von derselben Natur
 <lb n="20"/> sein? Denn gesund sind die Gedanken der Seele, solange als die Leidenschaften 
 des Leibes schwach sind; sie wird aber finster und dunkel, so
@@ -1878,23 +1882,23 @@ ihr Antilitz wegwendet. Aber sie halt es nicht einmal für würdig, sich
 den Augen des Leibes zu nähern noch durch seine anderen Sinne zu
 <lb n="35"/> wirken, solange sie über die Vorzüglichkeit nachsinnt. So oft sie aber
 kräftig sich verschließt und sich innerlich sammelt und weit weggeht
-<note type="footnote">5 „seiner“] „ihrer“ (der Engel) Σ. Falsches Explizitum 17 „für sich selbst
+<note type="footnote">5 „seiner“] „ihrer“ <supplied reason="undefined" resp="#editor">der Engel</supplied> Σ. Falsches Explizitum 17 „für sich selbst
 existiert“] ist hinter <foreign xml:lang="abbr">ABBREV</foreign> etwas ausgefallen? Etwa „in sich selber <add>gut</add> wird“;
 vgl. Z. 26 dagegen 773 18 man erwartet <foreign xml:lang="abbr">ABBREV</foreign> 31 „Reichtum“ Σ, lies vll.
 <foreign xml:lang="abbr">ABBREV</foreign> = κατασκευή „Αnlage“</note>
 
 <pb n="v.3.pt.2.p.77"/>
-von dem, was de Sinnen nahe ist und erscheint, und (so oft) sie dem
+von dem, was de Sinnen nahe ist und erscheint, und <supplied reason="undefined" resp="#editor">so oft</supplied> sie dem
 Leibe oben nur nahe ist und mit dem seelischen Auge vielmehr sich
 nach der anderen Seite wendet und in sich einsam ist, dann wiederum
 beiient sie sich sines leuchtenden Verstandes und reineen Gedäcchtnisses,
-(dann) geht eine Vernunft hervor, die nicht trübe ist, und tränkt sie, <lb n="5"/>
+<supplied reason="undefined" resp="#editor">dann</supplied> geht eine Vernunft hervor, die nicht trübe ist, und tränkt sie, <lb n="5"/>
 und alle vernünftigen Kräfte wirken ungehindert. Wenn aber plötzlich
 etwas sie ereilt von dem, was den Leib schäigt, so trübt das, wie ein
 Splitter die Sehkraft der Augen raubt, auf der Stelle die Sehkraft der
-Seele. Wenn sie aber (ganz) schlaff wird &lt;und&lt; sich dem Leibe hingibt
+Seele. Wenn sie aber <supplied reason="undefined" resp="#editor">ganz</supplied> schlaff wird &lt;und&lt; sich dem Leibe hingibt
 und dann an trunkenheit, Nahrung, Begierden und den übrigen Genüssen <lb n="10"/>
-des Leibes teil hat, in sich schwach gegürtet, *so wird nach Art eines
+des Leibes teil hat, in sich schwach gegürtet, <corr resp="#editor">so</corr> wird nach Art eines
 bösen und wilden Tieres der vergängliche Leib wider sie auftreten, sie
 aber wird nach unten in die Tiefe weichen und voll warden von Irrtum,
 Unverstand und aller Torheit. Was haben wir also nötig, uns vor dem
@@ -1902,19 +1906,19 @@ trennendden Tode zu fürchten, dem Befreeier der Seele vom Leibe? Und <lb n="15"
 warum sollen wir das Ablegen des schlechteren nicht zur Hilfe des
 Besseren annehmen und bekennen, daß dann in Wahrheeit rein und selig
 das leben der Gottliebenden sein werde, sobald nichts von entgegengesetzter
-(Natur) sie hindert? Denn wenn er, während die vernünftige
+<supplied reason="undefined" resp="#editor">Natur</supplied> sie hindert? Denn wenn er, während die vernünftige
 Natur an diesem Ort und in diesem Gafäß ist und auf Erdden wohnt und <lb n="20"/>
-mit einem dichten und irddischen Leibe nach Art von etwas *Tönernem
+mit einem dichten und irddischen Leibe nach Art von etwas <corr resp="#editor">Tönernem</corr>
 Bekleidet ist, so sehr trotz seines Gewandes sich anstrengt, daß er im
 Geeiste in die Höhe springt und die Glieder des  Leibes samt den Begierden
 durch enthaltsamkeit und Unterdrückung der Begierden tötet
 und vielmehr eifrig sich müht un bemüht um das Leben der Leiblosen, <lb n="25"/>
 sich hunter Führung der Weisheeit zu jeder Zeit absondert und
 frei macht von der Mischung des Schlechteren, und bereits vorher
-zu jeder Zeit *sich übt zu sterben, falls er einmal vonseinen fesseln
-<milestone unit="altnumbering" n="38"/> gelöst wird, *so wird er Schwingen wachsen lassen infloge seiner
+zu jeder Zeit <corr resp="#editor">sich</corr> übt zu sterben, falls er einmal vonseinen fesseln
+<milestone unit="altnumbering" n="38"/> gelöst wird, <corr resp="#editor">so</corr> wird er Schwingen wachsen lassen infloge seiner
 hiesigen Fürsorge und Übung, dann bei seinem Ende fliegen, den Ort <lb n="30"/>
-auf Erden vertauschen und (im Himmel) das treffen, was er liebt. Wie
+auf Erden vertauschen und <supplied reason="undefined" resp="#editor">im Himmel</supplied> das treffen, was er liebt. Wie
 das geschehen wirdd, frage nicht! Denn der Verkehr mit den Engeln im
 Himmel, dessen er gewürdigt ist, wird dann, sobald er an seinem Leeibe,
 dessen Natur sich von der Vergänglichkeit zur Unvergänglichkeit ändert,
@@ -1926,21 +1930,21 @@ und eilt“ Σ = σπεύδει καὶ σπουδάζει 28 „sich übt“] �
 abbrav vor Abbrav</note>
 
 <pb n="v.3.pt.2.p.78"/>
-*das Bild des Lichtes und das Bild des Glanzes empfangen hat, eintreten
+<corr resp="#editor">das</corr> Bild des Lichtes und das Bild des Glanzes empfangen hat, eintreten
 in der Art, in der auch das Geschlecht der göttlichen Engel lebt, entsprechend 
-der (im Menschen) eingeschlossenen Vernunft. Natürlich wird
+der <supplied reason="undefined" resp="#editor">im Menschen</supplied> eingeschlossenen Vernunft. Natürlich wird
 er auch teil haben an der Vorzüglichkeit jener zumal und an der Unsterblicheit.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="76">
 <lb n="5"/><p>Denn wie be idem Samen, der auf die Erde
 fällt, die Triebkraft, — der sogenannte Keim, — derart ist, daß sie den
-moisten verborgen liegt, sie, die zwar jetzt in dem Samen *eingeengt,
+moisten verborgen liegt, sie, die zwar jetzt in dem Samen <corr resp="#editor">eingeengt</corr>,
 aber ruhig nach Art eines Funkens drinnen im dichten Leibe eingeschlossen 
-ist, und (wie) eben dieser Same, sobald er in die Erde fällt
+ist, und <supplied reason="undefined" resp="#editor">wie</supplied> eben dieser Same, sobald er in die Erde fällt
 <lb n="10"/> und sein dichtes, ihn außen umgebendes Gewand in Vergänglichkeit 
-aufgelöst wird, dann als lebendig sich erweist, und (wie) er die Kraft, die
-in ihm (liegt), bewegt und von der ὕλη unter sich nimmt, und (wie) er
+aufgelöst wird, dann als lebendig sich erweist, und <supplied reason="undefined" resp="#editor">wie</supplied> er die Kraft, die
+in ihm <supplied reason="undefined" resp="#editor">liegt</supplied>, bewegt und von der ὕλη unter sich nimmt, und <supplied reason="undefined" resp="#editor">wie</supplied> er
 äußere alte und dichte Gewand anuszieht, und vielmehr ein neues anlegt,
 <lb n="15"/> das besser ist als das alte,</p>
 </div>
@@ -1948,24 +1952,24 @@ in ihm (liegt), bewegt und von der ὕλη unter sich nimmt, und (wie) er
 <div type="textpart" subtype="chapter" n="77">
 <p>demgemäß ist auch die Natur der
 vernünftigen Kraft im Menschen, die jetzt an den vergänglichen Leib
-* gebunden ist und schlechter als die ihr eigentümliche Kraft wirkt.
+<corr resp="#editor">gebunden</corr> ist und schlechter als die ihr eigentümliche Kraft wirkt.
 Wenn sie aber von dem Vergänglichen befreit wird, das sie umgibt,
 und den Platz im Himmel erhält and von da an im jenseitigen Verkehr
-<lb n="20"/> gesät und gepflanzt und des himmlischen Gewandes *der Engel würding
+<lb n="20"/> gesät und gepflanzt und des himmlischen Gewandes <corr resp="#editor">der</corr> Engel würding
 wird — wie es sein wird, sobald sie des reinen Lebens teilhaftig geworden
 und von  der Gemeinschaft mit dem STerblichen befreit ist, habe
 ich nicht nötig zu sagen. Es liegt aber für jeden, der sechen will, nahe,
-(es) aus dem (oben erwähnten) Beispiel (zu erkennen). Denn nicht wird
-<lb n="25"/> der genze Weizen vernichtet, sondern (nur) das Äußere wird vernichtet,
+<supplied reason="undefined" resp="#editor">es</supplied> aus dem <supplied reason="undefined" resp="#editor">oben erwähnten</supplied> Beispiel <supplied reason="undefined" resp="#editor">zu erkennen</supplied>. Denn nicht wird
+<lb n="25"/> der genze Weizen vernichtet, sondern <supplied reason="undefined" resp="#editor">nur</supplied> das Äußere wird vernichtet,
 sobald es auf die Erde fällt. Der innen verborgene Trieb aber und die
-lebendige Kraft in ihm ist und bleibt lebending, und er (der Weizen)
-wird besser als er (war), sodaß er auch lebendige Ähren gibt. Eine
+lebendige Kraft in ihm ist und bleibt lebending, und er <supplied reason="undefined" resp="#editor">der Weizen</supplied>
+wird besser als er <supplied reason="undefined" resp="#editor">war</supplied>, sodaß er auch lebendige Ähren gibt. Eine
 und dieselbe ist die Triebkraft der Pflanzen und aller Keime ebenso.
 <lb n="30"/> Und nur der Mensch sollte gnz und in allem vernichtet warden, sobald
 er im Tode aufgelöst wird? Und zugleich mit dem äußeren 
 Gewande sollte auch die innen ihm wohnende Vernunft vernichtet
 warden? Und das unkörperliche wissen, das sich mit allen diesen
-Kräften vereinigt (und) das sich um seiner Vorzüglichkeit willen Gott
+Kräften vereinigt <supplied reason="undefined" resp="#editor">und</supplied> das sich um seiner Vorzüglichkeit willen Gott
 <note type="footnote">1 „und das Bild“ Σ streiche (??) vor (??) 5 „bei“ wörtlich: „auf“ 
 6 „Triebkraft“ wörtlich λόγος,vgl.unten die Parallele zum Logos der Menschen
 7 „die in dem Samen notwending ist“ Σ aber lies( ??) nacg Σ 397 17 „bindet“
@@ -1974,8 +1978,8 @@ man (??) 32 Der syr. Übersetzer denkt an den  persönlichen Logos, da er das
 Mask. gebraucht</note>
 
 <pb n="v.3.pt.2.p.79"/> 
-<milestone unit="altnumbering" n="39"/> angeähnelt hat, sollte nicht einmal sein wie die Samen(körner), die zur
-Erde fallen? Oder (ist der Mensch) nicht viel besser? Denn er trägt
+<milestone unit="altnumbering" n="39"/> angeähnelt hat, sollte nicht einmal sein wie die Samen<supplied reason="undefined" resp="#editor">körner</supplied>, die zur
+Erde fallen? Oder <supplied reason="undefined" resp="#editor">ist der Mensch</supplied> nicht viel besser? Denn er trägt
 Keineswegs Grannen noch Gräser, sondern die vollkommenen und dichten
 Ähren seiner Vorzüglichkeit, dann wenn er dem irdischen Verderben
 entrinnt, sowie er von den Fesseln befreit ist und keineswegs unverständig <lb n="5"/>
@@ -1990,18 +1994,18 @@ Leibe eingeschlossen und wie in einem Ofen eingeengt war.</p>
 Sermon zum Folgenden kommen. Wenn also der Mensch, der im Verkehr
 auf Erden aufgewachsen ist, seine eigene Größe kennte und sich
 kümmerte um die Lehre Gottes, so gäbe es kein Hindernis für ihn, sobald
-er von hier entronnen ist, am (gleichen) Verkehr wie die Engel <lb n="15"/>
+er von hier entronnen ist, am <supplied reason="undefined" resp="#editor">gleichen</supplied> Verkehr wie die Engel <lb n="15"/>
 sich zu ergötzen und teil zu haben am königlichen Leben sienes Vaters
 im Himmel. Deswegen aber, weil weder Ein Mensch noch zweie noch
 mehr oder weniger, sondern das ganze vernünftige Geschlecht auf Erden
 die Kraft selbständiger herrschaft empfangen hat, weil seine Natur frei
-ist *und vom göttlichen Logos, dem König, den königlichen Samen <lb n="20"/>
+ist <corr resp="#editor">und</corr> vom göttlichen Logos, dem König, den königlichen Samen <lb n="20"/>
 empfangen hat, hat er nicht gut die ihm eigene Kraft gebraucht, sondern
 hat all das andere, was zum Nutzen des leibes notwendig ist und das
 Leben unterstützt, durch Berufsuissenschaften in all seiner Hoffart verarbeitet,
 hat ersonnen die Bebauung des Bodens, die Herstellung von
-Schiffen, den Handel, den Besitzerwerb, ud nicht nur (dies), sondern <lb n="25"/>
-er hat sich auch großen Überfluß *und hinlänglichen Reichtum an Begierden
+Schiffen, den Handel, den Besitzerwerb, ud nicht nur <supplied reason="undefined" resp="#editor">dies</supplied>, sondern <lb n="25"/>
+er hat sich auch großen Überfluß <corr resp="#editor">und</corr> hinlänglichen Reichtum an Begierden
 aller Art von überallher vollauf verschafft. All das aber, was
 auf die Erlösung der Seele und auf ein gottgeliebtes Leben der Gerechtigkeit
 hinzielt, eben das hat er mit Stumpf und Stiel aus seinem
@@ -2012,7 +2016,7 @@ hat die Gerechtigkeit seines Vaters im Himmel und sein Lob
 vernachlässigt und hat die unvernünftigen Antriebe des Wahnsinns und
 der Phantasie ausgesucht, was die törichtsten der Kinder zu tun pflegen, <lb n="35"/>
 <milestone unit="altnumbering" n="40"/> die die fürsorgliche Lehre und Zucht derer fliehen, die ihr Denken
-*groß gemacht haben. Das, was für den Augenblich angenehm ist,
+<corr resp="#editor">groß</corr> gemacht haben. Das, was für den Augenblich angenehm ist,
 <note type="footnote">20 Statt <foreign xml:lang="abbr">ABBREV</foreign> „die“ lies <foreign xml:lang="abbr">ABBREV</foreign> „und“ 23 „berufswissenschaften“ vgl.zu S. 6611
 26 Statt <foreign xml:lang="abbr">ABBREV</foreign> (Genitiv) lies <foreign xml:lang="abbr">ABBREV</foreign> „und“ 34 Gemeint sind die Antriebe zum Götzendienst
 37 „lang gemacht haben“ Σ aber lies <foreign xml:lang="abbr">ABBREV</foreign></note>
@@ -2020,14 +2024,14 @@ der Phantasie ausgesucht, was die törichtsten der Kinder zu tun pflegen, <lb n=
 <pb n="v.3.pt.2.p.80"/>
 aber die Seelen und Leiber zumal verderbt, ehren sie bei weitem
 mehr und erjagem sich Irrtum und törichte Wissenschaft zur eitlen und un-
-verständiegen Ergötzung. Während so alle Menschen *in der Vermehrung
+verständiegen Ergötzung. Während so alle Menschen <corr resp="#editor">in</corr> der Vermehrung
 des Bösen sich benfinden, stellt ihnen der Neider, der das Gute haßt,
 <lb n="5"/> und der Schädiger des Schönen nach und eben dieser bereitet in seinem
-bösen Neide Netze und Schlingen und viellistige *Intriguen aller Art
+bösen Neide Netze und Schlingen und viellistige <corr resp="#editor">Intriguen</corr> aller Art
 wider die Erlösung aller in Gemeinschaft mit den bösen Dämonen und
-treibt sie von oben in die Tiefen des Bösen, damit alle, die auf Erden (sind), nicht sehen, sondern übersehen sollten das Gesetz ihrer Natur,
-<lb n="10"/> und (damit) die Frucht des Bösen an Stelle des Samens der Vorzüglich-
-keit *erblühe. (So) fiel derjenige, der der allerfriedlichste, weiseste und vernünftigste war von allen auf Erden, in die äußerste Wildheit und
+treibt sie von oben in die Tiefen des Bösen, damit alle, die auf Erden <supplied reason="undefined" resp="#editor">sind</supplied>, nicht sehen, sondern übersehen sollten das Gesetz ihrer Natur,
+<lb n="10"/> und <supplied reason="undefined" resp="#editor">damit</supplied> die Frucht des Bösen an Stelle des Samens der Vorzüglich-
+keit <corr resp="#editor">erblühe</corr>. <supplied reason="undefined" resp="#editor">So</supplied> fiel derjenige, der der allerfriedlichste, weiseste und vernünftigste war von allen auf Erden, in die äußerste Wildheit und
 Unvernunft, so daß einer von den Gettliebenden über die Katastrophe
 seines Falles weint, ausruft und spricht: „Der Mensch in seiner Ehre
 15 hatte keine Einsicht, sondern wurde dem Tiere gleichgemacht und ihm
@@ -2059,10 +2063,10 @@ der Menschen und Gott als Helfer, der allein Uberflu? zu geben vermag
 denen, die in Verzweiflung, und Leben denen, die dem Tode verfallen
 sind, und das Kommen Gottes und die gOttliche Offenbarung <lb n="5"/>
 eben des gemeinsamen Erlosers aller-von ihm sagen wir, da? er notwendig
-den Menschen aufleuchtete, weil durch den au?ersten (Grad)
+den Menschen aufleuchtete, weil durch den au?ersten <supplied reason="undefined" resp="#editor">Grad</supplied>
 des Bosen, durch die Tiefe des gottlosen Irrtums, durch den Wahnsinn
 des Polytheismus und durch den eifrigen Neid der Damonen alles, was
-auf Erden (ist), verderbt war.</p>
+auf Erden <supplied reason="undefined" resp="#editor">ist</supplied>, verderbt war.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="2">
@@ -2078,10 +2082,10 @@ wenden.</p>
 <p>Denn lag es nicht auf dem Menschen wie eine Krankheit, die
 wider alle machtig wurde? Aber uber alles Bose und Scheuliche hinaus
 fuhrte <add>und</add> weidete nach Art einer todbringenden Seuche das ganze
-menschliche Geschlecht der bose Damon so (sehr), da? er den (Menschen), <lb n="20"/>
-der der allerfriedlichste war, zu dem au?ersten (Grade) der Wildheit
-trieb und (da?) der Vernunftigste der Allerunvernunftigste wurde. Seitdem
-kannten die Menschen in der Blindheit ihrer Seelen nicht (mehr)
+menschliche Geschlecht der bose Damon so <supplied reason="undefined" resp="#editor">sehr</supplied>, da? er den <supplied reason="undefined" resp="#editor">Menschen</supplied>, <lb n="20"/>
+der der allerfriedlichste war, zu dem au?ersten <supplied reason="undefined" resp="#editor">Grade</supplied> der Wildheit
+trieb und <supplied reason="undefined" resp="#editor">da?</supplied> der Vernunftigste der Allerunvernunftigste wurde. Seitdem
+kannten die Menschen in der Blindheit ihrer Seelen nicht <supplied reason="undefined" resp="#editor">mehr</supplied>
 den allerhochsten gott, die Ursache und den Verfertiger des Alls den
 verehrungswurdigen Namen der eingebornen, anfangslosen Natur, ihn, <lb n="25"/>
 der vor allem ist, den Logos Gottes, den Vater des geistigen und vernunftigen Seins, den Herrscher im Himmel und auf Erden, ihn, der
@@ -2096,7 +2100,7 @@ jederzeit der Welt nahe und in ihr ist, der allem die Ursache alles
 Guten ist, die Vorsehung, den Erlöser, den Fürsorger, den Geber des
 Regens, den Spender des Lichts, den Fürsten des Lebens und den
 Schöpfer dieses Alls, sondern legten der Sonne, dem Monde, dem Himmel <milestone unit="altnumbering" n="42"/>
-<lb n="5"/> selbst und den Gestirnen den Namen der Verehrung (d. h. Gottes) bei.
+<lb n="5"/> selbst und den Gestirnen den Namen der Verehrung <supplied reason="undefined" resp="#editor">d. h. Gottes</supplied> bei.
 Aber nicht einmal hierbei blieben sie stehen,</p>
 </div>
 
@@ -2112,7 +2116,7 @@ blieben sie stehen;</p>
 
 <div type="textpart" subtype="chapter" n="5">
 <p>sie vielmehr  machten auch die irdische Natur,
-die Früchte, die aus der Erde (sprossen), und die mannigfachen Nahrungsmittel
+die Früchte, die aus der Erde <supplied reason="undefined" resp="#editor">sprossen</supplied>, und die mannigfachen Nahrungsmittel
 des Leibes zu Göttern <add>und</add> machten Demeter, Kore, Dionysos
 <lb n="15"/> und auderes ihnen Verwandte zu Götzen. Aber nicht einmal hierbei
 blieben sie stehen,</p>
@@ -2120,20 +2124,20 @@ blieben sie stehen,</p>
 
 <div type="textpart" subtype="chapter" n="6">
 <p>sondern sie zögerten auch nicht, die Gedanken
-ihres Geistes und eben das Wort, den Dolmetscher jener (Gedanken),
+ihres Geistes und eben das Wort, den Dolmetscher jener <supplied reason="undefined" resp="#editor">Gedanken</supplied>,
 Götter zu nennen, ihren Geist aber nannten sie Athene und ihr Wort
-Hermes und die der Lehren fähigen Kräfte (des Geistes) nannten sie
+Hermes und die der Lehren fähigen Kräfte <supplied reason="undefined" resp="#editor">des Geistes</supplied> nannten sie
 <lb n="20"/> Mnemosyne und Musen. Aber nicht einmal hierbei blieben sie stehen;</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="7">
 <p>indem sie vielmehr wuchsen in der Vielheit des Betruges und in
-der Größe des Frevels, machten sie ihre eigenen Leidenschaften, die *sie
+der Größe des Frevels, machten sie ihre eigenen Leidenschaften, die <corr resp="#editor">sie</corr>
 fortstoßen und mit keuschem Sinn heilen sollten, — sie machten diese zu
 Göttern <add>und</add> nannten ihre eigene Begierde, die  lüsterne und leidenschaftliche
 <lb n="25"/> Krankheit der Seelen, die Glieder und Teile des Leibes, die
-zu schändlichem Tun hinziehen und ferner den Wahnsinn, der zu *schändlichen
-Lüsten (führt): Eros, Priepos, Aphrodite und andere, die diesen
+zu schändlichem Tun hinziehen und ferner den Wahnsinn, der zu <corr resp="#editor">schändlichen</corr>
+Lüsten <supplied reason="undefined" resp="#editor">führt</supplied>: Eros, Priepos, Aphrodite und andere, die diesen
 verwandt sind. Aber nicht einmal hierbei blieben sie stehen,</p>
 </div>
 
@@ -2152,16 +2156,16 @@ l. vielleicht <foreign xml:lang="abbr">ABBREV</foreign> 26 l. <foreign xml:lang=
 „ausschweifenden“ Σ; l. <foreign xml:lang="abbr">ABBREV</foreign> = αἰσχρῶν L</note>
 
 <pb n="v.3.pt.2.p.83"/>
-sie nach dem gemeinsamen Tode als Halbgötter (ἡμίθεοι) und Götter
+sie nach dem gemeinsamen Tode als Halbgötter <supplied reason="undefined" resp="#editor">ἡμίθεοι</supplied> und Götter
 <add>und</add>  glaubten, daß um die Gräber und Grabmale das göttliche
-(und) unsterbliche Sein schweife. Aber nicht einmal hierbei blieben
+<supplied reason="undefined" resp="#editor">und</supplied> unsterbliche Sein schweife. Aber nicht einmal hierbei blieben
 sie stehen,</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="9">
 <p>sondern sie ehrten auch die mannigfachen Arten der
 unvernünftigen Tiere und das schädliche Gewünrm mit dem verehrungswürdigen <lb n="5"/>
-Namen (Gott). Aber nicht einmal hierbei blieben sie stehen,</p>
+Namen <supplied reason="undefined" resp="#editor">Gott</supplied>. Aber nicht einmal hierbei blieben sie stehen,</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="10">
@@ -2174,16 +2178,16 @@ der Götter bei. Aber nicht einmal hierbei blieben sie stehen,</p>
 
 <div type="textpart" subtype="chapter" n="11">
 <p>sondern
-sie legten auch den Dämonen, die in die (Götzen)bilder kriechen und
+sie legten auch den Dämonen, die in die <supplied reason="undefined" resp="#editor">Götzen</supplied>bilder kriechen und
 in den finstern innersten Winkel eingetaucht sind <add>und</add> an den Spenden
-und dem Fett der Opfer lecken, *eben denselben Namen der Götter bei.
+und dem Fett der Opfer lecken, <corr resp="#editor">eben</corr> denselben Namen der Götter bei.
 Aber nicht einmal hierbei blieben sie stehen,</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="12">
-<p>sondern (eben) sie <lb n="15"/>
+<p>sondern <supplied reason="undefined" resp="#editor">eben</supplied> sie <lb n="15"/>
 zogen auch mit gewissen Knoten verwerflicher Zauberei, mit zwingenden
-(und) ungesetzlichen Gesängen und Besprechungen die unsichtbaren
+<supplied reason="undefined" resp="#editor">und</supplied> ungesetzlichen Gesängen und Besprechungen die unsichtbaren
 Kräfte, die in der Luft fliegen, als Genossen sich herbie und benutzten
 dann eben sie als Helfer wider den Irrtum der Götter, die sie gemacht
 hatten. Die einen also vergötterten andere sterbliche Menschen. Denn <lb n="20"/>
@@ -2194,7 +2198,7 @@ ihnen ähnliche Menschen für Götter gehalten. Die aber, die im Übermaß
 der Weisheit der Erfindung der Geometrie, der Astronomie und <lb n="25"/>
 Arithmetik sich rühmten, kannten nicht und die Weisen verstanden
 nicht, bei sick abzuwägen und zu überlegen den Unterschied des Maßes
-der Kraft Gottes von der sterblichen (und) unvernünftigen Natur. Deswegen
+der Kraft Gottes von der sterblichen <supplied reason="undefined" resp="#editor">und</supplied> unvernünftigen Natur. Deswegen
 zögerten sie nicht, alle Arten scheußlicher Lebewesen und die
 <note type="footnote">2 vgl. Platon Phaidon 81 C. D</note>
 <note type="footnote">1 ἡμιθέους Σ ἥρωας L 2 1. <foreign xml:lang="abbr">ABBREV</foreign> und <foreign xml:lang="abbr">ABBREV</foreign> mit
@@ -2209,35 +2213,35 @@ benutzten –20 hatten “&lt; L 22 ἡμιθέων Σ ἡρώων L 27 στα
 <pb n="v.3.pt.2.p.84"/>
 mannigfachen Geschlechter der Tiere und der giftspritzenden Schlangen
 und die wilden Tiere Götter zu nennen. Die Söhne der Phöniker aber
-nannten den *Melkathros und Ousoros und ferner einige andere sterbliche
+nannten den <corr resp="#editor">Melkathros</corr> und Ousoros und ferner einige andere sterbliche
 Menschen, die verachtter waren als diese, Götter, die Söhne der
-<lb n="5"/> Araber aber den Dusares und Obdos, die Gothen den *Zamolxis, die
+<lb n="5"/> Araber aber den Dusares und Obdos, die Gothen den <corr resp="#editor">Zamolxis</corr>, die
 Kiliker den Mopsos, die Thebaner den Amphiareos, und bei anderen
 wiederum ehrte man andere mit dem Namen der Gotter, die ihrer Natur
 nach sich in nichts unterschieden von den Sterblichen, sondern in Wahrheit
 allein dies: Menschen waren.</p>
 </div>
 <lb n="10"/>  <div type="textpart" subtype="chapter" n="13">
-<p>Allzumal also Ägypter, Phöniker, Griechen (und) das ganze
+<p>Allzumal also Ägypter, Phöniker, Griechen <supplied reason="undefined" resp="#editor">und</supplied> das ganze
 sterbliche Geschlecht, soweit der Glanz Sonne leuchtet, haben die <milestone unit="altnumbering" n="44"/>
 Teile der Welt, die στοιχεῖα, die Früchte, die aus der Erde sprossen,
 ihre eigenen Leidenschaften, ferner auch den dämonischen Wahnsinn
-und die (dämonischen) Phantasien und vor diesen die sterblichen
-<lb n="15"/> Menschen, die die menschlichen *Zufálligkeiten benutzten und weder
+und die <supplied reason="undefined" resp="#editor">dämonischen</supplied> Phantasien und vor diesen die sterblichen
+<lb n="15"/> Menschen, die die menschlichen <corr resp="#editor">Zuf</corr>álligkeiten benutzten und weder
 Schulen der Tugend zu ihren Lebzeiten gründeten noch die Lehren eines
-keuschen Lebens ersannen, (die) keine philosophischen Dogmen aufwiesen,
+keuschen Lebens ersannen, <supplied reason="undefined" resp="#editor">die</supplied> keine philosophischen Dogmen aufwiesen,
 kein hilfreiches Werk erfanden, keine Schüler der Tugend zurückließen,
 keine Worte und keine Schriften tradierten, die zu einem guten Leben
-<lb n="20"/> stimmten, (Männer) die sich kümmerten um Weiber und schändliche
-Lüste, (haben sie) &lt;ohne Grund&lt; und aufs Geratewohl, ich weiß nicht
+<lb n="20"/> stimmten, <supplied reason="undefined" resp="#editor">Männer</supplied> die sich kümmerten um Weiber und schändliche
+Lüste, <supplied reason="undefined" resp="#editor">haben sie</supplied> &lt;ohne Grund&lt; und aufs Geratewohl, ich weiß nicht
 durch welche Verführung dämonischer Wirksamkeit, Götter und Halbgötter
 genannt und durch Opfer und Dienste mitsamt dem zauberischen
-Betrug geehrt, haben (ihnen) Tempel und Heiligtümer in den Städten
+Betrug geehrt, haben <supplied reason="undefined" resp="#editor">ihnen</supplied> Tempel und Heiligtümer in den Städten
 <lb n="25"/> und Dörfern gebaut; ihn aber, der allein jenseits der Welt ist, den
 wahrhaftigen Logos Gottes, den Allkönig und Allschöpfer haben sie für
 nichts geachtet. Eben sie aber nahmen so sehr zu an Wahnsinn und
 Verstandesverderbtheit, daß sie auf der Stelle Menschen, welche sie
-(zufällig) trafen, Götter nannten und auf der Stelle eben denselben die
+<supplied reason="undefined" resp="#editor">zufällig</supplied> trafen, Götter nannten und auf der Stelle eben denselben die
 <lb n="30"/> Leidenschaften der Sterblichen anhängten und eben denselben ungesetzliche
 Ehebrüche, schändliche Taten, ein verkehrtes Leben und Tod bei-
 <note type="footnote">1 Melquthrurun Σ, 1. <foreign xml:lang="abbr">ABBREV</foreign> Μελκάθαρον L 5 Ὄβοδον und Ὄβδον
@@ -2250,10 +2254,10 @@ Anteilnahme an den Taten der Dämonen“ Σ = δαιμονικῆς συνεργ
 verkehrtes Leben“] ζωῆς τε καταστροφὰς καὶ θανάτους L</note>
 
 <pb n="v.3.pt.2.p.85"/>
-legten. Und obwohl sie (selbst) derartiges sagen, das keineswegs von anderen verleumderisch
-behauptet wird, sondern (obwolh) sie selbst Zeugen dafür
+legten. Und obwohl sie <supplied reason="undefined" resp="#editor">selbst</supplied> derartiges sagen, das keineswegs von anderen verleumderisch
+behauptet wird, sondern <supplied reason="undefined" resp="#editor">obwolh</supplied> sie selbst Zeugen dafür
 sind und Irrtum, TRauer und Tod und vor diesen Ehebruch, Schändung
-der Männer und Raub der Weiber (von ihren Göttern) bekannten, füllten
+der Männer und Raub der Weiber <supplied reason="undefined" resp="#editor">von ihren Göttern</supplied> bekannten, füllten
 sie nichts desto weniger alle Städte, Dörfer und Länder mit Tempeln, <lb n="5"/>
 Bildern und Heiligtümern.</p>
 </div>
@@ -2261,15 +2265,15 @@ Bildern und Heiligtümern.</p>
 <div type="textpart" subtype="chapter" n="14">
 <p>Und nicht nur dies, sondern sie
 Nahmen auch aus den Worten, die sie über ihre Götter machten, die
-Hilfsmittel zu (eigenem) schändlichen und widergesetzlichen Leben und
+Hilfsmittel zu <supplied reason="undefined" resp="#editor">eigenem</supplied> schändlichen und widergesetzlichen Leben und
 Verderbten durch alle Arten der Lüsternheit zumal ihre Leiber und
 Seelen zusammen. Welcher Art das war, was sie taten indem sie sich <lb n="10"/>
 Ihren Göttern anähnelten, können wir aus der Nähe an dem uns benachbarten
 Phönizien betrachten, indem wir sehen, was bis jetzt in
-<milestone unit="altnumbering" n="45"/> Baalbek *geschieht, wie dort die Überbleibsel der alten (Dämonen- )
+<milestone unit="altnumbering" n="45"/> Baalbek <corr resp="#editor">geschieht</corr>, wie dort die Überbleibsel der alten <supplied reason="undefined" resp="#editor">Dämonen- </supplied>
 Schäden und die Spuren des verderblichen Bösen bis jetzt wirksam
-Sind, sodaB die dortigen Frauen sich nicht eher in gesetzlicher (Ehe- ) <lb n="15"/>
-Gemeinschaft verbinden, als bis sie zuvor durch auBergesetzliche (Verderbung
+Sind, sodaß die dortigen Frauen sich nicht eher in gesetzlicher <supplied reason="undefined" resp="#editor">Ehe- </supplied> <lb n="15"/>
+Gemeinschaft verbinden, als bis sie zuvor durch außergesetzliche Verderbung
 Geschändet sind und an dem ungesetzlichen Mysterienkult der
 Aphrodite teilgenommen haben. Aber jetzt ist diese Stadt allein an
 Diesem Wahnsinn krnak zum Beweise des alten Bösen. Früher nämlich
@@ -2279,12 +2283,12 @@ Mächtig war.</p>
 
 <div type="textpart" subtype="chapter" n="15">
 <p>Und nicht allein dies, sondern auch diejenigen
-Männer, welche den genannten Göttern geweiht (verfallen) waren &lt;und&lt;
+Männer, welche den genannten Göttern geweiht <supplied reason="undefined" resp="#editor">verfallen</supplied> waren &lt;und&lt;
 Aus Lobgesängen und Liedern, Opfern und Mysterien, Schriften und
-Gelübden von Bildern gelernt haben, daB der Vater und Lenker aller
+Gelübden von Bildern gelernt haben, daß der Vater und Lenker aller
 Götter von leiblicher Lust besiegt sei und den Ganymedes geliebt habe, <lb n="25"/>
-*überschritten nach dem Vorbilde des Eifers ihrer Götter die Grenzen
-Der Natur, gingen über unsagbare *Taten hinaus und betrugen sich
+<corr resp="#editor">überschritten</corr> nach dem Vorbilde des Eifers ihrer Götter die Grenzen
+Der Natur, gingen über unsagbare <corr resp="#editor">Taten</corr> hinaus und betrugen sich
 Ohne Scheu frech gegeneinander, was zu hören unglaublich ist: „Männer
 Begingen Unanständigkeit gegen Männer und trugen an sich den gebührenden
 Lohn für ihre Verirrung davon“, wie die göttlichen Schriften <lb n="30"/>
@@ -2313,23 +2317,23 @@ die Strafen eines gottlosen Lebens zu Herzen.</p>
 <div type="textpart" subtype="chapter" n="17">
 <p>Und nicht nur
 dies, sondern auch mitten in das Theater liefen sie wie Herden rennen,
-Greise zumal und Jünglinge und Mütter mit *ihren Söhnen und Töchtern
-und dem Anhang der Sklaven, und wurden (so) mit allem Schändlichen
+Greise zumal und Jünglinge und Mütter mit <corr resp="#editor">ihren</corr> Söhnen und Töchtern
+und dem Anhang der Sklaven, und wurden <supplied reason="undefined" resp="#editor">so</supplied> mit allem Schändlichen
 <lb n="10"/> und Wahnwitzigen bekannt. Der Trunkenheit und Lüsternheit voll
 waren Männer zumal mitsamt den Weibern, wenn sie zusammen waren.
 Wie sollten sie das Gute tun, sie die ihre Ohren nicht dem Hören
 keuscher und gottesfürchtiger Worte, noch ihre Augen der Hilfe für
 ihre Seele, sondern der Lehre schändlicher Worte und dem Anblick der
-<lb n="15"/> bildlichen Darstellung aller Lüsternheit *darboten? Denn derartig war <milestone unit="altnumbering" n="46"/>
+<lb n="15"/> bildlichen Darstellung aller Lüsternheit <corr resp="#editor">darboten</corr>? Denn derartig war <milestone unit="altnumbering" n="46"/>
 das, was alle Scharen zu sehen bekamen, die sich bekümmerten um die
-Dinge, die in diesen (Schauspielen gezeigt wurden): wahnsinniger Pferdewettkampf, 
+Dinge, die in diesen <supplied reason="undefined" resp="#editor">Schauspielen gezeigt wurden</supplied>: wahnsinniger Pferdewettkampf, 
 gottloses Ergötzen an denen, die von wilden Tieren gefressen
 wurden, grausame und unmenschliche Quälereien derer, die in Gladiatorenspielen
-<lb n="20"/> getötet wurden, ferner lüsternes Lachen über schändliche (Dinge),
+<lb n="20"/> getötet wurden, ferner lüsternes Lachen über schändliche <supplied reason="undefined" resp="#editor">Dinge</supplied>,
 törichtes Vergnügen an Musik, lüsterner Anblick derer, die Weiber
 darstellten, und starkes Geschrei bei Liedern. Denn bei diesen und derartigen
-(Dingen) waren Myriaden Scharen unverständiger Massen vereinigt
-mitsamt ihren Fürsten, Strategen und *Hegemonen und wurden
+<supplied reason="undefined" resp="#editor">Dingen</supplied> waren Myriaden Scharen unverständiger Massen vereinigt
+mitsamt ihren Fürsten, Strategen und <corr resp="#editor">Hegemonen</corr> und wurden
 <lb n="25"/> mit den Verderbnissen durchtränkt, die die Seelen zum Verfaulen bringen.</p>
 </div>
 
@@ -2343,7 +2347,7 @@ männlichen und weiblichen Gottheiten, voll von allerlei Schande
 und Leidenschaften und furchtbaren Verbrechen, in nichts unterschieden
 von den sterblichen Naturen, infolge der Belehrung und des Studiums
 der trügerischen, dramatischen Werke der Komöden und Tragöden in
-<lb n="35"/> ihr Gedächtnis auf. Diese verderblichen und schädlichen (Dinge) des
+<lb n="35"/> ihr Gedächtnis auf. Diese verderblichen und schädlichen <supplied reason="undefined" resp="#editor">Dinge</supplied> des
 <note type="footnote">1 vermutlich ἀλόγῳ εἱμαρμένῃ καὶ φυσικῇ ἀνάγκῃ τὴν τοῦ παντὸς οὐσίωσίν
 τε καὶ σύστασιν ἀνετίθεσαν vgl. L 8 1. (??) 10 „bekannt“] wörtlicher
 „bekleidet“(Syriasmus) 15 „darboten“]1. (??) mit HS 42 1. (??) 
@@ -2352,26 +2356,26 @@ muß an verkehrter Stelle stehen 32 „Verbrechen“] „Trauer“ Σ = συμφ
 
 <pb n="v.3.pt.2.p.87"/>
 Lebens säten sie sunächst in sich und dann in den Seelen der Jünglinge
-aus. Der Frevel aber, der von allen der erste und letzte (ist), war, daß
+aus. Der Frevel aber, der von allen der erste und letzte <supplied reason="undefined" resp="#editor">ist</supplied>, war, daß
 vollständig alle Menschen, die Fürsten zumal und die  Untertanen, die
 Könige der Völker und die Gesetzgeber, die Heerscharen und Massen
 in den Dörfern und Städten, unter Griechen und Barbaren das Lob, das <lb n="5"/>
 allein dem König des Alls geberbten, Götter nannten und Hymnen sangen
 den irdischen und bösen geistern, den seelenlosen στοιχεῖα und den
 sinnlichen Elementen der Welt. Die Mengen der vernünftigen Lebewesen
-auf Erden brachten weder das Lob (nach Art) des Priesters noch <lb n="10"/>
+auf Erden brachten weder das Lob <supplied reason="undefined" resp="#editor">nach Art</supplied> des Priesters noch <lb n="10"/>
 das mit ihren Brüdern im Himmel, den heiligenEngeln und göttlichen
-Geistern, die den Allkönig loben, das mit ihnen zusammenstimmende *Lob
+Geistern, die den Allkönig loben, das mit ihnen zusammenstimmende <corr resp="#editor">Lob</corr>
 dar, sondern sangen ein ungebührliches und nicht zusammenstimmendes
-<milestone unit="altnumbering" n="47"/> (Lob) an Feiertagen und Festen den betrügerischen Geistern, die die
+<milestone unit="altnumbering" n="47"/> <supplied reason="undefined" resp="#editor">Lob</supplied> an Feiertagen und Festen den betrügerischen Geistern, die die
 Welt verderben, und fügten ihnen die Ehre der Anbetung zu, sodaß <lb n="15"/>
 fortan das ganze στοιχεῖον der Erde übereinstimmend mit allen Völkern
 in der ganzen Welt nichts anderes war als ein im Sturm befindliches
-Schiff, dessen schwer (beschädigtes) Wrack durch einen *anderen Sturm
+Schiff, dessen schwer <supplied reason="undefined" resp="#editor">beschädigtes</supplied> Wrack durch einen <corr resp="#editor">anderen</corr> Sturm
 sofort mit völligem Untergang bedroht ist.</p>
 </div>
 <div type="textpart" subtype="chapter" n="19">
-<p>Mit Recht also war wegen aller dieser (Dinge) Gott als Erlöser <lb n="20"/>
+<p>Mit Recht also war wegen aller dieser <supplied reason="undefined" resp="#editor">Dinge</supplied> Gott als Erlöser <lb n="20"/>
 und Helfer nötig für das Geschlecht der Menschen.  Wären nur die
 Massen zu dieser Verirrung geführt, so ware das Böse vielleicht gering.
 Jetzt aber waren völlig die Häupter der Städte, die Lenker der  Völker,
@@ -2379,10 +2383,10 @@ die Könige der Länder, die Führer der Ortschaften und die  Fürsten der
 Völker allzumal übereinstimmend an derselben dämonischen und polytheistischen <lb n="25"/>
 Verirrung erkrankt. Ferner fürwahr aber auch diejenigen,
 die sich rühmten unter den Griechen der Philosophie und bekannten,
-daß sie ein reicheres Wissen besäßen als die moisten Menschen, (die)
+daß sie ein reicheres Wissen besäßen als die moisten Menschen, <supplied reason="undefined" resp="#editor">die</supplied>
 auf den Straßen prunkten, indem sie sich aufblähten und breit in ihre
 Stola hüllten, schweiften auf der weiten und langen Erde umher und <lb n="30"/>
-*bettelten sich von anderen Völkern die herrlichen Lehrsätze zusammen,
+<corr resp="#editor">bettelten</corr> sich von anderen Völkern die herrlichen Lehrsätze zusammen,
 von hier die Geometrie, von der andern Richtung die Arithmetik,
 wiederum aber von anderer Seite die Musik und die Heilkunde und 
 <note type="footnote">28 vgl. Praep. X 4 27 f.</note>
@@ -2393,37 +2397,37 @@ ABBREN  vgl. Hoffmann in Stud. 70 f. 29 „ die . . . . prunkten“] Σ Ηauptsa
 31 „bettelten“] „befreiten“ Σ 1. ΑBBREV</note>
 
 <pb n="v.3.pt.2.p.88"/>
-andere (Dinge), die auf rationeller Erfahrung *beruhen. Diese aber und
-ähnliche (Dinge) brachten sie von überallher zusammen und verfielen
+andere <supplied reason="undefined" resp="#editor">Dinge</supplied>, die auf rationeller Erfahrung <corr resp="#editor">beruhen</corr>. Diese aber und
+ähnliche <supplied reason="undefined" resp="#editor">Dinge</supplied> brachten sie von überallher zusammen und verfielen
 in sterbliches und gottloses Denken. Durch beschwatzendes Wortemachen
 setzten die einen fest, daß die Atome, die unzerbegbar, ohne
-<lb n="5"/> Teile und *ähnliche Teile und ohne Ende (sind), — als ob sie fürwahr die
+<lb n="5"/> Teile und <corr resp="#editor">ähnliche</corr> Teile und ohne Ende <supplied reason="undefined" resp="#editor">sind</supplied>, — als ob sie fürwahr die
 Wahrheit nicht prüften — „der Anfang des Alls“ seien, wie sie sagen.
 Eben dieselben definierten auch die Lust als den äußersten Grad der
 Glückseligkeit, was augenscheinlich verderblicher ist als alles Böse. Denn
 was könnte es Kostbarers geben als die Lust für diejenigen, die festgestellt
 <lb n="10"/> haben, daß in diesem Seienden weder eine Vorsehung noch ein
 Gott noch eine unsterbliche Seele noch eine verständige οὐσία noch
-ein Logow der über allem (waltet), noch ein Anfang noch
+ein Logow der über allem <supplied reason="undefined" resp="#editor">waltet</supplied>, noch ein Anfang noch
 ein Ende existiere, sondern daß allein die unzerlegbaren vernunftund
 seelenlosen Atome — es sind dies aber winzige Körper, die
 <lb n="15"/> eben wegen ihrer vorzüglichen Kleinheit nicht einmal in die Sinne
-fallen — daß eben diese seelen- , vernunft- und anfangslosen (Dinge) <milestone unit="altnumbering" n="48"/>
+fallen — daß eben diese seelen- , vernunft- und anfangslosen <supplied reason="undefined" resp="#editor">Dinge</supplied> <milestone unit="altnumbering" n="48"/>
 die ersten seien, nicht gezeugt, unendlich an Menge und von unübersehbaren
 Zeiten her, wie es sich gerade traf, zerstreut? Indessen
 aber, obwohl sie derart sind, hat man gesaft, daß sie die Ursache des
 <lb n="20"/> Schmuckes des Alls seien, und daß es keinen Gott, keine Vorsehung
-und keinen Logos gebe, der (alles) sah, noch einen, der mächtig war über
-alles, aber wenn es auch einen solchen gebe, er weder (selbst) eine Beschäftigung
+und keinen Logos gebe, der <supplied reason="undefined" resp="#editor">alles</supplied> sah, noch einen, der mächtig war über
+alles, aber wenn es auch einen solchen gebe, er weder <supplied reason="undefined" resp="#editor">selbst</supplied> eine Beschäftigung
 habe noch sie anderen gewähre, und wie ich glaube, legten
-sie die von ihnen geliebte Lust auch Gott selbst bei. *Derartig aber
+sie die von ihnen geliebte Lust auch Gott selbst bei. <corr resp="#editor">Derartig</corr> aber
 <lb n="25"/> waren Philosophen die Anhänger des Epikuros und Demokritos, und
-indem sie auftraten als Anwälte dieser (Ideen), war ihre gan͌  e Überlieferung
+indem sie auftraten als Anwälte dieser <supplied reason="undefined" resp="#editor">Ideen</supplied>, war ihre gan͌  e Überlieferung
 mitten unter den Griechen lebendig. Obwohl sie aber so die
-Besseren waren, schmiegten sie sich (heuchlerisch) den Massen an.
+Besseren waren, schmiegten sie sich <supplied reason="undefined" resp="#editor">heuchlerisch</supplied> den Massen an.
 Bald wandelten sie mit den Scharen zum Tempel, bald stellten sie sich
 <lb n="30"/> gottesfürchtig aus Furcht vor der gesetzlichen Strafe. Aber diese, die
-für die Lust kämpften, (waren) derart.</p>
+für die Lust kämpften, <supplied reason="undefined" resp="#editor">waren</supplied> derart.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="20">
@@ -2440,30 +2444,30 @@ ist von Σ wohl fälschlich zum Vorhergehenden gezogen</note>
 <pb n="v.3.pt.2.p.89"/>
 falls als den höchsten Gradd der Glückseligkeit weder Tugend noch
 Philosophie definierten, außer wenn sie zufällig mit Reichtum an Besitz,
-mit Überfluß an Gold und silber, mit (vornehmer) Familie und Berühmtheit
-verbunden ist, die bei vielen (anerkannt sind). Und was himdert sie,
+mit Überfluß an Gold und silber, mit <supplied reason="undefined" resp="#editor">vornehmer</supplied> Familie und Berühmtheit
+verbunden ist, die bei vielen <supplied reason="undefined" resp="#editor">anerkannt sind</supplied>. Und was himdert sie,
 sich ebenfalls dessen zu rühmen? Leute, die bis zum Monde die über <lb n="5"/>
-alles (sich erstreckende) Vorsehung gleichsam hinter Schloß und Riegel
-gefangen gehalten, und (die) gesagt haben, daß die geistige undd vernünftige
-Leibe, sondern ihm entspreche an Art und Gestalt, (weswegen) sie
+alles <supplied reason="undefined" resp="#editor">sich erstreckende</supplied> Vorsehung gleichsam hinter Schloß und Riegel
+gefangen gehalten, und <supplied reason="undefined" resp="#editor">die</supplied> gesagt haben, daß die geistige undd vernünftige
+Leibe, sondern ihm entspreche an Art und Gestalt, <supplied reason="undefined" resp="#editor">weswegen</supplied> sie
 sie auch Entelechie zunnen pflegen. An die Spitze des Guten Stellten <lb n="10"/>
 sie demgemäß weder das philosphische Leben noch die Haupttugend,
 sondern sie verfielen auf zufällige Dinge, auf Reichtum, Macht und
 Familie. Denn mit diesen Dingen, sagen sie, existiere auch die Tugend,
-die der Vernunft würdig sei, ohne  sie aber sei *sie niemals. Nichts
+die der Vernunft würdig sei, ohne  sie aber sei <corr resp="#editor">sie</corr> niemals. Nichts
 Besseres gebe es für den Weisen, außer wenn er auch reich sei, noch <lb n="15"/>
 se idem, der sich um keuschheeit bemüht, etwas Gutes nahe, außer wenn
-er ein Sohn (vornehmer) Familie sei, noch sei di Gerechtigkeit und
-die mit der Tugend übereinstimmende (geistige) Beschaffenheit, falls sie
+er ein Sohn <supplied reason="undefined" resp="#editor">vornehmer</supplied> Familie sei, noch sei di Gerechtigkeit und
+die mit der Tugend übereinstimmende <supplied reason="undefined" resp="#editor">geistige</supplied> Beschaffenheit, falls sie
 in der Seele des Menschen existiere, genügend zu einem glückseligen
 <milestone unit="altnumbering" n="49"/> Leben, außer wenn ihm eine schöne Ordnung der Glieder des Leibes <lb n="20"/>
 zufällig eigne. Eben sie aber glauben, dab die Gottheit irgendwo auberhalb
 von den Dingen der Menscchen oberhalb des Mondes existiere und behaupten,
 dab die vorsehung Gottes die Dinge auf Erden nicht sehe. Auch den geneinnicht,
-indessen aber stellten sie sich (heeuchlerisch) auch an, als fürchteten sie <lb n="25"/>
+indessen aber stellten sie sich <supplied reason="undefined" resp="#editor">heeuchlerisch</supplied> auch an, als fürchteten sie <lb n="25"/>
 die Götter in Stadt und Land. Des eine redeten sie weise mit ihren Theoremen,
 ein anderes aber taten sie in ihrer Praxis und leisteten den Eid bei
-den Göttern in ihren allgeemeein (zugänglichen) Schriften und Worten, in
+den Göttern in ihren allgeemeein <supplied reason="undefined" resp="#editor">zugänglichen</supplied> Schriften und Worten, in
 ihrem Denken aber war nichts Derartiges, sondern um der menge zu
 gefallen, heuchelten sie solches Tun, sodaß sie daher, eher Dämonen als <lb n="30"/>
 Menschen, von jeder gesunden Philosophie verachtet warden.</p>
@@ -2485,10 +2489,10 @@ aber abgesehen von diesen, die sich brüsten, die besten Philosophen zu
 sein, haben gewagt, mit gottlosem Munde zu sagen, daß Gott ein Körper
 sei, seiner Natur nach in nichts unterschieden vom Feuer. Dies ist die 
 andere Verirrung: der Stoiker, die diese sinnliche Welt als Gott ausgegeben
-<lb n="5"/> und (so) eine ruchlose, ganz verderbliche Lehre aufgestellt haben. 
+<lb n="5"/> und <supplied reason="undefined" resp="#editor">so</supplied> eine ruchlose, ganz verderbliche Lehre aufgestellt haben. 
 Denn die schaffenskräftige Ursache und die leidensfähige Hyle bestehen 
-(nach ihnen) aus ein und derselben οὐσία und beides sind wirkende 
-und gewirkte Körper. Der Allkönig Gott, der über allem (steht), ist 
+<supplied reason="undefined" resp="#editor">nach ihnen</supplied> aus ein und derselben οὐσία und beides sind wirkende 
+und gewirkte Körper. Der Allkönig Gott, der über allem <supplied reason="undefined" resp="#editor">steht</supplied>, ist 
 vom sinnlichen Feuer in nichts unterschieden, sondern wird auch mit
 <lb n="10"/> allem zumal vermicscht gemäß  dem periodischen Feuer zu bestimmten 
 Zeiten. Groß ist das Böse, daß Gott, wie sie sagen, verwandelt und 
@@ -2499,20 +2503,20 @@ Gott vermischt wird und sich alles „ins Feuer verwandelt wie in einen
 wie es fuüher war”. Götter aber gibt es so viele wie es Teile der 
 Welt gibt. Deswegen weil auch die ganze Welt aus lauter Teilen 
 besteht, ist sie vollkommen Gott. Eben dieselben haben ferner gesagt, 
-daß die verständige und vernünftige Seele im menschen (ebenso) vergänglich
-<lb n="20"/> wie körperlich sei. Was wollte sie den (daran) hinder, sie, 
+daß die verständige und vernünftige Seele im menschen <supplied reason="undefined" resp="#editor">ebenso</supplied> vergänglich
+<lb n="20"/> wie körperlich sei. Was wollte sie den <supplied reason="undefined" resp="#editor">daran</supplied> hinder, sie, 
 die gegen den Allkönig Gott solches zu sagen sich erfrecht haben? <milestone unit="altnumbering" n="50"/>
 Diese Seelen sollen ferner nach ihrer Definition aus Hyle und Körpern 
 bestehen und nichts weiter sein als der Qualm und Rauch der Körper. 
 Ferner bleiben nach dem Lebensende keineswegs die Seelen aller, sondern
-<lb n="25"/> nur die der Philosophen (gewisse) Zeiten hindurch, die ihnen bestimmt 
+<lb n="25"/> nur die der Philosophen <supplied reason="undefined" resp="#editor">gewisse</supplied> Zeiten hindurch, die ihnen bestimmt 
 sind, am Ende aber warden auch sie mit dem Brande des Alls
 brennen mit Gott zumal und der ganzen Welt, und die Seelen der Ungerechten 
 zumal und der Gerechten, der Frommen mitsamt den Gottlosen 
 warden von Einem Feuer aufgezehrt warden, als ob sie geschmolzen
 <lb n="30"/> würden. Dann aber warden von neuem aus dem Feuerfraß des Alls 
 Welten geboren, die in nichts vershieden, sondern in allem ähnlich 
-sind den früheren, so sehr, daß von neuem eben dieselben (Menschen) 
+sind den früheren, so sehr, daß von neuem eben dieselben <supplied reason="undefined" resp="#editor">Menschen</supplied> 
 geboren werdenund ein und dieselbe Nachfolge geboren wird. Die 
 Lebensweisen ferner sind derart, daß sie in allem ähnlich und nicht
 <lb n="35"/> verwandelt sind, die Moden, Gebräuche, Sitten und Leidenschaften 
@@ -2528,18 +2532,18 @@ Gift des Sokrates und wiederum eben dieselben Streitigkeiten und <lb n="5"/>
 Spaltungen der Philosophen, und am Ende wird wiederum alles vom
 Feuer verzehrt, und nachdem es verbrannt ist, wird es wieder von
 neuem zurückkehren und wieder in denselben Gleisen verharren. Aber
-auch diese (Philosophen) hängen so notwendig ihrem Irrtum an.</p>
+auch diese <supplied reason="undefined" resp="#editor">Philosophen</supplied> hängen so notwendig ihrem Irrtum an.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="22">
 <p>Die Philosophen aber, die die ersten Physiker heißen, die vor allen <lb n="10"/>
-(anderen) auftraten, gründeten den Anfang des Alls auf ein seelenloses
+<supplied reason="undefined" resp="#editor">anderen</supplied> auftraten, gründeten den Anfang des Alls auf ein seelenloses
 στοιχεῖον, ohne einen Gott, eine Vorsehung, einen Schöpfer und Werk-
 meister des Alls zu kennen. Eitel aber und ohne Grund legten sie
 sich lügnerisch den Namen und das Gebaren der Philosophen bei.
 Denn teils sagten sie, daß die Erde und eine trockene οὐσία der An- <lb n="15"/>
 fang des Alls sei, teils nannten sie den Ozean und so eine feuchte οὐσία,
-*das Wasser als den Allerzeuger, teils das Feuer, teils die Luft, teils
+<corr resp="#editor">das</corr> Wasser als den Allerzeuger, teils das Feuer, teils die Luft, teils
 Mischungen aus diesen, und führten viele männliche wie auch weibliche
 Gottheiten ein und Hochzeiten und Kindergeburten, &lt;und&lt; änderten in
 <milestone unit="altnumbering" n="51"/> physikalische Allegorien das Mythengefasel der Poeten durch schöne <lb n="20"/>
@@ -2550,10 +2554,10 @@ sinnlichen Teile der Welt niederfielen.</p>
 
 <div type="textpart" subtype="chapter" n="23">
 <p>Andere aber, abgesehen
-von diesen, fabrizierten (gerade) Entgegengesetztes all dem, abgesehen
-von diesen, fabrizierten (gerade) Entgegengesetztes all dem, was gesagt
+von diesen, fabrizierten <supplied reason="undefined" resp="#editor">gerade</supplied> Entgegengesetztes all dem, abgesehen
+von diesen, fabrizierten <supplied reason="undefined" resp="#editor">gerade</supplied> Entgegengesetztes all dem, was gesagt
 ist, behauptend, daß es nichts Göttliches in dem Seienden gebe, weder <lb n="25"/>
-den höchsten Gott noch die lokalgötter, daß der Name (Gott) vielmehr
+den höchsten Gott noch die lokalgötter, daß der Name <supplied reason="undefined" resp="#editor">Gott</supplied> vielmehr
 besser und über die οὐσία gesetzt sei, die nicht ist, sodaß sie in großen
 Frevel des Bösen sich ausgebreitet haben.</p>
 </div>
@@ -2568,7 +2572,7 @@ das Erste und die Ursache des Alls ist, und redet mit Recht weise
 <div type="textpart" subtype="chapter" n="25">
 <p>Er hat auch
 schön und richtig festgestellt, daß Himmel, Sonne, Mond, Sterne und 
-überhaupt die ganze Welt zumal von dem Gotte des Alls (geschaffen)
+überhaupt die ganze Welt zumal von dem Gotte des Alls <supplied reason="undefined" resp="#editor">geschaffen</supplied>
 wurden.</p>
 </div>
 
@@ -2580,12 +2584,12 @@ und der Vergänglichkeit fremd sei. Er hat auch geistige οὐσίαι ge-
 und vgl. Praep. II 6 17 24 Man erwartet das Femininum <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.92"/>
-kannt und zugegeben, daß der über allem (waltende) Verstand, den wir
+kannt und zugegeben, daß der über allem <supplied reason="undefined" resp="#editor">waltende</supplied> Verstand, den wir
 Logos Gottes nennen, der König des Alls sei. Eben ihn setzte auch er
 als Herrscher über das All nach Art eines Steuermannes, der schön und
-sicher für alles sorgt, und wies (ihn) als Lenker nach. Er allein von
+sicher für alles sorgt, und wies <supplied reason="undefined" resp="#editor">ihn</supplied> als Lenker nach. Er allein von
 <lb n="5"/> allen Griechen bekannte den Logos Gottes, den Schöpfer der Welt,
-gleich wie wir selbst. Abe res ist am Platze, ihn (selbst) zu hören, in
+gleich wie wir selbst. Abe res ist am Platze, ihn <supplied reason="undefined" resp="#editor">selbst</supplied> zu hören, in
 welcher Art er über Gott redet:</p> 
 </div>
 
@@ -2593,24 +2597,24 @@ welcher Art er über Gott redet:</p>
 <p> „Und Ehren wollen wire r-
 weisen, nicht dem für ein Jahr und jenem für einen Monat und anderen
 aber überhaupt keinen Anteil und keine Zeit zuerteilen, in der er seine
-<lb n="10"/> Bahn durchläuft und die Weltordnung (mit) vollendet, die der aller* gott-
+<lb n="10"/> Bahn durchläuft und die Weltordnung <supplied reason="undefined" resp="#editor">mit</supplied> vollendet, die der aller<corr resp="#editor">gott</corr>-
 lichste Logos sichtbar anordnete, den, wer immer glückselig ist, zuerst
-bewundert, zu deme r dann aber Liebe faßt, um (ihn) kennen zu lernen,
+bewundert, zu deme r dann aber Liebe faßt, um <supplied reason="undefined" resp="#editor">ihn</supplied> kennen zu lernen,
 soweit es die sterbliche Natur vermag“.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="28">
 <p>Er nannte auch den, <milestone unit="altnumbering" n="52"/>
-*den ere ben als „göttlichen Logos“ bezeichnet hat, den „Vater“ und
+<corr resp="#editor">den</corr> ere ben als „göttlichen Logos“ bezeichnet hat, den „Vater“ und
 <lb n="15"/> „Herrn“ des Alls und den „Lenker“ des Alls mit denselben Worten
 wie wir und sagte so:</p> 
 </div>
 
 <div type="textpart" subtype="chapter" n="29">
 <p> „Diesen Brief sollt ihr alle, die ihr drei
-seid, lessen, besonders in Gemeinschaft, wenn aber (dies) nicht (mög-
-lich), so zu zweien zusammen, nach Kräften soviel ihr könnt, &lt;und&lt;
-sollt dies als herrschendes Übereinkommen und Gesetz *gebrauchen, in-
+seid, lessen, besonders in Gemeinschaft, wenn aber <supplied reason="undefined" resp="#editor">dies</supplied> nicht <supplied reason="undefined" resp="#editor">mög-
+lich</supplied>, so zu zweien zusammen, nach Kräften soviel ihr könnt, &lt;und&lt;
+sollt dies als herrschendes Übereinkommen und Gesetz <corr resp="#editor">gebrauchen</corr>, in-
 <lb n="20"/> dem ihr schwört wie es recht ist, und indem ihr mit nicht unweisem
 Eifer zumal und mit der Zucht, der Schwester des Eifers, bei dem
 &lt;Gotte&lt; des Alls, dem Lenker des Seienden und Kommenden und dem
@@ -2636,9 +2640,9 @@ was kommt“ &lt;φεὸν Σ mit Unrecht 24 εἰσόμεφα πάντες σ
 ἀνφρώπων εὐσαιμόνων] wörtlich „nach unsere Kraft aus glückseligen Menschen“ Σ</note>
 
 <pb n="v.3.pt.2.p.93"/>
-heit, der Tugend anzuhängen und mit ihr (wie ein Zwilling) verhunden
+heit, der Tugend anzuhängen und mit ihr <supplied reason="undefined" resp="#editor">wie ein Zwilling</supplied> verhunden
 zu sein, zeigte er sehr göttlich.</p>
-<p>Aber aueh er setzte sich mit Recht mehr als aller (und) augenscheinlich
+<p>Aber aueh er setzte sich mit Recht mehr als aller <supplied reason="undefined" resp="#editor">und</supplied> augenscheinlich
 dem Tadel aus. Warum? Weil er wußte, daß ein Gott sei,
 aber ihn nicht als Gott pries. Er verbarg vielmehr die Wahrheit und <lb n="5"/>
 machte sie zur Lüge für viele. Denen, die er liebte, brachte er als
@@ -2649,24 +2653,24 @@ bete und mit der ganzen Plebs zumal das Fest der Bendis feiere. <lb n="10"/>
 Er sagte aber ferner, daß sein Meister, als sein Lebensende nahe war,
 einen Hahn zu opfern befahl. Nicht schämte sich noch beschönigte es
 der beste der Philosophen, daß der Vater der Philosophie befahl, durch
-gewordene, irdische Hyle und (durch) ein wenig Blut und Fleisch eines
+gewordene, irdische Hyle und <supplied reason="undefined" resp="#editor">durch</supplied> ein wenig Blut und Fleisch eines
 toten Vogels die Gottheit zu versöhnen. Er nannte aber ferner diejenigen <lb n="15"/>
-(Götter), die in den Städten verehrt wurden, Dämonen und tat
+<supplied reason="undefined" resp="#editor">Götter</supplied>, die in den Städten verehrt wurden, Dämonen und tat
 wohl daran, und er bekanute auch, daß sie Vorfahren seien von sterblichen
 Menschen und redete recht. Dennoch aber riet er, eben sie als
-Götter zu verechen *weil er sich mit der Menge zu (ihrem) Irrtum erniedrigte,
-<add>und</add> mit Recht auch sie als Ursache (des Alls) anzunehmen, <lb n="20"/>
-weil er unter dem Schein (σχῆμα) der Philosophie das Wort der Wahrheit
-<milestone unit="altnumbering" n="53"/> verbarg, das der Lüge aber erheuchelte. Höre jedoch, was er *im
+Götter zu verechen <corr resp="#editor">weil</corr> er sich mit der Menge zu <supplied reason="undefined" resp="#editor">ihrem</supplied> Irrtum erniedrigte,
+<add>und</add> mit Recht auch sie als Ursache <supplied reason="undefined" resp="#editor">des Alls</supplied> anzunehmen, <lb n="20"/>
+weil er unter dem Schein <supplied reason="undefined" resp="#editor">σχῆμα</supplied> der Philosophie das Wort der Wahrheit
+<milestone unit="altnumbering" n="53"/> verbarg, das der Lüge aber erheuchelte. Höre jedoch, was er <corr resp="#editor">im</corr>
 Timaios sagt:</p> 
 </div>
 
 <div type="textpart" subtype="chapter" n="31">
 <p> „Über die anderen Dämonen aber zu redden und
-ihre *Geburt kennen zu lernen, ist zu groß für uns. Wir müssen uns
+ihre <corr resp="#editor">Geburt</corr> kennen zu lernen, ist zu groß für uns. Wir müssen uns
 vielmehr überzeugen lassen von denen, die vor uns gesagt haben, sie <lb n="25"/>
 seien Söhne der Götter, wie sie behauptet haben, und kennten ihre Vorfahren
-(wohl) genau. Unmöglich also ist es, Göttersöhnen nicht zu
+<supplied reason="undefined" resp="#editor">wohl</supplied> genau. Unmöglich also ist es, Göttersöhnen nicht zu
 glauben, obwohl sie ohne zwingende Wahrscheinlichkeits-  und Beweis-
 <note type="footnote">5 vgl. Platon Timaiow 28 C 9 vgl. Platon Politeia 327 A Phaidon 118 A
 16 vgl. Platon Timaios 40 D 23—S. 94, 8 = Platon Timaios 40 D; Praep. II 7 1 f.
@@ -2681,7 +2685,7 @@ Kraft“ 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.94"/>
 gründe reden, sondern dem Gesetze anhangend müssen wir ihnen glauben,
-da sie vorgeblich eigene (Familiengeschichten) erzählen. So also, wie
+da sie vorgeblich eigene <supplied reason="undefined" resp="#editor">Familiengeschichten</supplied> erzählen. So also, wie
 sie sagen, möge sich die Geburt in betreff dieser Götter verhalten und
 gesagt warden: Kinder der Erde und des Himmels waren Okeanos und
 <lb n="5"/> Tethys, und deren: Phorkys, Kronos, Rhea <add>und alle, die mit diesen
@@ -2695,28 +2699,28 @@ Sprößlinge dieser“.</p>
 den Bildern oberhalb der Welt und von den körperlosen, geistigen
 <lb n="10"/> οὐσίαι nach unten auf die Erde und auf den Ozean wie in die Tiefe
 des Bösen hinabgetaucht ist und Göttergeburten einführte, er der allein
-besser als (sonst) die Menschen mit hochtönendem Geist sagen konnte:</p>
+besser als <supplied reason="undefined" resp="#editor">sonst</supplied> die Menschen mit hochtönendem Geist sagen konnte:</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="33">
 <p> „Was ist das immer Seiende, aber niemals Werdende? <add>Und
 was ist das immer Werdende, aber niemals Seiende?</add> Das eine wird
-<lb n="15"/> durch das mit Vernunft (begabte) Wissen wahrgenommen und ist immer
+<lb n="15"/> durch das mit Vernunft <supplied reason="undefined" resp="#editor">begabte</supplied> Wissen wahrgenommen und ist immer
 sich selber gleich. Das andere aber wird mit unvernünftigem Sinne
-gewähnt, ist werdend und vergehend, aber völlig seiend *niemals“.</p>
+gewähnt, ist werdend und vergehend, aber völlig seiend <corr resp="#editor">niemals</corr>“.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="34">
-<p>Derselbe wackere (Mann) also ehrt eben dasselbe, was wird,
+<p>Derselbe wackere <supplied reason="undefined" resp="#editor">Mann</supplied> also ehrt eben dasselbe, was wird,
 vergeht und durchaus niemals ist, wegen seines Werdens und Vergehens
 <lb n="20"/> jetzt mit dem Namen der Götter. Eben derselbe sagt ferner, indem er diejenigen
 widerlegt, die diesen Göttermythos ausgestreut haben, daß sie
 keineswegs infolge „ zwingender Wahrscheinlichkeits-  und Beweisgründe“
-den Irrtum (betreffs) der anogeblichen Götter vorbrachten. Neachdem er
+den Irrtum <supplied reason="undefined" resp="#editor">betreffs</supplied> der anogeblichen Götter vorbrachten. Neachdem er
 sie in dieser Weise beschuldigt hat, sagt er hinterdrein, daß wir ihnen
 <lb n="25"/> glauben und sie für wahrhaftig halten müssen, obwohl sie nichts Wahrhaftiges
 reden, aber obwohl er sie sogar Göttersöhne nennt, ist ihm <milestone unit="altnumbering" n="54"/>
-(doch) offenbar bewußt, daß er ihre Vorfahren als sterblich, jedermann
+<supplied reason="undefined" resp="#editor">doch</supplied> offenbar bewußt, daß er ihre Vorfahren als sterblich, jedermann
 ähnlich einführt und ferner an sterbliche Götter und sterbliche, ihren
 Vorfahren ähnliche Söhne erinnert, die sagen, „daß sie ihre Vorfahren
 <lb n="30"/> genau kennten“. Obwohl er unverhohlen sagt: „Unmöglich also ist es.
@@ -2731,18 +2735,18 @@ und fügt hinzu, daß „wir sie für wahrhaftig halten müssen, da sie vor-
 wohl „trotz“</note>
 
 <pb n="v.3.pt.2.p.95"/>
-geblich eigene (Familiengeschichten) erzählen“. Durchaus
+geblich eigene <supplied reason="undefined" resp="#editor">Familiengeschichten</supplied> erzählen“. Durchaus
 aber sagt er nicht: „da sie erzählen“, sondern „da sie
 „Wir müssen uns vielmehr überzeugen“, sagt er,
-seien Söhne der Götter“. Woher hat er (denn) dies zu
+seien Söhne der Götter“. Woher hat er <supplied reason="undefined" resp="#editor">denn</supplied> dies zu
 „wie sie behauptet “? Denn sie haben dies behauptet, nicht ich. <lb n="5"/>
 das heißt aber: Dennoch, da sie über sich selbst aussagen, wenn
-auch (nur) ohne Wahrscheinlichkeitsgrunde und ohne Beweise (die)
-selbst (betreffenden Tatsachen) feststellen können, — dennoch
+auch <supplied reason="undefined" resp="#editor">nur</supplied> ohne Wahrscheinlichkeitsgrunde und ohne Beweise <supplied reason="undefined" resp="#editor">die</supplied>
+selbst <supplied reason="undefined" resp="#editor">betreffenden Tatsachen</supplied> feststellen können, — dennoch
 wir ihnen. Hinterher sagt er: „So also, wie sie sagen, sagen, sich die
 Geburt der Götter verhalten“. Notwendig bemerkt er, „wie sie sagen“. <lb n="10"/>
 Denn keineswegs nach meiner, sondern nach ihrer Meinung soll dies
-gesagt sein (will er damit ausdrücken).</p>
+gesagt sein <supplied reason="undefined" resp="#editor">will er damit ausdrücken</supplied>.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="35">
@@ -2751,9 +2755,9 @@ rät, wir üßten dem Irrtum nachfolgen. Weswegen aber stellt er
 fest? Um keiner anderen Ursache als um des Gesetzes, das heißt,
 des Todes willen, der am Gesetze hängt. Eben dies bekennt er offen, <lb n="15"/>
 indem er sagt: „Dem Gesetze folgend glauben “. Geht denn die
-Furcht vor den Menschen und dem Gesetz *bei den Philosophen über
+Furcht vor den Menschen und dem Gesetz <corr resp="#editor">bei</corr> den Philosophen über
 die Furcht und das Gesetz der Wahrheit hinaus? Wo sind die vorzüglichen
-und weisen (Worte) jener schönen Sprache, mit denen er
+und weisen <supplied reason="undefined" resp="#editor">Worte</supplied> jener schönen Sprache, mit denen er
 durchaus staunenswerter Sprache gewaltig so redete:</p> 
 </div>
 
@@ -2776,7 +2780,7 @@ Tode bewegt und heuchelst, sterbliche Götter um des Gesetzes
 <note type="footnote">20–24 = Piaton Nomoi 875 C 24–27 = Piaton Apologia 28
 XIII 10 3 28. 29 = Piaton Apologia 29 A; Praep. XIII 10 5</note>
 <note type="footnote">17 „von den “ Σ. Vielleicht kann man verstehen : „und dem von
-den Philosophen (stammenden) “. Aber dagegen spricht die Stellung der
+den Philosophen <supplied reason="undefined" resp="#editor">stammenden</supplied> “. Aber dagegen spricht die Stellung der
 Worte und der Sinn. Denn gemeint ist das staatliche Gesetz der ἀσέβεια Lies
 (<foreign xml:lang="abbr">ABBREV</foreign>) (<foreign xml:lang="abbr">ABBREV</foreign>). Oder παρά c. Dat. mißverstanden als παρά c. Gen.? 23
 θινὸς ἐλεύθερός τε ὄντως] ἀληθινὸς und τε &lt;Σ 24 „stellt" + ἧ ὑπὸ
@@ -2785,11 +2789,11 @@ Worte und der Sinn. Denn gemeint ist das staatliche Gesetz der ἀσέβεια 
 <pb n="v.3.pt.2.p.96"/>
 <lb n="96"/> Eueebius.
 zu ehren? Waruni aber hältst du es für würdig,
-glauben und ihnen vertrauen? Durch dein (eigenes) Wort
+glauben und ihnen vertrauen? Durch dein <supplied reason="undefined" resp="#editor">eigenes</supplied> Wort
 machst du zu Schanden und schüttelst ab, was sie durchaus
 noch auf Grund irgend eines Beweises über ihre Vorfahren gesagt
 <lb n="5"/> haben. Wie kannst du, nachdem du sie so beschuldigt hast, den
-Menschen (noch) raten, ihnen zu glauben? Was ihre Väter sind,
+Menschen <supplied reason="undefined" resp="#editor">noch</supplied> raten, ihnen zu glauben? Was ihre Väter sind,
 wir prüfen!</p> 
 </div>
 
@@ -2809,19 +2813,19 @@ der den fliegenden Wagen treibt? Oder wars nicht dein eigenes Wort,
 </div>
 
 <div type="textpart" subtype="chapter" n="40">
-<p>Aber das weiß ich nicht, warum (erst) nach der
+<p>Aber das weiß ich nicht, warum <supplied reason="undefined" resp="#editor">erst</supplied> nach der
 nach dem Meere, nach Okeanos, Rhea und Kronos, den Sterblichen,
-Zeus erschien und wie (dies) dein Wort jenem (anderen) entspricht:
+Zeus erschien und wie <supplied reason="undefined" resp="#editor">dies</supplied> dein Wort jenem <supplied reason="undefined" resp="#editor">anderen</supplied> entspricht:
 „Wir müssen uns überzeugen lassen von denen, die vor uns
 <lb n="20"/> haben, sie seien Söhne der Götter, wie sie behauptet haben,
-ihre Vorfahren (wohl) genau. Unmöglich also ist es, Göttersöhnen
+ihre Vorfahren <supplied reason="undefined" resp="#editor">wohl</supplied> genau. Unmöglich also ist es, Göttersöhnen
 zu glauben, obwohl sie ohne zwingende Wahrscheinlichkeits- und Beweisgründe
 reden“. Er fährt aber fort: „So also, wie
 sich die Geburt betreffs dieser Götter verhalten und
 <lb n="25"/> Daran reiht er eine lange Rede und Erzählung über die Geburten
 Götter, die die Poeten sagen, versichert uns obendrein und
-„Von Kronos und Rhea (stammten) Zeus und Hera und alle, von denen
-wir wissen, *daß sie alle als ihre üder genannt werden, und
+„Von Kronos und Rhea <supplied reason="undefined" resp="#editor">stammten</supplied> Zeus und Hera und alle, von denen
+wir wissen, <corr resp="#editor">daß</corr> sie alle als ihre üder genannt werden, und
 andere als Spröblinge dieser“.</p>
 </div>
 
@@ -2830,7 +2834,7 @@ andere als Spröblinge dieser“.</p>
 <lb n="30"/> erzählt? Und erzählt er nicht Dinge, die leicht sind, wohl
 die gottlos und seiner eigenen Philosophie entgegengesetzt sind? Denn
 eben er treibt in der Politeia vornehm diejenigen, die er jetzt Göttersöhne
-nennt, (und) vollends diejenigen früheren (Schriftsteller), die
+nennt, <supplied reason="undefined" resp="#editor">und</supplied> vollends diejenigen früheren <supplied reason="undefined" resp="#editor">Schriftsteller</supplied>, die
 deren Gottheit ählt haben, den Homer, Hesiod und vor allem den
 <lb n="35"/> Orpheus aus seiner πολιτεία weit weg, jetzt aber ät dieser Philosoph,
 <note type="footnote">14–16 = Piaton Phaidros 246 Ε 32 vgl. Piaton Politeia 377 f.; Praep. XIII 31 ff.</note>
@@ -2845,20 +2849,20 @@ hinter der Erde und dem Himmel und hinter der feuchten οὐσία, die
 er als Okeanos bezeichnet, im Entstehen und Vergehen sucht und bekennt,
 daß der Vater aller Menschen und Götter und Hera
 anderen noch dazu, die nach seinen Worten als ihre Brüder und Söhne <lb n="5"/>
-genannt werden, aus der Erde und dem Ozean stammten, und (trotzdem)
+genannt werden, aus der Erde und dem Ozean stammten, und <supplied reason="undefined" resp="#editor">trotzdem</supplied>
 rät er nachher, sie als Götter zu verehren. Wo ist
-οὐσίαι, wo ist jenes körperlose, jenseits der Welt (befindliche)
+οὐσίαι, wo ist jenes körperlose, jenseits der Welt <supplied reason="undefined" resp="#editor">befindliche</supplied>
 oder jene göttliche Erzählung Erzählung über die farb-
 Wenn aber jede Seele unsterblich ist, warum machst du Sterblichen <lb n="10"/>
 Untertan die Unsterblichen, den Körpern der Dämonen
 den vergänglichen Sinnesdingen die geistige und vernünftige
 Mit Recht also meine ich diesen Mann mehr zu tadeln als die übrigen,
 obwohl mich die Liebe zu ihm hinzieht wegen der Verwandtschaft seiner
-Lehren (mit den unsern). Denn er allein von allen Griechen scheint <lb n="15"/>
+Lehren <supplied reason="undefined" resp="#editor">mit den unsern</supplied>. Denn er allein von allen Griechen scheint <lb n="15"/>
 mir die Vortüren der Wahrheit zu erreichen und hat in vielen
 Verwandtschaft mit uns gezeigt. Aber nicht möge dieser Mann
-geehrt werden als die Wahrheit. Deswegen, scheint es mir, * muß
-mehr als alle um ihretwillen getadelt werden. Denn (obwohl) das Lust-
+geehrt werden als die Wahrheit. Deswegen, scheint es mir, <corr resp="#editor">muß</corr>
+mehr als alle um ihretwillen getadelt werden. Denn <supplied reason="undefined" resp="#editor">obwohl</supplied> das Lust-
 liebende und das, was aus seiner Lehre sich ergibt, als todbringend beschuldigt <lb n="20"/>
 werden mag, und obwohl er glaubt, daß es keine Götter
 heuchelt er indessen dennoch, als ob er ein anderes Leben nicht kenne,
@@ -2872,7 +2876,7 @@ meinten, die Seele im Menschen sei sterblich, und behaupteten, ihre Ge-
 stalt und ihr Körper sei die „Entelechie“. Zu gunsten des
 <milestone unit="altnumbering" n="57"/> Lebens, das sie allein kannten, gerieten sie unter die Menge und heu-
 chelten Götter, obwohl sie glaubten, daß diejenigen, die nach
-der πολιτεία (verehrt werden mußten), niemals existierten, aus Furcht <lb n="30"/>
+der πολιτεία <supplied reason="undefined" resp="#editor">verehrt werden mußten</supplied>, niemals existierten, aus Furcht <lb n="30"/>
 vor dem Tode und vor der gesetzlichen Strafe.</p>
 </div>
 
@@ -2896,18 +2900,18 @@ als den Anfang des Alls festsetzten, sollten dem entspreched die στοιχεῖ
 </div>
 
 <div type="textpart" subtype="chapter" n="44">
-<p>Er aber (Piaton) setzte wie durch göttliche
+<p>Er aber <supplied reason="undefined" resp="#editor">Piaton</supplied> setzte wie durch göttliche
 fest, was „das immer Seiende, aber niemals Werdende“
 was „das durch Wissen mit der Vernunft Wahrgenommene und immer
 sich selbst “ sei, und sagte, wie weit es reiche, und redete offen-
 kundig und mit offenkundigen Worten schön und weise eine
 <lb n="10"/> göttliche Geschichte der Natur gemäß folgendermaßen:
-auch das alte Wort (lautet), hat Anfang, Ende und Mitte alles Seienden
+auch das alte Wort <supplied reason="undefined" resp="#editor">lautet</supplied>, hat Anfang, Ende und Mitte alles Seienden
 inne und vollendet richtig, indem er naturgemäß dahingeht. Dem aber
 immer die Gerechtigkeit, indem sie ein Rächer ist derer, die hinter
 göttlichen Gesetze zurückbleiben“. Und wie blieb zurück
 <lb n="15"/> hinter dem göttlichen Gesetz und achtete gering die
-die über alles (waltet), und brachte uns die Gesetze der Sterblichen und
+die über alles <supplied reason="undefined" resp="#editor">waltet</supplied>, und brachte uns die Gesetze der Sterblichen und
 fürchtete sich vor dem Tode, er, der die Seele über die
 hinaussandte! Aber nicht lauter hat dieser Mann, scheint mir, seine
 Lehre, ß die Seele der Menschen unsterblich sei, bewahrt, weil er sie
@@ -2915,16 +2919,16 @@ Lehre, ß die Seele der Menschen unsterblich sei, bewahrt, weil er sie
 die der Hunde, Affen, Ameisen, Pferde, Esel und der übrigen unvernünftigen
 Tiere sei unsterblich und in nichts unterschieden von der Seele der
 Philosophen ihrer οὐσία nach. Agyptisierend sagt er, daß nach
-Meinung eben diese (Seelen) allerlei Leiber wechseln und die der Menschen
-<lb n="25"/> in die Natur der Tiere umgegossen werden. Um dieser (Dinge) willen <milestone unit="altnumbering" n="58"/>
+Meinung eben diese <supplied reason="undefined" resp="#editor">Seelen</supplied> allerlei Leiber wechseln und die der Menschen
+<lb n="25"/> in die Natur der Tiere umgegossen werden. Um dieser <supplied reason="undefined" resp="#editor">Dinge</supplied> willen <milestone unit="altnumbering" n="58"/>
 wird er auch darin verachtet, worin er die Wahrheit gesagt Δαὶ, wie jemand,
 mand, der auf der andern Seite lügt. Denn wenn dieser Mann auch
-wundernswert ist (darin), ß er den Werkmeister und Schöpfer
-Alls erreichen (begreifen) konnte, muß er dennoch besonders
+wundernswert ist <supplied reason="undefined" resp="#editor">darin</supplied>, ß er den Werkmeister und Schöpfer
+Alls erreichen <supplied reason="undefined" resp="#editor">begreifen</supplied> konnte, muß er dennoch besonders
 <lb n="30"/> werden bei jedermann, weil er das richtige Wort nicht vorbrachte.
 „Denn obwohl er Gott kannte, pries er ihn nicht als Gott, sondern ehrte
 und diente dem Geschöpfe mehr als seinem Schöpfer“,
-verehrte diejenigen (Wesen), die an sichtbare Körper gebunden
+verehrte diejenigen <supplied reason="undefined" resp="#editor">Wesen</supplied>, die an sichtbare Körper gebunden
 <note type="footnote">6 f. = Piaton Timaios 27 D 10–14 = Piaton Nornoi 716 A; Praep. XI 13
 17 vgl. Praep. XIII 14 3 16 3 20 vgl. Piaton Phaidon 81 D; Praep. XIII 16 4 ᾖ.
 31 = öm 1 21. 25</note>
@@ -2934,9 +2938,9 @@ gemacht “ Σ = ἐκοίνωσεν 26 „wie einer, der in etwas die Wahrheit
 auf der andern Seite aber gelogen “ Σ</note>
 
 <pb n="v.3.pt.2.p.99"/>
-Sonne, Mond und Sterne und bekennt zugleich und in demselben (Atemzuge),
+Sonne, Mond und Sterne und bekennt zugleich und in demselben <supplied reason="undefined" resp="#editor">Atemzuge</supplied>,
 daß sie geworden, vergänglich ihrer
-seien *aus Feuer, Erde und den übrigen στοιχεῖα *und betet sie
+seien <corr resp="#editor">aus</corr> Feuer, Erde und den übrigen στοιχεῖα <corr resp="#editor">und</corr> betet sie
 an zumal, ehrt sie und nennt sie Götter. Hinterher aber bekennt er
 dann wiederum, daß sie auflösbar und vergänglich seien. Doch is es <lb n="5"/>
 an der Zeit, ihn selber zu hören wie er im Timaios sagt:</p>
@@ -2946,28 +2950,28 @@ an der Zeit, ihn selber zu hören wie er im Timaios sagt:</p>
 <p>Gótter der Götter, deren Bildner ich bin. Alles also,
 wird, ist auflösbar. Deswegen weil ihr geworden seid, seid
 nicht unsterblich und völlig unauflösbar“. Ferner aber sagt
-ihr Werden, woher es ist und wie es begrenzt wurde: „daß (sich) das <lb n="10"/>
-Feuer zur Luft so (wie) die Luft zum Wasser und (wie) das Wasser
-zur Erde (verhielt), aus denen er band und hinstellte den sichtbaren und
-*tastbaren Himmel. Und zu diesem Zwecke und aus diesen (Dingen), die
-derart (waren) und deren Zahl vier (betrug (betrug), ward der Körper der
+ihr Werden, woher es ist und wie es begrenzt wurde: „daß <supplied reason="undefined" resp="#editor">sich</supplied> das <lb n="10"/>
+Feuer zur Luft so <supplied reason="undefined" resp="#editor">wie</supplied> die Luft zum Wasser und <supplied reason="undefined" resp="#editor">wie</supplied> das Wasser
+zur Erde <supplied reason="undefined" resp="#editor">verhielt</supplied>, aus denen er band und hinstellte den sichtbaren und
+<corr resp="#editor">tastbaren</corr> Himmel. Und zu diesem Zwecke und aus diesen <supplied reason="undefined" resp="#editor">Dingen</supplied>, die
+derart <supplied reason="undefined" resp="#editor">waren</supplied> und deren Zahl vier <supplied reason="undefined" resp="#editor">betrug</supplied>, ward der Körper der
 Hinterher aber sagt er: „Zum Werden der Zeit, damit die Zeit entstehe. <lb n="15"/>
 entstanden Sonne, Mond und die fünf anderen Sterne, die den
 Wandelsterne haben, zur Abgrenzung und Bewahrung der Zahlen der
 Zeit. Körper aber machte Gott einem jeden von ihnen und setzte
-in die (Kreis bahnen“. Indem er aber ferner vom Himmel
+in die <supplied reason="undefined" resp="#editor">Kreis</supplied>bahnen“. Indem er aber ferner vom Himmel
 „ob er immer war ohne irgend einen Anfang des Werdens, oder ob er <lb n="20"/>
 entstanden ist, von irgend einem Anfang ausgehend“, antwortet er
-sich selber und sagt: „Er ist entstanden; denn er ist sichtbar und *tastbar
+sich selber und sagt: „Er ist entstanden; denn er ist sichtbar und <corr resp="#editor">tastbar</corr>
 bar und hat einen Körper. Alles derartige aber ist wahrnehmbar
 das Wahrnehmbare wird durch die Vorstellung begriffen und erscheint
 <milestone unit="altnumbering" n="59"/> als geworden“.</p>  
 </div>
 
 <div type="textpart" subtype="chapter" n="46">
-<p>Er also, der so über diese (Dinge) schön und <lb n="25"/>
+<p>Er also, der so über diese <supplied reason="undefined" resp="#editor">Dinge</supplied> schön und <lb n="25"/>
 richtig geredet hat, entfernte er sich nicht weit von der gesunden Meinung,
-indem er sie Götter nannte, (zugleich) aber bekannte, daß
+indem er sie Götter nannte, <supplied reason="undefined" resp="#editor">zugleich</supplied> aber bekannte, daß
 seien aus der vergänglichen ὕλη der Körper des Feuers,
 <note type="footnote">6–9 = Piaton Timaios 41 A; Praep. XIII 18 10 10–14 =
 32 B; Praep. XIII 184 15 — 19 = Piaton Timaios 38 C; Praep. XIII 18 6
@@ -2981,40 +2985,40 @@ seien aus der vergänglichen ὕλη der Körper des Feuers,
 “ (oder „Erstlings“) Σ = ἀπαρχῆς 22 ἁπτός] „wahrnehmbar“ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.100"/>
-der Luft und der Erde? Er sagt (zwar), ß diese auflösbar
+der Luft und der Erde? Er sagt <supplied reason="undefined" resp="#editor">zwar</supplied>, ß diese auflösbar
 ihrer Natur nach und vergänglich, dann aber nennt er eben
 ehrenwerte Götter. Was für eine Geroeinschaft nun hat der Name
-Ehre *der Ursache des Alls mit den wahrnehmbaren und auflösbaren
-<lb n="5"/> Körpern? Oder welche Gemeinschaft (hat) die Vernunft, die „das
-Seiende, niemals “ *hernorbringt, mit „dem immer Werdenden,
-niemals Seienden“, daß er diese (Dinge) beidemal Götter
+Ehre <corr resp="#editor">der</corr> Ursache des Alls mit den wahrnehmbaren und auflösbaren
+<lb n="5"/> Körpern? Oder welche Gemeinschaft <supplied reason="undefined" resp="#editor">hat</supplied> die Vernunft, die „das
+Seiende, niemals “ <corr resp="#editor">hernorbringt</corr>, mit „dem immer Werdenden,
+niemals Seienden“, daß er diese <supplied reason="undefined" resp="#editor">Dinge</supplied> beidemal Götter
 wenn „das immer Seiende, niemals Werdende“ in Wahrheit Gott
-(dann) ist alles, was nicht so ist, nicht Gott. Wenn aber „das immer
-<lb n="10"/> Werdende, niemals Seiende“ (Gott ist), (dann) ist alles, was anders
+<supplied reason="undefined" resp="#editor">dann</supplied> ist alles, was nicht so ist, nicht Gott. Wenn aber „das immer
+<lb n="10"/> Werdende, niemals Seiende“ <supplied reason="undefined" resp="#editor">Gott ist</supplied>, <supplied reason="undefined" resp="#editor">dann</supplied> ist alles, was anders
 nicht Gott. Welcher Schluß ist klarer als dieser? Denn beide
 die ihrer Natur nach entgegengesetzt sind, — das eine, das „durch
-das mit Vernunft (begabte) Wissen “, das andere, das
+das mit Vernunft <supplied reason="undefined" resp="#editor">begabte</supplied> Wissen “, das andere, das
 „mit unvernünftigem Sinne gewähnt wird“, das
-<lb n="15"/> zu schaffen, das andere (mit der Fähigkeit) zu leiden — wie sollen
-entgegengesetzten (Dinge) Eines Namens würdig sein? Denn es
+<lb n="15"/> zu schaffen, das andere <supplied reason="undefined" resp="#editor">mit der Fähigkeit</supplied> zu leiden — wie sollen
+entgegengesetzten <supplied reason="undefined" resp="#editor">Dinge</supplied> Eines Namens würdig sein? Denn es
 natürlich, wie jemand, der sich wundert über das Wissen des
-meisters, der aber (dennoch) die Ehre dem von ihm (herrührenden)
+meisters, der aber <supplied reason="undefined" resp="#editor">dennoch</supplied> die Ehre dem von ihm <supplied reason="undefined" resp="#editor">herrührenden</supplied>
 Werke zufügt, und wie jemand, der das Schiff κυβερνήτης und
-<lb n="20"/> mit Pferden (bespannten) Wagen ἡνίοχος nennt, die (richtige) Ordnung
+<lb n="20"/> mit Pferden <supplied reason="undefined" resp="#editor">bespannten</supplied> Wagen ἡνίοχος nennt, die <supplied reason="undefined" resp="#editor">richtige</supplied> Ordnung
 verkehrt, daß so also sehr töricht handelt derjenige, der
 die Geschöpfe Gottes Götter zu nennen, obwohl er
 ganz deutlich zugibt, daß sie durch die Fesseln Gottes,
-des Alls, *gebunden seien und aus seelenlosen στοιχεῖα, (aus) Feuer,
-<lb n="25"/> Wasser, Luft und Erde best:ünden. Aber auch der (Piaton möge)
-(beendigt sein).</p>
+des Alls, <corr resp="#editor">gebunden</corr> seien und aus seelenlosen στοιχεῖα, <supplied reason="undefined" resp="#editor">aus</supplied> Feuer,
+<lb n="25"/> Wasser, Luft und Erde best:ünden. Aber auch der <supplied reason="undefined" resp="#editor">Piaton möge</supplied>
+<supplied reason="undefined" resp="#editor">beendigt sein</supplied>.</p>
 </div>
 <div type="textpart" subtype="chapter" n="47">
-<p>Was habe ich jetzt (noch) nötig, ans klare Licht zu
+<p>Was habe ich jetzt <supplied reason="undefined" resp="#editor">noch</supplied> nötig, ans klare Licht zu
 wie die Weisen sich gleichsam in Reihen sammelten, sich entzweiten
 und trennten von einander, sich wie in Schlachtreihe und Kampf
 <lb n="30"/> mächtig widereinander rüsteten. „Sie begegneten sich aber
 Lanzen und Männerkraft, wie einer von den Poeten sagt, indem fürwahr
-gewaltiger Tumult *erregt wrurde der Vernichtenden und der Vernichteten“.</p>
+gewaltiger Tumult <corr resp="#editor">erregt</corr> wrurde der Vernichtenden und der Vernichteten“.</p>
 <note type="footnote">5 ff. vgl. Piaton Timaios 27 D; Praep. XI 9 4 23 vgl. Piaton Timaios 41 A
 28 vgl. Homer llias ιβ 80 30 = Homer Ilias δ 447. 449. 451; Praep. XIV 6 7</note>
 <note type="footnote">4 <foreign xml:lang="abbr">ABBREV</foreign>] 1. <foreign xml:lang="abbr">ABBREV</foreign> 6 <foreign xml:lang="abbr">ABBREV</foreign>] zur Not: „die mit dem immer Seienden . . . .
@@ -3051,14 +3055,14 @@ mit Lanzen und Schilden und beschossen einer den andern. Wo es nicht
 recht war. entzweiten sie sich, wo es aber notwendig war, mit aller Kraft
 zu ringen, kamen sie überein, ich weiß nicht wie. Vor allem aber
 sie sich in dem Irrtum des Polytheismus, obwohl sie vor jedermann und
-besser als alle Menschen wußten, das es nichts (mit ihm) sei; das heißt <lb n="20"/>
+besser als alle Menschen wußten, das es nichts <supplied reason="undefined" resp="#editor">mit ihm</supplied> sei; das heißt <lb n="20"/>
 aber, die Epikureer mitsamt den Stoikern und Aristotelikern, mitsamt
 den Piatonikern und Physikern, mitsamt den Skeptikern zumal, mitsamt
 ihren Weibern und Töchtern und mitsamt der Schar der Laien
 in die Tempel, stellten sich, als ob sie die seelenlosen, nach Art der
-Menschen (gebildeten) Götzen mit Gelübden als Götter anbeteten, und <lb n="25"/>
+Menschen <supplied reason="undefined" resp="#editor">gebildeten</supplied> Götzen mit Gelübden als Götter anbeteten, und <lb n="25"/>
 taten, als ob sie sie mit Spenden, Fettgeruch, dem Blute und den Opfern unvernünftiger
-Tiere ehrten. Nur in diesem Einen (Punkte) ließen sie
+Tiere ehrten. Nur in diesem Einen <supplied reason="undefined" resp="#editor">Punkte</supplied> ließen sie
 von ihrer gegenseitigen Feindschaft. Hier bekannten alle sorgfältig
 ihren Irrtum. Wo ihnen aber die Wahrheit offenkundig war, taten sie
 das Gegenteil von ihr, während es recht gewesen wäre, dort, wo ihr <lb n="30"/>
@@ -3072,19 +3076,19 @@ Eben jene aber waren hierin liebevoll gegen einander, indem sie sich <lb n="35"/
 <note type="footnote">9 „Jünglinge“ Σ (= νεώτεροι?) ß 33 „und" &lt;Σ 1.</note>
 
 <pb n="v.3.pt.2.p.102"/>
-wegen des Verborgenen und Unbekannten dieser (Dinge), darüber
+wegen des Verborgenen und Unbekannten dieser <supplied reason="undefined" resp="#editor">Dinge</supplied>, darüber
 stritten sie wie um die Wahrheit und kämpften willig
 Dinge, indem sie einander beschossen und verwundeten mit unzähligen
-Worthieben. Was habe ich ötig, *festzustellen, ß die Weisen in ihren
+Worthieben. Was habe ich ötig, <corr resp="#editor">festzustellen</corr>, ß die Weisen in ihren
 <lb n="5"/> gegenseitigen Kampf, in ihre feindlichen Worte und in ihren gemeinsamen
 Krieg verfielen, weil sie menschliche Weisheit benutzten und
-sterbliche Erwägungen (und) Gedanken, aber nicht Gott als
+sterbliche Erwägungen <supplied reason="undefined" resp="#editor">und</supplied> Gedanken, aber nicht Gott als
 trafen?</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="50">
 <p>Was also? Warum hatten diejenigen keinen Gott, die um diese
-<lb n="10"/> (Dinge) kämpften, obwohl doch die Schar der Götter
+<lb n="10"/> <supplied reason="undefined" resp="#editor">Dinge</supplied> kämpften, obwohl doch die Schar der Götter
 war? Mochte auch der von Delphi und der von Lebadia weissagen,
 mochte der von Kolophon Antwort erteilen und der von Milet orakeln,
 mochte ein anderer von anderer Gegend her rufen, dennoch konnte
@@ -3095,49 +3099,49 @@ nicht im geringsten gefördert in der Auffindung göttlicher
 obwohl es kein Hindernis für sie gab, au der Stelle in der
 zu wandeln, indem sie als Lehrer die Götter benutzten, die ihnen
 <lb n="20"/> Erden nahe waren, indem sie nicht mit einander kämpften und
-sondern vom Geschrei schwiegen und die Götter über die (Dinge)
-Streites befragten und die Wahrheit (von ihnen) wie von Arzten lernten
-und sich (von ihnen) helfen ließen. Zuerst war es für
+sondern vom Geschrei schwiegen und die Götter über die <supplied reason="undefined" resp="#editor">Dinge</supplied>
+Streites befragten und die Wahrheit <supplied reason="undefined" resp="#editor">von ihnen</supplied> wie von Arzten lernten
+und sich <supplied reason="undefined" resp="#editor">von ihnen</supplied> helfen ließen. Zuerst war es für
 Epikurs zu lernen nötig, nicht ohne Götter sein, sich
 <lb n="25"/> Lust unterwerfen, nicht töricht sein in so lächerlichen
 kleinen, unteilbaren Körpern die Kraft beilegen, die Welt zu
 sondern sich überzeugen lassen von den Göttern, indem sie dies über
 lernen. Die Anhänger des Aristoteles aber, die mit ihren eigenen
-die Tempel, Heiligtümer und (Götter)bilder auf Erden
+die Tempel, Heiligtümer und <supplied reason="undefined" resp="#editor">Götter</supplied>bilder auf Erden
 <lb n="30"/> eines, sondern Myriaden in allen Städten und an allen
-ihre (der Götter) Macht prüfen und (durften) infolge
-fernerhin nicht (mehr) ihre Worte über die Vorsehung oberhalb des
+ihre <supplied reason="undefined" resp="#editor">der Götter</supplied> Macht prüfen und <supplied reason="undefined" resp="#editor">durften</supplied> infolge
+fernerhin nicht <supplied reason="undefined" resp="#editor">mehr</supplied> ihre Worte über die Vorsehung oberhalb des
 Himmels noch oberhalb des Mondes festhalten, sondern mußten
 überzeugen, ß es auch auf Erden Götter gebe, und daß sie sich um <milestone unit="altnumbering" n="62"/>
 <lb n="35"/> die Menschen kümmern, mit denen sie zusammen sind. Von eben
-(mußten sie) lernen, daß es ihnen nicht erlaubt sei,
-denen zu kämpfen, die ihnen entgegentraten, (darum), ob die Seele
+<supplied reason="undefined" resp="#editor">mußten sie</supplied> lernen, daß es ihnen nicht erlaubt sei,
+denen zu kämpfen, die ihnen entgegentraten, <supplied reason="undefined" resp="#editor">darum</supplied>, ob die Seele
 <note type="footnote">4 1. <foreign xml:lang="abbr">ABBREV</foreign> „daß ich “ statt <foreign xml:lang="abbr">ABBREV</foreign> „in ihrem gemeinsamen
 Kriege, den sie “ Σ 31 „Untersuchung“ „Heimsuchung“ Σ = ἐπισκοπή
 36 1. <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.103"/>
 lieh oder unsterblich sei. sondern daß sie den nächsten Gott
-ein wahres wie von den Göttern (herstammendes) Wort annahmen.
-(mußten) auch die Stoiker, so auch die Platoniker. so auch die Skeptiker,
-sogenannten *Pyrrhoniker, so ferner auch die früheren (so)genannten
-(lernen), nicht ablassen von der Sorge um die Wahrheit <lb n="5"/>
+ein wahres wie von den Göttern <supplied reason="undefined" resp="#editor">herstammendes</supplied> Wort annahmen.
+<supplied reason="undefined" resp="#editor">mußten</supplied> auch die Stoiker, so auch die Platoniker. so auch die Skeptiker,
+sogenannten <corr resp="#editor">Pyrrhoniker</corr>, so ferner auch die früheren <supplied reason="undefined" resp="#editor">so</supplied>genannten
+<supplied reason="undefined" resp="#editor">lernen</supplied>, nicht ablassen von der Sorge um die Wahrheit <lb n="5"/>
 und nicht alles für wahr halten, was in den Sinn kommt, als ob
 Würfel spiele, sondern über alles Unbekannte die Götter
 bei ihnen wohnen. Allein auch nicht einer von den Weisen tat dies
-noch *bedachte er es. Warum waren sie denn gottlos und überdrüssig der
+noch <corr resp="#editor">bedachte</corr> er es. Warum waren sie denn gottlos und überdrüssig der
 Götter in frevelhaftem Sinn und taten dies? Aber so erscheinen alle Philosophen <lb n="10"/>
-zumal *besondersgottlos gottlos und viel schlimmer als die törichten
+zumal <corr resp="#editor">besondersgottlos</corr> gottlos und viel schlimmer als die törichten
 die nicht überdrüssig werden, die Götter zu befragen beim Nehmen
 Weibes, beim Gehen eines Weges, bei Blindheit und bei Leibeskrankheit. Sie
-(die Götter) aber wurden willig angehört und weissagten
+<supplied reason="undefined" resp="#editor">die Götter</supplied> aber wurden willig angehört und weissagten
 die sie baten. Die Weisen fürwahr hatten nicht nötig, um ihrer Leiber <lb n="15"/>
-willen, (wohl) aber um der Heilung ihrer Seelen willen die Götter zu
-befragen, die bei ihnen (wohnten), die sie anbeteten und ehrten. Da
+willen, <supplied reason="undefined" resp="#editor">wohl</supplied> aber um der Heilung ihrer Seelen willen die Götter zu
+befragen, die bei ihnen <supplied reason="undefined" resp="#editor">wohnten</supplied>, die sie anbeteten und ehrten. Da
 dies aber auch nicht einer von den bewundernswerten Philosophen tat.
-bleibt (nur übrig), eines von beiden anzuerkennen: entweder, daß
+bleibt <supplied reason="undefined" resp="#editor">nur übrig</supplied>, eines von beiden anzuerkennen: entweder, daß
 nicht weise sind oder daß jene keine Götter sind. Denn wenn siel jene, <lb n="20"/>
-obwohl sie in Wahrheit Götter (waren), verachteten, waren sie
+obwohl sie in Wahrheit Götter <supplied reason="undefined" resp="#editor">waren</supplied>, verachteten, waren sie
 weise, sondern Toren und Idioten. Wenn sie aber in Wahrheit die
 Liebe zur Weisheit gepflegt und Überfluß an Wissen mehr als die meisten
 gehabt hätten, so wäre dies klar, daß sie mit reinem
@@ -3145,17 +3149,17 @@ Torheit der Menge aller Wahrscheinlichkeit nach gespottet hätten. <lb n="25"/><
 </div>
 
 <div type="textpart" subtype="chapter" n="51">
-<p>Wenn die (so)genannten Götter aber in Wahrheit existierten,
+<p>Wenn die <supplied reason="undefined" resp="#editor">so</supplied>genannten Götter aber in Wahrheit existierten,
 traf es sie, in dem Verkehr auf Erden wohnen zu müssen? Gewiß
 um der Gesamtheit aller Menschen zu helfen? Wenn aber dies der
 Fall war, warum unterließen sie dann nicht jene jene
-<milestone unit="altnumbering" n="63"/> und verkündeten (lieber) jedermann, was zum Erwerb der Tugend hilft? <lb n="30"/>
+<milestone unit="altnumbering" n="63"/> und verkündeten <supplied reason="undefined" resp="#editor">lieber</supplied> jedermann, was zum Erwerb der Tugend hilft? <lb n="30"/>
 Warum boten sie sich nicht selber an, den Menschen Gesetze zu geben,
-indem sie *recht machten die Sitten der Allgemeinheit und für
+indem sie <corr resp="#editor">recht</corr> machten die Sitten der Allgemeinheit und für
 Werke anordneten zu einem besseren Leben? Warum kümmerten
 sie sich nicht vielmehr um die Heilung der seelischen Leidenschaften
 statt um die der Leiber und befreiten diejenigen, die zu ihnen ihre Zuflucht <lb n="35"/>
-nahmen, (nicht) viel mehr von der Torheit und der ἰδιωτεία als
+nahmen, <supplied reason="undefined" resp="#editor">nicht</supplied> viel mehr von der Torheit und der ἰδιωτεία als
 <note type="footnote">4 1. <foreign xml:lang="abbr">ABBREV</foreign> Lee 9 1. <foreign xml:lang="abbr">ABBREV</foreign> ß 11 „und" Σ str. 27 „in
 dem “ Σ oder „an dem Wohnort"? vermutlich ἐν διατριβῇ Ι „oder öllig“
 Σ; vermutlich ἥ που 32 „indem recht gemacht wurden" 1. <foreign xml:lang="abbr">ABBREV</foreign> entsprechend
@@ -3164,10 +3168,10 @@ dem “ Σ oder „an dem Wohnort"? vermutlich ἐν διατριβῇ Ι „ode
 <pb n="v.3.pt.2.p.104"/>
 von dem Mangel an Besitz? Und wenn sie die Menschen sahen, die
 <lb n="5"/> die Weisheit liebten, die bei Tag und bei Nacht elend waren um des
-(Suchens und) Findens der Wahrheit willen, die unter Qualen und
+<supplied reason="undefined" resp="#editor">Suchens und</supplied> Findens der Wahrheit willen, die unter Qualen und
 Martern nach einem Worte forschten über die Furcht eben dieser Götter.
 ὁ die dann hineingingen in die Orakelstätten, ihnen opferten gleich
-Vorfahren und sie ehrten mit den Ehren, die sie (die Götter) nach
+Vorfahren und sie ehrten mit den Ehren, die sie <supplied reason="undefined" resp="#editor">die Götter</supplied> nach
 Gewohnheit inne hatten, warum nahmen sie sie dann nicht auf mit
 liebevollen Worten, belobten sie wegen Ihrer Mühe, Múhe, losten
 los von ihrem gegenseitigen Kampf, gewährten ihnen infolge
@@ -3179,15 +3183,15 @@ rühmten, Philosophen zu sein, dieses Namens wert seien. Denn
 <lb n="15"/> sie in Wahrheit weise gewesen wären, so ätten sie jene
 Götter gehalten, da sie etwas Götterwürdiges
 noch das Göttliche diejenigen zu lehren vermochten, die sich um
-Wissen dieser (Dinge) kümmerten.</p>
+Wissen dieser <supplied reason="undefined" resp="#editor">Dinge</supplied> kümmerten.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="52">
 <p>Sie aber, die nicht so
 sondern der Menge heuchelten und Götter diejenigen nannten, von
-<lb n="20"/> sie besser als jedermann (und) genau wußten, daß sie
+<lb n="20"/> sie besser als jedermann <supplied reason="undefined" resp="#editor">und</supplied> genau wußten, daß sie
 welches Namens sind sie würdig? Ich brauche nichts weiter zu
-als daß sie, die ihre Haarlocken (lang) herabfallen ließen,
+als daß sie, die ihre Haarlocken <supplied reason="undefined" resp="#editor">lang</supplied> herabfallen ließen,
 Gastwirten, verworfenen Männern und Huren in die Tempel
 Was fragten denn jene Weisen von den Göttern? Das, was den
 <lb n="25"/> nützt? Niemand dürfte das von ihnen behaupten. So also
@@ -3201,7 +3205,7 @@ mit etwas Hahnenblut oder durch die Schlachtung eines Widders oder
 Stieres und mit Kuchen und mit λαγάνιον oder mit etwas Mehl oder
 mit vergänglichen Kränzen bewundernd und staunend
 <lb n="35"/> kein Gott war ihnen ein wahrhaftiger Lehrer für das, was mit
-Tugend stimmt, noch *einer für das, was zur Heilung der Seele
+Tugend stimmt, noch <corr resp="#editor">einer</corr> für das, was zur Heilung der Seele
 Deswegen scheinen mir die Weisen zwar stark am Kriege gegen einander
 <note type="footnote">26 vgl. Dem. V Prooem. 17</note>
 <note type="footnote">22 „Haarlocken" Σ (= πώγων?) 36 streiche <foreign xml:lang="abbr">ABBREV</foreign> „und" vor ABBVER <foreign xml:lang="abbr">ABBREV</foreign></note>
@@ -3210,7 +3214,7 @@ Deswegen scheinen mir die Weisen zwar stark am Kriege gegen einander
 gearbeitet und ihren Unterschied von einander sehr gefestigt zu haben,
 aber hinter dem wahren göttlichen Wissen zurückgeblieben zu sein.
 So war es zwar möglich, in ihren Worten von Göttern, Göttersöhnen,
-Halbgöttern (ἡμίθεοι) und guten Dämonen zu hören, in ihren Taten aber
+Halbgöttern <supplied reason="undefined" resp="#editor">ἡμίθεοι</supplied> und guten Dämonen zu hören, in ihren Taten aber
 war alles das Gegenteil. Das Entgegengesetzte also war stolz auf das <lb n="5"/>
 Entgegengesetzte wie jemand, der die Sonne und die Lichter am Himmel
 jemandem zeigen will, seine Augen nicht nach oben erheben, sondern
@@ -3220,7 +3224,7 @@ suchen möchte. Demgemäß also war auch das ganze Geschlecht der <lb n="10"/>
 Menschen zumal mit den Philosophen und Königen durch Verstandeswahnsinn
 und durch Verführung der bösen Dämonen überzeugt, daß die
 geistige und göttliche οὐσία, die jenseits des Himmels und jenseits der
-Welt (ist), unten irgendwo in der Entstehung der Körper und in den
+Welt <supplied reason="undefined" resp="#editor">ist</supplied>, unten irgendwo in der Entstehung der Körper und in den
 Leidenschaften und Todesfällen der Sterblichen sei. Da so großer Verstandeswahnsinn <lb n="15"/>
 das ganze Geschlecht der Menschen schädigte, wie haben
 wir da nicht mit Recht gesagt, daß Gott als Erlöser und die göttliche
@@ -3229,8 +3233,8 @@ war?</p>
 </div>
 <div type="textpart" subtype="chapter" n="53">
 <p>So weit aber waren ferner viele zum Wahnsinn geführt, daß <lb n="20"/>
-sie auch ihr Liebstes opferten denen, die Götter (zu sein) schienen und
-kein *Mitleid hatten mit der Natur, sondern sogar ihre einzigen und
+sie auch ihr Liebstes opferten denen, die Götter <supplied reason="undefined" resp="#editor">zu sein</supplied> schienen und
+kein <corr resp="#editor">Mitleid</corr> hatten mit der Natur, sondern sogar ihre einzigen und
 geliebten Kinder im Wahnsinn und in der Raserei des Verstandes töteten.
 Denn welcher Wahnsinn könnte größer sein als der, Menschen
 <milestone unit="altnumbering" n="65"/> zu opfern und alle ihre Städte und alle ihre Häuser mit dem eigenen <lb n="25"/>
@@ -3243,7 +3247,7 @@ ist nicht ihre ganze Geschichte voll von der Erinnerung daran?</p>
 einzigen Kinder. Eben demselben wurde ferner auch auf Rhodos am
 sechsten im Monat Kanôn ein Mensch geschlachtet. Diese Sitte war sehr <lb n="30"/>
 mächtig, wurde dann aber geändert. Denn Einen von denen, die von
-Staats wegen zum Tode verurteilt waren, bewahrten sie bis zum *Fest
+Staats wegen zum Tode verurteilt waren, bewahrten sie bis zum <corr resp="#editor">Fest</corr>
 <note type="footnote">3—15 = Laus 237 31—238 9 20—30 = Laus 238 10—19 30—S. 107, 20
 = Porphyrius, De abstinentia II 54—56. 27; Praep. IV 16; vgl. Laus 238 19—239 6.</note>
 <note type="footnote">7 δεῖζαί τῳ βουληθεὶς] „demjenigen“ = τῷ Σ 15 ἐν σωμάτων γενέσει καὶ
@@ -3253,12 +3257,12 @@ l. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.106"/>
 des Kronos auf. Als aber das Fest begann, führten sie den Mann
-den Toren heraus (bis) gegenüber dem Bilde der
+den Toren heraus <supplied reason="undefined" resp="#editor">bis</supplied> gegenüber dem Bilde der
 ihn mit Wein und töteten ihn.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="55">
-<p>In dem jetzt (so) genannten
+<p>In dem jetzt <supplied reason="undefined" resp="#editor">so</supplied> genannten
 dem früheren Koroneia, wurde in dem Monat, der bei den
 <lb n="5"/> Aphrodisios heißt, der Agraulos, der Tochter des Kekrops
 der agraulischen Nymphe, ein Mensch geschlachtet. Diese Sitte dauerte
@@ -3276,7 +3280,7 @@ Kypern ab, der um die Zeit des Theologen Seleukos lebte, und änderte die
 <div type="textpart" subtype="chapter" n="56">
 <p>Es schaffte aber auch zu Heliopolis
 in Agypten Amosis das Gesetz, daß Menschen geopfert wurden, ab, wie
-Manethos bezeugt in den (Büchern) über den Anfang und über die
+Manethos bezeugt in den <supplied reason="undefined" resp="#editor">Büchern</supplied> über den Anfang und über die
 Gerechtigkeit.</p>
 </div>
   
@@ -3284,11 +3288,11 @@ Gerechtigkeit.</p>
 <p>Sie wurden aber <del>auch</del> der Hera geopfert und
 ausgewählt, wie reine Kälber geprüft und geschlachtet werden. Es
 <lb n="20"/> wurden aber drei am Tage geopfert. Dafür befahl Amosis, daß gleiche
-ihnen (an Zahl) entsprechende (Bilder) aus Wachs auferlegt würden.</p>
+ihnen <supplied reason="undefined" resp="#editor">an Zahl</supplied> entsprechende <supplied reason="undefined" resp="#editor">Bilder</supplied> aus Wachs auferlegt würden.</p>
 </div>
   
 <div type="textpart" subtype="chapter" n="58">
-<p>Man opferte aber auch in Chios dem *Omadios Dionysos einen Menschen,
+<p>Man opferte aber auch in Chios dem <corr resp="#editor">Omadios</corr> Dionysos einen Menschen,
 indem man ihn zerriss, und in Tenedos, wie Euelpis, der Karystier, sagt. <milestone unit="altnumbering" n="66"/></p>
 </div>
 
@@ -3297,7 +3301,7 @@ indem man ihn zerriss, und in Tenedos, wie Euelpis, der Karystier, sagt. <milest
 <lb n="25"/> einen Menschen. Die Phöniker aber opferten bei großen
 wie Kriegen oder Seuchen oder Hungersnöten einen der
 der ausgewählt wurde, dem Kronos. Voll aber ist die Geschichte
-Phöniker von denen, die geopfert wurden, welche *von
+Phöniker von denen, die geopfert wurden, welche <corr resp="#editor">von</corr>
 in phönikischer Sprache geschrieben wurde, die aber Philon Byblios
 <note type="footnote">5 τῇ Ἀγραύλῳ τῇ Κέκροπος καὶ νύμφης Ἀγραυλίδος] “der Argaulos, der
 Tocliter des Kekrops und der Schwiegertochter des “ Σ 9 „Argaulos“ Σ
@@ -3318,7 +3322,7 @@ die griechische Sprache in acht Büchern übersetzte.</p>
 <div type="textpart" subtype="chapter" n="60">
 <p>Istros aber 
 sagt in der Sammlung der kretisechen Opfer, ß die Kureten früher &lt;dem
-Kronos) Kinder opferten. Die Menschenopfer aber, die (fast) an jedem
+Kronos) Kinder opferten. Die Menschenopfer aber, die <supplied reason="undefined" resp="#editor">fast</supplied> an jedem
 Ort waren, wurden abgeschafft, sagt Pallas, der am vorzüglichsten über
 die Mysterien des Mithras gesammelt hat, in den Tagen des Königs <lb n="5"/>
 Hadrian.</p>
@@ -3347,17 +3351,17 @@ insgesamt Menschen opferten, bevor sie in den Krieg hinauszogen.</p>
 Athener die Tochter des Erechtheus und der Praxithea töteten.
 wem wäre verborgen, daß bis jetzt in der Hauptstadt am Feste des <lb n="15"/>
 latiarischen Zeus ein Mensch geopfert wird? Bis jetzt aber opfern keines-
-wegs nur in Arkadien alle insgesamt Menschen am Feste des *Lykäers
-(Zeus), auch nicht (nur) in Karchedon dem Kronos, sondern sie spritzen
-um der gesetzlichen Erinnerung willen in jedem Jahr eigenes (Stammes)blut
+wegs nur in Arkadien alle insgesamt Menschen am Feste des <corr resp="#editor">Lykäers</corr>
+<supplied reason="undefined" resp="#editor">Zeus</supplied>, auch nicht <supplied reason="undefined" resp="#editor">nur</supplied> in Karchedon dem Kronos, sondern sie spritzen
+um der gesetzlichen Erinnerung willen in jedem Jahr eigenes <supplied reason="undefined" resp="#editor">Stammes</supplied>blut
 fortwährend an die Altäre“. Daß dies so sei, bezeugen auch die <lb n="20"/>
 erlesensten Philosophen. Diodoros aber, der die Bibliotheken ver-
 <milestone unit="altnumbering" n="67"/> kleinerte, sagt, daß die Libyer dem Kronos zweihundert der
 Kinder von Staatsivegen opferten, daß sie aber dreihundert andere,
-*geringer(en Standes) als diese, dem Opfer (der Vorfahren) hinzufügten.
+<corr resp="#editor">geringer</corr><supplied reason="undefined" resp="#editor">en Standes</supplied> als diese, dem Opfer <supplied reason="undefined" resp="#editor">der Vorfahren</supplied> hinzufügten.
 Der Historiker der römischen Geschichte, mit Namen Dionysius, aber <lb n="25"/>
 sagt, daß Zeus und Apollon einmal Menschenopfer forderten in
-von den (so)genannten Aboriginern, daß aber die Gebetenen den
+von den <supplied reason="undefined" resp="#editor">so</supplied>genannten Aboriginern, daß aber die Gebetenen den
 <note type="footnote">20–8. 108, 6 = Laus 239 7–17 21 vgl. Diodor. XX u; Praep. IV
 25 vgl. Dion. Hai. I 23 f.; Praep. IV 16 15</note>
 <note type="footnote">1 Ἴστρος δὲ ἐν τῇ Συναγωγῇ τῶν Κρητικῶν θυσιῶν φησι Ρ] „Istros aber sagt,
@@ -3372,37 +3376,37 @@ L brige ist in Ordnung, οὐκ ἐλάττους δὲ ἐπιδοῦναι τ
 
 <pb n="v.3.pt.2.p.108"/>
 in allerlei Früchten und Vieh den Göttern opferten. Weil
-nicht (auch) Menschen opferten, seien sie in mannigfaches Unglück
+nicht <supplied reason="undefined" resp="#editor">auch</supplied> Menschen opferten, seien sie in mannigfaches Unglück
 und hätten nicht früher Ruhe gehabt vor dem Unheil, als
 sich dezimierten. Indem so also der zehnte Teil der Menschen vertilgt
-<lb n="5"/> und dem Zeus und Apollon geopfert wurde, wurden sie (selbst) die
+<lb n="5"/> und dem Zeus und Apollon geopfert wurde, wurden sie <supplied reason="undefined" resp="#editor">selbst</supplied> die
 Ursache der Verwüstung des Landes. So große Verderbnis
 vernichtete das Leben der Menschen, daß sie eine andere Hoffnung
-Erlösung (sich) nicht verschreiben konnten als die von Gott,
+Erlösung <supplied reason="undefined" resp="#editor">sich</supplied> nicht verschreiben konnten als die von Gott,
 der allein — und kein anderer — dem sterblichen Geschlecht nötig
 <lb n="10"/> war.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="65">
-<p>In solchen (Zuständen) der Seele waren alle Menschen
+<p>In solchen <supplied reason="undefined" resp="#editor">Zuständen</supplied> der Seele waren alle Menschen
 jedem Ort.</p>
-<p>Nicht genügte ihnen aber ausser diesen (Dingen)
+<p>Nicht genügte ihnen aber ausser diesen <supplied reason="undefined" resp="#editor">Dingen</supplied>
 sondern sie wurden auch von außen her an jedem Ort und in
 Stadt durch Myriaden andere, unheilbare Unfälle gequält.
 <lb n="15"/> Völker zumal in der ganzen Welt, Barbaren und Griechen wurden
-von der Wirksamkeit dämonischer Raserei *in Wut versetzt (und)
+von der Wirksamkeit dämonischer Raserei <corr resp="#editor">in</corr> Wut versetzt <supplied reason="undefined" resp="#editor">und</supplied>
 schwere und böse Krankheit beunruhigt, sodaß das
 Menschen ohne Verkehr und ohne Versöhnung war mit sich selber,
 der große Körper der gemeinsamen Natur hierhin
-<lb n="20"/> gerissen wurde, indem die Menschen in jedem Winkel der Erde *abfielen
+<lb n="20"/> gerissen wurde, indem die Menschen in jedem Winkel der Erde <corr resp="#editor">abfielen</corr>
 und mit Sitten und Gesetzen einander bekämpften, und
-nur dies, sondern (indem) sie auch wild wurden durch häufige
+nur dies, sondern <supplied reason="undefined" resp="#editor">indem</supplied> sie auch wild wurden durch häufige
 wider einander, sodaß sie immer und wáhrend
 Lebens mit Kämpfen und Kriegen wider einander beschäftigt
 <lb n="25"/> sodaß es nicht möglich war, irgendwohin in Geshäften
-wenn man nach Art des *Kriegers gerüstet war, und (sodaß)
+wenn man nach Art des <corr resp="#editor">Kriegers</corr> gerüstet war, und <supplied reason="undefined" resp="#editor">sodaß</supplied>
 Dörfern und auf den Ackern die Feldarbeiter mit Schwertern
-waren und mehr *Ausrüstung als äte be- <milestone unit="altnumbering" n="68"/>
+waren und mehr <corr resp="#editor">Ausrüstung</corr> als äte be- <milestone unit="altnumbering" n="68"/>
 <note type="footnote">12–8. 109, 2 = Laus 239 19—240 2</note>
 <note type="footnote">1 καρπῶν . . . . καὶ βοσκημάτων Ρ „Früchten und “ Σ (= βλαστημάτων?)
 4 ἀφαιρουμένους L „ausgewählt“ Σ (= ἐξαιρουμένους, wohl nicht
@@ -3429,7 +3433,7 @@ und Fürsten der Länder gab.</p>
 nach dem Auszug aus Ägypten durch Mose, in das Land Palästina
 kamen, verfolgten sie dreißig Könige an der Zahl
 Es blieben aber, ohne ausgerottet zu werden, indem sie ihre Einwohner, <lb n="10"/>
-ihren Wohnort und ihre Könige (auch fernerhin) <del>in Gebrauch</del>
+ihren Wohnort und ihre Könige <supplied reason="undefined" resp="#editor">auch fernerhin</supplied> <del>in Gebrauch</del>
 diejenigen, die in Gaza und Askalon wohnten. Joppe und Asdod ferner wurden
 den besonders für sich beherrscht. Skythopolis und die Städte um es
 herum wurden so regiert, daß es sich daher ereignete, daß sie die ganze
@@ -3439,8 +3443,8 @@ wurde, den Salomo baute, was habe ich nötig zu sagen, wieviel
 hinterher auch vom Volk der Juden aus Rache feführt wurden
 Vernachlässignung der Verehrung ihres Gottes, sodaß deswegen
 sich von einander trennten und wider einander erhoben, sodaß sie verschiedene <lb n="20"/>
-schiedene und *feindliche Könige <del>in Gebrauch</del> hatten, von denen
-einen das früher (so)genannte Samarien, jetzige Sebaste
+schiedene und <corr resp="#editor">feindliche</corr> Könige <del>in Gebrauch</del> hatten, von denen
+einen das früher <supplied reason="undefined" resp="#editor">so</supplied>genannte Samarien, jetzige Sebaste
 inne hatten, die anderen aber in Jerusalem wohnten und immerfort mit
 ihren Stammesgenossen kämpften und sie mit ihnen.</p>
 </div>
@@ -3464,43 +3468,43 @@ Städten und Könige ebenso, die auch widersprechende
 21 „Könige und “ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.110"/>
-und Erfinder von allerlei Göttern waren, sodaß daher (nach ibnen) bis
+und Erfinder von allerlei Göttern waren, sodaß daher <supplied reason="undefined" resp="#editor">nach ibnen</supplied> bis
 jetzt Ortschaften unter den Ägyptern heißen und ihre Gesetze in den
 Ortschaften gelten. Da sie zugleich Götter und auch Gesetze ersannen
-denjenigen, die unter ihrer Herrschaft (standen), so machten sie ihre
+denjenigen, die unter ihrer Herrschaft <supplied reason="undefined" resp="#editor">standen</supplied>, so machten sie ihre
 <lb n="5"/> Nachbarn zu Feinden und Hassern, sodaß daher auch sie die ganze Zeit
 ihres Lebens mit Kriegen verbrachten und wider einander in Aufruhr
-gerieten, dementsprechend, daß sie *viele Fürsten *und
+gerieten, dementsprechend, daß sie <corr resp="#editor">viele</corr> Fürsten <corr resp="#editor">und</corr>
 <del>in Gebrauch </del> hatten. Von dort aber begann auch die Verirrung des
 Polytheismus weidete wie eine böse
-<lb n="10"/> *die übrigen Orte der Völker. Die Ägypter waren mehr als
-Menschen in der Verehrung der Götter (bewandert) und hätten
+<lb n="10"/> <corr resp="#editor">die</corr> übrigen Orte der Völker. Die Ägypter waren mehr als
+Menschen in der Verehrung der Götter <supplied reason="undefined" resp="#editor">bewandert</supplied> und hätten
 ehren können als jedermann. Aber frage nicht, was die Früchte
 Wachstums ihrer Verehrung waren! Denn keineswegs gab es früher
 die jetzt den Augen sichtbaren Gründe ihres Friedens und
-<lb n="15"/> Eintracht unter einander, sondern alles (war) gerade entgegengesetzt.
+<lb n="15"/> Eintracht unter einander, sondern alles <supplied reason="undefined" resp="#editor">war</supplied> gerade entgegengesetzt.
 Deswegen wurden sie durch Kriege und Kämpfe wider einander
 ganze Zeit ihres Lebens gequält und füllten ihre Länder
-(Stammes)blut und Mord, indem die Götter als Frucht ihrer
-ihnen *diese und derartige *Werke förderten.</p>
+<supplied reason="undefined" resp="#editor">Stammes</supplied>blut und Mord, indem die Götter als Frucht ihrer
+ihnen <corr resp="#editor">diese</corr> und derartige <corr resp="#editor">Werke</corr> förderten.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="68">
 <p>Wenn aber
-<lb n="20"/> (Dinge) nicht jedermann bekannt sein sollten, wem von meinen Freunden
+<lb n="20"/> <supplied reason="undefined" resp="#editor">Dinge</supplied> nicht jedermann bekannt sein sollten, wem von meinen Freunden
 sollte das verborgen sein, was man von den Griechen liest? Der Krieg
 der Peloponnesier und Athener, den Thukydides beschrieb, wo Griechen
-mit Griechen kämpften, wie sie die *Potidäer einschlossen, wie
+mit Griechen kämpften, wie sie die <corr resp="#editor">Potidäer</corr> einschlossen, wie
 Thebaner und ergriffen, Platäer ergriffen, wie die Thraker und
 <lb n="25"/> die Athener unterstützten, bisweilen aber eben diesen
 waren, wie die Athener die Korinther einschlossen, wie sie das Land <milestone unit="altnumbering" n="70"/>
-der *Epidaurier und Trözenier verwüsteten, wie sie (das Land)
+der <corr resp="#editor">Epidaurier</corr> und Trözenier verwüsteten, wie sie <supplied reason="undefined" resp="#editor">das Land</supplied>
 verwüsteten und selbst wiederum Entsprechendes von
 Lakedämoniern erlitten, indem diese nach Attika kamen und das
 <lb n="30"/> der Athener verwüsteten, zu anderer Zeit aber die Olynthier mit
 Athenern kämpften, und die einen ferner mit den anderen und
-(wieder) mit ihren Nachbarn, und (wie) alle Arten des Krieges bei ihnen
-*zugerüstet wurden, der Kampf auf Schiffen und der Kampf auf
+<supplied reason="undefined" resp="#editor">wieder</supplied> mit ihren Nachbarn, und <supplied reason="undefined" resp="#editor">wie</supplied> alle Arten des Krieges bei ihnen
+<corr resp="#editor">zugerüstet</corr> wurden, der Kampf auf Schiffen und der Kampf auf
 Trockenen und der Kampf auf Pferden! Und das alles, obwohl, wie
 <note type="footnote">7 1. <foreign xml:lang="abbr">ABBREV</foreign> | „viele Fürsten böser Dämonen“
 9. 10 „wie eine böse . . . . Krankheit und weidete die übrigen Orte der
@@ -3509,10 +3513,10 @@ mit HS 23 1. <foreign xml:lang="abbr">ABBREV</foreign> Lee 27 „Epidaurier“ 1
 
 <pb n="v.3.pt.2.p.111"/>
 man sagen darf, Myriaden Götter in jener Zeit das Land der Griechen
-füllten, und nicht nur dies, sondern auch mit den Menschen lebten, (von
-ihnen) geehrt und bedient wurden, nicht wie (es) jetzt (der Fall ist),
-sondern, wie man sagt, wie ihre Vorfahren jene alten (Götter)
-*und (sie) ihnen überlieferten, damit sie ihre Freunde seien und mit den <lb n="5"/>
+füllten, und nicht nur dies, sondern auch mit den Menschen lebten, <supplied reason="undefined" resp="#editor">von
+ihnen</supplied> geehrt und bedient wurden, nicht wie <supplied reason="undefined" resp="#editor">es</supplied> jetzt <supplied reason="undefined" resp="#editor">der Fall ist</supplied>,
+sondern, wie man sagt, wie ihre Vorfahren jene alten <supplied reason="undefined" resp="#editor">Götter</supplied>
+<corr resp="#editor">und</corr> <supplied reason="undefined" resp="#editor">sie</supplied> ihnen überlieferten, damit sie ihre Freunde seien und mit den <lb n="5"/>
 Göttern redeten, die mit ihnen zusammen waren und lebten auf
 und sie äufig durch Orakel und Offenbarungen unterstützten.
 die Früchte dieser Götterverehrung waren diese:
@@ -3523,14 +3527,14 @@ und Gefangenschaft.</p>
 <p>Wenn du aber das prüfen willst, was älter ist als dies, so <lb n="10"/>
 richte deinen Geist auf den, der in Delphi den Griechen vorsitzt, auf
 den Pythier, meine ich, der bei allen Griechen gepriesen wird. Eben
-er rief dem Lydier (Krösus) zu und war war stark, indem er sagte:
+er rief dem Lydier <supplied reason="undefined" resp="#editor">Krösus</supplied> zu und war war stark, indem er sagte:
 kenne die Zahl des Sandes und das Maß des Meeres, die Stummen
 stehe ich und die Stammelnden höre ich.“ Der aber sandte ihm als <lb n="15"/>
-Lohn für diesen Hymnus goldene Ziegel (im Werte) von zwei
+Lohn für diesen Hymnus goldene Ziegel <supplied reason="undefined" resp="#editor">im Werte</supplied> von zwei
 und ebenso goldene Phiolen und Schüsseln. Aber dem Krösus
-mit seinen Worten so sehr starl: Aber seinen (eigenen) Hausgenossen
+mit seinen Worten so sehr starl: Aber seinen <supplied reason="undefined" resp="#editor">eigenen</supplied> Hausgenossen
 ’den Griechen) half der Gott nicht einmal so sehr, daß sie ruhig
-besonnen lebten, sondern über die Athener *herrschte der Tyrann Pisistratus, <lb n="20"/>
+besonnen lebten, sondern über die Athener <corr resp="#editor">herrschte</corr> der Tyrann Pisistratus, <lb n="20"/>
 während der Pythier auf die Griechen sah und die übrigen
 über sie mächtig waren. Sie waren sogar Genossen im Kriege, als
 Argiver mit den Korinthern kämpften und die Lakedämonier
@@ -3553,32 +3557,32 @@ Rede ist. Vielleicht Verwechslung von ἐρρώσθη und ἠρώστει 20 2
 „bedrängt “</note>
 
 <pb n="v.3.pt.2.p.112"/>
-*Branchide waren voll von den Opfern, die von den Dämonen
+<corr resp="#editor">Branchide</corr> waren voll von den Opfern, die von den Dämonen
 den Opfern wilder Stierhekatomben, den Opfern an geliebten
-(Kindern der) Menschen und, vielleicht weil sie Dämonen waren,
-von Fettgeruch, freuten sich sehr daran und nahmen sie (gnädig)
-<lb n="5"/> Die die Götter liebenden und (für sie) sorgenden Griechen
-als sie von dem bösen Wahnsinn *der Kriegsliebe *in Wut
+<supplied reason="undefined" resp="#editor">Kindern der</supplied> Menschen und, vielleicht weil sie Dämonen waren,
+von Fettgeruch, freuten sich sehr daran und nahmen sie <supplied reason="undefined" resp="#editor">gnädig</supplied>
+<lb n="5"/> Die die Götter liebenden und <supplied reason="undefined" resp="#editor">für sie</supplied> sorgenden Griechen
+als sie von dem bösen Wahnsinn <corr resp="#editor">der</corr> Kriegsliebe <corr resp="#editor">in</corr> Wut
 und wider einander rasend wTaren, von den die Griechen liebenden
 und schützenden, vielmehr aber, wenn man aufrichtig
 soll, von den kriegsliebenden, die Menschen hassenden und mit Gott
-<lb n="10"/> kämpfenden (Dämonen) nicht gehindert, obwohl diese bei
+<lb n="10"/> kämpfenden <supplied reason="undefined" resp="#editor">Dämonen</supplied> nicht gehindert, obwohl diese bei
 Denn diese waren die Ursache für alles dies, weil sie
-liebten und auf der Stelle, so oft ihnen (dies) durch Kriege unmöglich
+liebten und auf der Stelle, so oft ihnen <supplied reason="undefined" resp="#editor">dies</supplied> durch Kriege unmöglich
 war, sich durch Menschenopfer in jeder Stadt voll füllten
 an vergossenem Menschenblute freuten.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="70">
 <p>Eines also von zweien
-<lb n="15"/> (gilt): Entweder waren sie nichts und eine böse Verirrung hatte
+<lb n="15"/> <supplied reason="undefined" resp="#editor">gilt</supplied>: Entweder waren sie nichts und eine böse Verirrung hatte
 die Menschen erfaßt, daß daß sie seelenlose Bilder
-eitel und unnütz ihre eigenen geliebten (Kinder) im Wahnsinn
+eitel und unnütz ihre eigenen geliebten <supplied reason="undefined" resp="#editor">Kinder</supplied> im Wahnsinn
 Oder wenn eine Kraft in ihnen war, so ist es natürlilich, daß
 entweder Gutes oder Böses wirkend war. Wenn sie also
 <lb n="20"/> wären ihrer Natur nach, auf Erden wären und mitten
-herrschten, so würden sie dies(e ihre gute Natur) nicht genügend
-außer wenn (sie) zur Hilfe und Erlösung
+herrschten, so würden sie dies<supplied reason="undefined" resp="#editor">e ihre gute Natur</supplied> nicht genügend
+außer wenn <supplied reason="undefined" resp="#editor">sie</supplied> zur Hilfe und Erlösung
 denen sie wTohnten. Wenn sie aber böse Dämonen
 sie in allem das Gegenteil des Guten tun. Welcher Beweis ist zwingender
 <lb n="25"/> hierfür als die Früchte ihrer eigenen Verwaltung? Denn an
@@ -3590,9 +3594,9 @@ seinen Früchten wird der Baum erkannt.“<milestone unit="altnumbering" n="72"/
 und Kämpfe sind — nicht der Feinde und nicht der Barbaren, die
 wider die Griechen erhoben — sondern der Griechen selst, welche
 <lb n="30"/> die Götter ihrer Vorfahren bekannten und wider einander rasend
-und (was das für) Götter (sind), die innerhalb der Tore
+und <supplied reason="undefined" resp="#editor">was das für</supplied> Götter <supplied reason="undefined" resp="#editor">sind</supplied>, die innerhalb der Tore
 waren und jeden Tag von den Städtern geehrt wurden? Welche
-Verehrung entsprechenden (Dinge) gaben sie denen, die sie verehrten?
+Verehrung entsprechenden <supplied reason="undefined" resp="#editor">Dinge</supplied> gaben sie denen, die sie verehrten?
 Etwa vor allem Frieden, in ruhigem Leben und Genuß zu leben,
 <note type="footnote">24 = Matth 12 33</note>
 <note type="footnote">1 1. <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> = ὁ ἐν Βραγχίδαις 4 vgl. ο. S. 83 14 = L 236 16 |
@@ -3602,7 +3606,7 @@ Göttern gehindert“ Die Worstellung im Σist unsinnig 6 „und“ Σ1. <foreig
 <foreign xml:lang="abbr">ABBREV</foreign> Bernstein 29 „schrieben“ Σ = ἐπιγράφομαι 33 „oder“ Σ = ἢ</note>
 
 <pb n="v.3.pt.2.p.113"/>
-dann feste Gesetze, die ein Schutz für das Gute *sind? Wenn nun
+dann feste Gesetze, die ein Schutz für das Gute <corr resp="#editor">sind</corr>? Wenn nun
 das wäre, was vorher gesagt worden ist, so wäre es
 zu zweifeln, daß die οὐσία der Verwalter gut ist. Wenn aber
 Gipfel des Bösen das ganze Land der Griechen beherrschte und
@@ -3610,11 +3614,11 @@ die Götter, die zahlreichere Bewohner waren als die Menschen und nicht <lb n="5
 nur in jeder Stadt, sondern auch in den Häusern geehrt wurden,
 sie geehrt wurden, denen, die sie ehrten, nichts weiter gaben als
 Mord, Krieg, Verwüstung der Dörfer, Vernichtung
-und Exil, indem Griechen wider Griechen durch sie *entflammt
-waren, was ermangelt es noch (weiteres) zu wissen und zu sagen? Vielmehr <lb n="10"/>
-das eine von beidem, was vermutet wurde, (gilt). Denn entweder
+und Exil, indem Griechen wider Griechen durch sie <corr resp="#editor">entflammt</corr>
+waren, was ermangelt es noch <supplied reason="undefined" resp="#editor">weiteres</supplied> zu wissen und zu sagen? Vielmehr <lb n="10"/>
+das eine von beidem, was vermutet wurde, <supplied reason="undefined" resp="#editor">gilt</supplied>. Denn entweder
 konnten die Götter nichts, weil sie nichts waren — so waren sie
-fern (und unschuldig) an der Ursache des Bösen — oder
+fern <supplied reason="undefined" resp="#editor">und unschuldig</supplied> an der Ursache des Bösen — oder
 etwas Macht und waren selbst die Ursache des Bösen, indem sie
 zuließen, daß es so geschehe, oder indem sie selbst es bewirkten. <lb n="15"/>
 Wenn sie also derart Täter des Bösen waren, ist es
@@ -3628,7 +3632,7 @@ böse.</p>
 <p>Denn wenn sie keine Götter, auch ihrer Natur nach nichts <lb n="20"/>
 Besseres als wir selbst, sondern Menschen waren, nur daß sie mit
 versehen waren wegen ihrer Tugend und Weisheit, warum traten sie
-(dann) nicht ins Mittel und befreiten ihre Freunde vom Kampf, indem 
+<supplied reason="undefined" resp="#editor">dann</supplied> nicht ins Mittel und befreiten ihre Freunde vom Kampf, indem 
 sie sie entweder durchs Wort überzeugten oder mit Gewalt trennten und
 weit von einander entfernten und ihnen das rieten, was recht ist, indem <lb n="25"/>
 <milestone unit="altnumbering" n="73"/> sie die Taten guter Menschen wirkten und sie von der Feindschaft
@@ -3640,8 +3644,8 @@ sind?</p>
 <p>Was also? Auch gute Menschen würden dies tun,
 es ihnen begegnete. Die Götter aber vernachlässigten ihre
 sie ihnen nahe und bei ihnen waren, inmitten der Griechen wandelten <lb n="30"/>
-und von allen geehrt wurden, indem sie sie dem Blut (vergießen),
-Schwert und dem Mord der eigenen (Brüder) übergaben. WTie
+und von allen geehrt wurden, indem sie sie dem Blut <supplied reason="undefined" resp="#editor">vergießen</supplied>,
+Schwert und dem Mord der eigenen <supplied reason="undefined" resp="#editor">Brüder</supplied> übergaben. WTie
 Weil sie nicht helfen konnten oder nicht wollten, obwohl sie konnten?
 Denn wenn sie nicht wollten, obwohl sie konnten, hatten sie keineswegs
 hilfreiche Eigenschaften für die, die sie ehrten, sondern feindliche und <lb n="35"/>
@@ -3650,7 +3654,7 @@ hilfreiche Eigenschaften für die, die sie ehrten, sondern feindliche und <lb n=
 „an der οὐσία guter “ 9 1. <foreign xml:lang="abbr">ABBREV</foreign> Bernstein 21 „anders“
 Σ = ἄλλως 28 „und“ Σ = καί 35 „Taten“ Σ = ποιότης wie ο. S. 539</note>
 
-<pb n="114"/>
+<pb n="v.3.pt.2.p.114"/>
 hinterlistige. Denn diejenigen, die das Böse entfernen konnten, es
 nicht taten, waren nichts Besseres als Feinde. Wenn sie aber nicht
 konnten, obwohl sie wollten, verdienen sie Verzeihung wegen ihrer
@@ -3662,19 +3666,19 @@ halfen wegen der Schwäche der Natur.</p>
 
 <div type="textpart" subtype="chapter" n="74">
 <p>Wenn
-aber das Fatum über uns setzt (der Art), daß es alles und selbst
-Götter beherrscht, und (anführt), daß eben dies die Ursache des
+aber das Fatum über uns setzt <supplied reason="undefined" resp="#editor">der Art</supplied>, daß es alles und selbst
+Götter beherrscht, und <supplied reason="undefined" resp="#editor">anführt</supplied>, daß eben dies die Ursache des
 <lb n="10"/> und alles dessen sei, was unter den Menschen geschieht, so wird eben
 unser Leben ganz und gar zerstört, sobald das vernichtet ist, was
-uns ist, und ist (folglich) eine falsche und *trügerische Lehre statt
+uns ist, und ist <supplied reason="undefined" resp="#editor">folglich</supplied> eine falsche und <corr resp="#editor">trügerische</corr> Lehre statt
 über uns gekommen. So wird auch ihre Meinung von den Göttern
-vernichtet, die nichts können außer dem, was (durchs
+vernichtet, die nichts können außer dem, was <supplied reason="undefined" resp="#editor">durchs Schicksal</supplied> bestimmt
 <lb n="15"/> ist, was, wie auch immer, notwendig eintreten muß, selbst wenn
 nicht wollen. So wird ferner auch die Fürsorge
 eitel und unnütz, da sie solche ehren, die nichts tun können.
-Aber hierdurch sind begriffen worden jene wunderbaren (Wesen), in
+Aber hierdurch sind begriffen worden jene wunderbaren <supplied reason="undefined" resp="#editor">Wesen</supplied>, in
 denen keine Kraft war, dem Bösen der Menschen zu helfen, und
-<lb n="20"/> offenbar (als solche) erschienen, welche sich freuen an schändlichen
+<lb n="20"/> offenbar <supplied reason="undefined" resp="#editor">als solche</supplied> erschienen, welche sich freuen an schändlichen
 verwerflichen Göttergeschichten und an den bösen
 Opfern der Menschen. Daher also müssen wir glauben, daß
 die solches mit den damaligen Menschen taten wegen ihrer das Böse <milestone unit="altnumbering" n="74"/>
@@ -3688,12 +3692,12 @@ für jene genannten ötter) vergessen ist und jene Äußerungen)
 alten Krankheit verringert sind, leben alle Städte und Ortschaften
 den Provinzen und in den Ländern in tiefem Frieden. Ganz
 <lb n="30"/> Europa, Libyen und Ägypten, die früher nichts anderes waren als
-im Wetter (befindliches) Schiff, das heftige Winde und Stürme
+im Wetter <supplied reason="undefined" resp="#editor">befindliches</supplied> Schiff, das heftige Winde und Stürme
 allen Seiten zugleich ergriffen haben und hierhin und dorthin im Orkan
 eintauchen, werden jetzt in lustvoller Heiterkeit, glänzender Ruhe
-friedlicher Freude *vom Steuer *gelenkt und bekennen den Einen Steuermann
-<lb n="35"/> des Alls. Und alles dies jetzt, obwohl der *Delphier verwüstet,
-obwohl der Pythier ausgelöscht und obwohl die Erinnerung an (alle)
+friedlicher Freude <corr resp="#editor">vom</corr> Steuer <corr resp="#editor">gelenkt</corr> und bekennen den Einen Steuermann
+<lb n="35"/> des Alls. Und alles dies jetzt, obwohl der <corr resp="#editor">Delphier</corr> verwüstet,
+obwohl der Pythier ausgelöscht und obwohl die Erinnerung an <supplied reason="undefined" resp="#editor">alle</supplied>
 übrigen ötter aus dem Gehör der Menschen verwischt ist und
 kein Zwang des Schicksals, welcher auch immer es sei, und keine kriegs-
 <note type="footnote">1 1. <foreign xml:lang="abbr">ABBREV</foreign> ß 4 <foreign xml:lang="abbr">ABBREV</foreign> = τὸ ἐπιφημίζειν 12 1. <foreign xml:lang="abbr">ABBREV</foreign> Lee
@@ -3706,38 +3710,38 @@ die Lehre unseres Erlösers stark geworden ist und seit nicht mehr das
 Geschlecht der Dámonen, sondern nur Gott, der König des Alls und der
 Schöpfer der ganzen Welt, der Logos Gottes, bei allen Menschen, Barbaren <lb n="5"/>
 und Griechen, anerkannt und gepriesen wird, ist jedes Wort vom
-Schicksal aufgelöst, und jeder Krieg bewirkende Zwang (ist)
+Schicksal aufgelöst, und jeder Krieg bewirkende Zwang <supplied reason="undefined" resp="#editor">ist</supplied>
 Ferne. Vielmehr wird der göttliche, Frieden bewirkende Logos
 ganzen Erde besungen, und das Menschengeschlecht hängt Gott, dem
-Vater, an, *der Frieden und Liebe allen Menschen fördert, Jetzt, wo <lb n="10"/>
-die (Kulte) der Götter nicht mehr geübt werden noch die (Folgen) des
+Vater, an, <corr resp="#editor">der</corr> Frieden und Liebe allen Menschen fördert, Jetzt, wo <lb n="10"/>
+die <supplied reason="undefined" resp="#editor">Kulte</supplied> der Götter nicht mehr geübt werden noch die <supplied reason="undefined" resp="#editor">Folgen</supplied> des
 gegenseitigen Krieges bestehen, wo auf der ganzen Erde die Tempel,
 die einst in die Höhe errichtet wurden, in den äußersten
-geraten sind und (wo) alle jene Götter, die einst an jedem
-Orte riefen, aus Scham oder aus Furcht schweigen, *sind alle Städte, <lb n="15"/>
+geraten sind und <supplied reason="undefined" resp="#editor">wo</supplied> alle jene Götter, die einst an jedem
+Orte riefen, aus Scham oder aus Furcht schweigen, <corr resp="#editor">sind</corr> alle Städte, <lb n="15"/>
 Provinzen und Länder zugleich durch die rechte Hand) der Liebe zum
 Frieden gebracht worden und genießen unter Einer Herrschaft von
 <milestone unit="altnumbering" n="75"/> aus Ordnung zumal und Eintracht. Früher aber, als sie die Götter viel
-mehr sogar als ihre geliebten (Kinder) ehrten, in welcher Lebensverfassung
+mehr sogar als ihre geliebten <supplied reason="undefined" resp="#editor">Kinder</supplied> ehrten, in welcher Lebensverfassung
 sich da die Völker Griechenlands und der Barbaren befanden. <lb n="20"/>
 brauchen wir nicht weiter in längerer Rede darzutun, da diese Dinge
-in kurzem klargelegt sind. Aber derart (sind) die alten (Überlieferungen)
+in kurzem klargelegt sind. Aber derart <supplied reason="undefined" resp="#editor">sind</supplied> die alten <supplied reason="undefined" resp="#editor">Überlieferungen</supplied>
 der Geschichte.</p>
 </div>
 <div type="textpart" subtype="chapter" n="77">
 <p>Die neueren aber — wie sollte jemand sagen, wieviele
 Herrschaften seit dem Makedonier Alexandros, kurz vor dem Erscheinen <lb n="25"/>
-unseres Erlösers, bestanden? Denn *Aridaios, der Bruder
+unseres Erlösers, bestanden? Denn <corr resp="#editor">Aridaios</corr>, der Bruder
 empfing das Königtum von
 in Europa beherrschte, Ptolemaios aber Agypten und Alexandria
 erhielt. Phönikien aber und Kölesyrien regierte
-Antigonos Asien, Kassandros Karien, *Leonnatos den Hellespont, <lb n="30"/>
+Antigonos Asien, Kassandros Karien, <corr resp="#editor">Leonnatos</corr> den Hellespont, <lb n="30"/>
 Eumenes Paphlagonien und Lysimachos die Gegenden von Thrakien.
 Daher zogen wie aus einer Schranke zum gegenseitigen Kriege aus
 eben dieselben, die die Herrschaft empfangen hatten. Denn Ptolemaios,
 der Sohn des Lagos, brach fünfzehn Mal aus Ägypten
 aber trat dem Ptolemaios, dem König der Makedonier, entgegen und <lb n="35"/>
-wurde getötet. *Perdikas drang in Ägypten ein mit
+wurde getötet. <corr resp="#editor">Perdikas</corr> drang in Ägypten ein mit
 <note type="footnote">10 „der“] „und“ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 15 „und alle Städte“ Σ streiche
 26 <foreign xml:lang="abbr">ABBREV</foreign> = „Auraios"? Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> Lee 30 „Leonos" Σ 1.
 <foreign xml:lang="abbr">ABBREV</foreign> Lee 36 „Pertikos" Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> Lee</note>
@@ -3758,7 +3762,7 @@ die Tempel mit vielen Weih gescheuten geschmückt
 war das Götterwort bei den
 <lb n="10"/> und Massen ehrten in den Dörfern und an jedem Ort, so
 den Häusern, selbst in den Schatzkammern und
-Altären und Bildern die (Götter)
+Altären und Bildern die <supplied reason="undefined" resp="#editor">Götter</supplied>
 sie so waren, unterschieden sie sich in nichts von dämonischen Menschen, <milestone unit="altnumbering" n="76"/>
 deren Seelen in Wahnsinn verkehrt, die die ganze Zeit ihres Lebens mit
 <lb n="15"/> dem Blute ihrer Ortsgenossen befleckt und in Wahrheit dämonisch waren,
@@ -3775,12 +3779,12 @@ ist der größte Beweis ihrer Minderwertigkeit und eine zwingende
 jener Orakel, die einst unter allen Griechen verkündet wurden.
 Keiner der Orakelnden also sagte das Erscheinen unseres Erlösers unter
 <lb n="25"/> den Menschen voraus noch die neue Lehre, die von ihm allen Völkern
-gegeben würde, sondern (keiner), nicht einmal der Pythier
+gegeben würde, sondern <supplied reason="undefined" resp="#editor">keiner</supplied>, nicht einmal der Pythier
 anderer der großen Dämonen wußte das eigene Verderben voraus noch
 sagte vorher den, der kommen werde als Vernichter und Zerstörer aller,
 noch sah alle diejenigen voraus, die aus den Griechen- und Barbarenvölkern
 <lb n="30"/> dem Irrtum des Polytheismus sich abwenden und den
-Einen über alles (herrschenden) Gott erkennen würden.</p>
+Einen über alles <supplied reason="undefined" resp="#editor">herrschenden</supplied> Gott erkennen würden.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="80">
@@ -3800,15 +3804,15 @@ prophezeite die Vernichtung der eigenen Tempel und den äußersten
 Grad ihrer Verwüstung? verkündigte
 Gold und Silber bestehenden Götzenbildern die Einschmelzung
 Feuer und die Veränderung von unbrauchbarem Anblick zur vorzüglichen <lb n="5"/>
-Brauchbarkeit der Menschen? Denn an die *Götzenbilder. die von ihnen
+Brauchbarkeit der Menschen? Denn an die <corr resp="#editor">Götzenbilder</corr>. die von ihnen
 eingeschmolzen und verächtlich und erbärmlich in ganz kleine Stücke
 gehauen wurden. — wer von den Göttern dachte jemals daran? Wo
-aber waren die Fürsorger dieser (Bilder), die ihren
+aber waren die Fürsorger dieser <supplied reason="undefined" resp="#editor">Bilder</supplied>, die ihren
 nicht halfen, als sie von den Menschen zerstört wurden? Wo waren <lb n="10"/>
 diejenigen, die früher Kriege bewirkten, bei ihrem Unheil aber
 selbst Zerstörenden susahen, während diese im tiefsten Frieden waren?
 <milestone unit="altnumbering" n="77"/>Wunderbar zu sagen aber ist es, daß, als ihre Tempel vernichtet
-ein das Schöne und *Gute fördernder Friede
+ein das Schöne und <corr resp="#editor">Gute</corr> fördernder Friede
 beherrschte, daß das gerade Gegenteil aber eintrat, als die Götter im <lb n="15"/>
 Frieden waren. Kriege also und Kämpfe und Aufruhre
 die wir früher geschichtlich besprochen haben,
@@ -3817,9 +3821,9 @@ aber eben derselben war ganz und gar Friede und reichliches Glück.
 Daher ist es für jeden, der überlegt, klar, daß deine götter noch <lb n="20"/>
 gute Dämonen waren, sondern im Gegenteil böse
 deren Macht Ursache war für das Böse
-aber das Kommen des Guten für jedermann *förderte.
+aber das Kommen des Guten für jedermann <corr resp="#editor">förderte</corr>.
 das Volk der Griechen in Verwirrung war und wie die Völker
-ganzen Erde verwirrt waren, haben wir (nunmehr) wie in Kürze erkannt.</p>
+ganzen Erde verwirrt waren, haben wir <supplied reason="undefined" resp="#editor">nunmehr</supplied> wie in Kürze erkannt.</p>
 </div> <lb n="25"/>
 <div type="textpart" subtype="chapter" n="81">
 <p>Wie aber die Sitten, deren Arten wechseln, das ganze
@@ -3846,34 +3850,34 @@ andern jedoch, dem Feuer zu übergeben. Andere aber unterließen
 vor. Die einen schlachteten die Fremdlinge, die zu ihnen kamen, die
 andern aber verzehrten sogar Menschenfleisch. Ferner aßen
 Geliebten, die alt geworden waren, bevor sie der Tod erreichte, vorher,
-nachdem sie sie zuvor geopfert hatten. *Die einen stürzten diejenigen,
+nachdem sie sie zuvor geopfert hatten. <corr resp="#editor">Die</corr> einen stürzten diejenigen,
 <lb n="10"/> die sich dem Greisenalter näherten, vom Felsen, die
 sie der Schlinge. Die einen warfen sie den Hunden vor, während sie <milestone unit="altnumbering" n="78"/>
-(noch) lebendig waren, die andern aber als Tote. Die einen begruben,
-die anderen töteten (zu gleicher Zeit) mit ihnen auf
+<supplied reason="undefined" resp="#editor">noch</supplied> lebendig waren, die andern aber als Tote. Die einen begruben,
+die anderen töteten <supplied reason="undefined" resp="#editor">zu gleicher Zeit</supplied> mit ihnen auf
 die Lebenden, die von den Toten geliebt wurden.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="82">
 <p>So also war
-<lb n="15"/> fortan das ganze Menschengeschlecht zum äußersten (Grad) der
+<lb n="15"/> fortan das ganze Menschengeschlecht zum äußersten <supplied reason="undefined" resp="#editor">Grad</supplied> der
 geführt, und er, der vernünftig ist,
-Kein anderes (Wesen) von denen, die auf Erden sind, war
-böser als der Mensch, der (ein Leben) führte
+Kein anderes <supplied reason="undefined" resp="#editor">Wesen</supplied> von denen, die auf Erden sind, war
+böser als der Mensch, der <supplied reason="undefined" resp="#editor">ein Leben</supplied> führte
 und seinen Geist mit jeder Art der Bosheit verderbte, sodaß
-<lb n="20"/> er sich bald auch abwandte von der in seiner Natur (liegenden) Erwägung
-und nicht mit Recht die (Dinge) seiner Seele, noch die seines
+<lb n="20"/> er sich bald auch abwandte von der in seiner Natur <supplied reason="undefined" resp="#editor">liegenden</supplied> Erwägung
+und nicht mit Recht die <supplied reason="undefined" resp="#editor">Dinge</supplied> seiner Seele, noch die seines
 Leibes, noch die außerhalb von ihnen tat,
 allerorten litt. Denn das Leben der Menschen wird eingeteilt in die
-(Dinge) der Seele, in die des Leibes und in die außerhalb
+<supplied reason="undefined" resp="#editor">Dinge</supplied> der Seele, in die des Leibes und in die außerhalb
 <lb n="25"/> und auf allerlei Art herrschte die Verirrung der Dämonen und
-verderbte das Leben der Menschen, sodaB die (Dinge) der Seele
+verderbte das Leben der Menschen, sodaß die <supplied reason="undefined" resp="#editor">Dinge</supplied> der Seele
 verflochten wurden in die Raserei der Dämonenverehrung, die
-hatte, in die von der Wahrheit (entfernte) Torheit und Blindheit,
+hatte, in die von der Wahrheit <supplied reason="undefined" resp="#editor">entfernte</supplied> Torheit und Blindheit,
 inbezug auf die auch das Geschlecht der Philosophen getrübt
-<lb n="30"/> war, die (Dinge) des Leibes aber in Menschenopfer auf der ganzen
+<lb n="30"/> war, die <supplied reason="undefined" resp="#editor">Dinge</supplied> des Leibes aber in Menschenopfer auf der ganzen
 Erde und ferner in schändliche, ungesetzliche Taten
-Schändung, und (endlich) die (Dinge) außerhalb
+Schändung, und <supplied reason="undefined" resp="#editor">endlich</supplied> die <supplied reason="undefined" resp="#editor">Dinge</supplied> außerhalb
 daß alle Städte, Orter und Völker
 waren, bald aber, indem sie sich vereinigten, wider einander kämpften
 <lb n="35"/> und durch gegenseitige Verwüstung
@@ -3884,19 +3888,19 @@ von bloßem τὰ ἔξω. Man erwartet <foreign xml:lang="abbr">ABBREV</foreign
 wurden"] „mit ihnen kämpften“ Σ (=σχμ-πλἑχομαι?)</note>
 
 <pb n="v.3.pt.2.p.119"/>
-(Dinge) der alten Krankheit erzählen wollte, die das
+<supplied reason="undefined" resp="#editor">Dinge</supplied> der alten Krankheit erzählen wollte, die das
 ergriffen hatte. Deswegen besonders war Gott der Erlöser
-(uns) als solchen, die in den äußersten (Grad) des Bösen
+<supplied reason="undefined" resp="#editor">uns</supplied> als solchen, die in den äußersten <supplied reason="undefined" resp="#editor">Grad</supplied> des Bösen
 und keine andere bessere Heilung und Hilfe als die durch die Theophanie
 unserem Leben erforderlich.</p>
 </div> <lb n="5"/>
 <div type="textpart" subtype="chapter" n="83">
-<p>Was also war nach diesen (Dingen) dem Logos, dem
+<p>Was also war nach diesen <supplied reason="undefined" resp="#editor">Dingen</supplied> dem Logos, dem
 Vater der Vernünftigen, recht zu tun, dem Erlöser
 der Vorsehung, dem Hirten der vernünftigen
 Erden, damit er zu großer Ehre das geistige und vernünftige
 <milestone unit="altnumbering" n="79"/> den Menschen hinaufführe, das in große Tiefe gefallen war, und damit <lb n="10"/>
-er den als seinen vertrauten (Freund) sehe, der durch sich selbst die
+er den als seinen vertrauten <supplied reason="undefined" resp="#editor">Freund</supplied> sehe, der durch sich selbst die
 Ursache des Untergangs sich zugezogen hatte? Ist es recht, daß jemand
 über die Erlösung seiner Geliebten hinweggeht und
 daß diejenigen, die der höchsten
@@ -3926,9 +3930,9 @@ des Logos ist. Vielleicht zu lesen <foreign xml:lang="abbr">ABBREV</foreign> „
 21 ἀλλὰ τὰ μὲν εὖ ἔχ’ ὄντα αὐτῷ ἐν ἀσφαλεῖ κείμενα καταλείψει L</note>
 
 <pb n="v.3.pt.2.p.120"/>
-(schiffbaren) Lauf des Meeres gab und (für den) er die Erde mit
-Pflanzen schmückte, er, dem er auch die *(schwimmenden
-Fische) in der verborgenen Tiefe und die Vögel in
+<supplied reason="undefined" resp="#editor">schiffbaren</supplied> Lauf des Meeres gab und <supplied reason="undefined" resp="#editor">für den</supplied> er die Erde mit
+Pflanzen schmückte, er, dem er auch die <corr resp="#editor">schwimmenden</corr> Arten <supplied reason="undefined" resp="#editor">der 
+Fische</supplied> in der verborgenen Tiefe und die Vögel in
 machte, der Mensch, dem er die Kraft des Wissens zur Aufnahme
 <lb n="5"/> mannigfacher Lehre gewährte, dem er auch die Schauspiele am Himmel
 enthüllte und die Läufe der Sonne, die
@@ -3937,20 +3941,20 @@ die Gleise der Planeten und Fixsterne offenbarte.</p>
 
 <div type="textpart" subtype="chapter" n="84">
 <p>Wie sollte
-also nach diesen (Dingen) die Fúrsorge des Vaters gelähmt
-alles (waltende) Vorsehung (zu) schwach sein zur Heilung der vernünftigen
-<lb n="10"/> οὐσία in den Menschen? (Er), der sich richtig kümmerte um
-(Dinge) des Leibes und der wahrnehmbaren Welt, der den Menschen
+also nach diesen <supplied reason="undefined" resp="#editor">Dingen</supplied> die Fúrsorge des Vaters gelähmt
+alles <supplied reason="undefined" resp="#editor">waltende</supplied> Vorsehung <supplied reason="undefined" resp="#editor">zu</supplied> schwach sein zur Heilung der vernünftigen
+<lb n="10"/> οὐσία in den Menschen? <supplied reason="undefined" resp="#editor">Er</supplied>, der sich richtig kümmerte um
+<supplied reason="undefined" resp="#editor">Dinge</supplied> des Leibes und der wahrnehmbaren Welt, der den Menschen
 alle Arten der Nahrung und alle Arten der Heilung und Gesundheit
 des Leibes, und der Größe,
-und Überfluß an Besitz zum Gebrauch gab, *sollte
+und Überfluß an Besitz zum Gebrauch gab, <corr resp="#editor">sollte</corr>
 <lb n="15"/> für das, was besser ist im Menschen, für die Seele
-verständige οὐσία, die *töricht geworden sind? Aber so würde jemand <milestone unit="altnumbering" n="80"/>
+verständige οὐσία, die <corr resp="#editor">töricht</corr> geworden sind? Aber so würde jemand <milestone unit="altnumbering" n="80"/>
 mit Recht die Schwäche tadeln, nicht das von der Herde
 sondern besonders die Nachlässigkeit des Hirten, ferner
 deren Seele krank ist und denen es übel ergeht, sondern besonders die
 <lb n="20"/> Nichtbeachtung und Schwäche des Arztes, wenn er
-Arten der heilenden und helfenden Arzneien denen nicht giebt, die (ihrer)
+Arten der heilenden und helfenden Arzneien denen nicht giebt, die <supplied reason="undefined" resp="#editor">ihrer</supplied>
 bedürfen. Daber rief jeder Zwang den Fürsorger
 zur Heilung seiner Schafe.</p>
 </div>
@@ -3962,11 +3966,11 @@ Logos Gottes als ein guter Hirte, Erlöser
 Herde auf Erden am schlimmsten erging, da er keine Zeit jemals verstreichen
 ließ, in der er nicht die Bedürftigen mit
 Vorsehung durch Versorgung mit allem Guten versah. Allezeit also
-von jemals aller Ewigkeit an blickte er auf die irdischen (Dinge),
+von jemals aller Ewigkeit an blickte er auf die irdischen <supplied reason="undefined" resp="#editor">Dinge</supplied>,
 <lb n="30"/> beaufsichtigte sie, gab zu den erforderlichen Zeiten von sich aus reichliche
 Versorgung und zeigte sich jedermann als einen tadellosen Fürsorger
 der Vorsehung über die Menschen, sodab er auch durch Offenbarung
-der Engel und durch die (den Menschen) vorstehenden heiligen
+der Engel und durch die <supplied reason="undefined" resp="#editor">den Menschen</supplied> vorstehenden heiligen
 <note type="footnote">1 ἡ καὶ θάλατταν πλωτὴν ἀνῆκε L. Vielleicht hat Σ πλωτὴν als Substantivum
 mißverstanden 2 τὰ ἐν βυθοῖς ἕρποντα πτηνῶν τε μετάρσια L 1.
 PSm 5 τὰς οὐρανίους ἐξεκάλυψε θεωρίας L besser wohl „die Himmelslehven
@@ -3976,11 +3980,11 @@ ist in Ordnung (gegen Lee)</note>
 
 <pb n="v.3.pt.2.p.121"/>
 Diener Gottes um diejenigen sich bekümmerte, die würdig waren unter
-den Menschen, durch Prophetie und (unterredenden) Verkehr die Gottheit
+den Menschen, durch Prophetie und <supplied reason="undefined" resp="#editor">unterredenden</supplied> Verkehr die Gottheit
 seines Vaters und das Leben in der Tugend denen verkündete,
-die im Geheimnis der Gottesverehrung wandeln konnten, *in jener Zeit,
+die im Geheimnis der Gottesverehrung wandeln konnten, <corr resp="#editor">in</corr> jener Zeit,
 wo er unseren Vätern als solchen, die noch kindlich und im Bösen <lb n="5"/>
-nicht erfahren waren, das Wissen von seiner (eigenen Person) gab.</p>
+nicht erfahren waren, das Wissen von seiner <supplied reason="undefined" resp="#editor">eigenen Person</supplied> gab.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="86">
@@ -3988,33 +3992,33 @@ nicht erfahren waren, das Wissen von seiner (eigenen Person) gab.</p>
 dem Denken ihres Willens Abstand nahmen und aus dem Leben der
 Tugend ins Böse gerieten, bemühte sich wiederum mit Recht der Logos
 Gottes als Arzt der Seelen um diejenigen, die an dieser Krankheit litten <lb n="10"/>
-mit passenden Hilfsmitteln (und) brachte durch bittere Arzneien diejenigen
-zur Umkehr, die bei seiner (freundlichen) Gabe nicht besser geworden
+mit passenden Hilfsmitteln <supplied reason="undefined" resp="#editor">und</supplied> brachte durch bittere Arzneien diejenigen
+zur Umkehr, die bei seiner <supplied reason="undefined" resp="#editor">freundlichen</supplied> Gabe nicht besser geworden
 waren. Sie also strafte er durch die schweren Schmerzen des Unheils bei
 <milestone unit="altnumbering" n="81"/> Seuchen, Hungersnöten, Kriegen, Bränden und Überschwemmungen und
 wendete zu sich zurück diejenigen, die dessen bedürftig waren. Bald reinigte <lb n="15"/>
-er das ganze Leben (besserte er die Welt) durch Verlust des Wassers,
-bald aber strafte er die Gottlosen strichweise durch (zu) reichliche Regenfälle,
+er das ganze Leben <supplied reason="undefined" resp="#editor">besserte er die Welt</supplied> durch Verlust des Wassers,
+bald aber strafte er die Gottlosen strichweise durch <supplied reason="undefined" resp="#editor">zu</supplied> reichliche Regenfälle,
 durch Blitzschläge, Brände und Mangel an Regen. Ferner aber
 bekräftigte er in der Vorzüglichkeit seiner Liebe durch Werke die
-Widerlegung *der Lehre über die Dämonenverirrung. Selbst die Tempel <lb n="20"/>
+Widerlegung <corr resp="#editor">der</corr> Lehre über die Dämonenverirrung. Selbst die Tempel <lb n="20"/>
 derer, die für Götter gehalten wurden, und die Kapellen mitsamt den
 Bildern und Dämonen vernichtete er, indem sie durch Blitzschläge untergingen,
 und brachte so die Toren zur Besonnenheit. Und nicht nur
-dies, sondern er lehrte sie (auch) durch Erwägung erkennen, daß das
+dies, sondern er lehrte sie <supplied reason="undefined" resp="#editor">auch</supplied> durch Erwägung erkennen, daß das
 niemals Götter seien, die nicht einmal sich selbst helfen konnten, noch <lb n="25"/>
 daß Hausgenossen des Allkönigs Gott noch Freunde die seien, mit
-denen er kämpfe. Denn wie sollte (Gott) die Ursache alles Guten dem
+denen er kämpfe. Denn wie sollte <supplied reason="undefined" resp="#editor">Gott</supplied> die Ursache alles Guten dem
 Untergang durch sein eigenes Feuer die Tempel überliefern, die man
 zu seiner Ehre baute, wenn er es nicht zur Widerlegung ihres Irrtums
 tat? Denn wenn er wollte, daß die Dämonen, die unter ihnen wohnten, <lb n="30"/>
-geehrt wurden, warum verderbte er dann die Tempel dieser (Wesen)
+geehrt wurden, warum verderbte er dann die Tempel dieser <supplied reason="undefined" resp="#editor">Wesen</supplied>
 mitsamt den Götzenbildern? Durch die vou oben aus der Höhe von
 Gott gesandten Pfeile trieb er diejenigen, die bei ihnen wohnten, in die
 Ferne und verkündete hierdurch völlig eben durch Taten in die Ohren
-jedermanns, indem er rief: Schweigt (still) von dem Irrtum der Dämonen <lb n="35"/>
-und des Polytheismus und bekennt (vielmehr) den Herrn Himmels
-und der Erden, der der Gott der ganzen Welt ist, (und) den Erlöser,
+jedermanns, indem er rief: Schweigt <supplied reason="undefined" resp="#editor">still</supplied> von dem Irrtum der Dämonen <lb n="35"/>
+und des Polytheismus und bekennt <supplied reason="undefined" resp="#editor">vielmehr</supplied> den Herrn Himmels
+und der Erden, der der Gott der ganzen Welt ist, <supplied reason="undefined" resp="#editor">und</supplied> den Erlöser,
 <note type="footnote">1 „übt“ ( „belehrt“) Σ = μελετάω c. Acc. Eusebius schrieb vermutlich den Gen.
 4 „und in jener Zeit“ Σ, streiche ABBREV 9 „bestrafte“ Σ (sachlich richtig) = μετέρχομαι
 13 man eiwartet <foreign xml:lang="abbr">ABBREV</foreign></note> 20 „und“ Σ l ABBREV 27 beachte ABBREV vor ABBREV
@@ -4022,15 +4026,15 @@ und der Erden, der der Gott der ganzen Welt ist, (und) den Erlöser,
 <pb n="v.3.pt.2.p.122"/>
 den Ernährer, den Beschützer, den sie mit ihren eigenen Augen sahen.
 wie er bald durch Versorgung mit Regen zu rechter Zeit und durch Reichtum und
-alles tragende, aus der Erde (sprossende) Früchte, durch
-reichliche Annehmlichkeit seine Fürsorge für ür sie zeigte, (wie)
+alles tragende, aus der Erde <supplied reason="undefined" resp="#editor">sprossende</supplied> Früchte, durch
+reichliche Annehmlichkeit seine Fürsorge für ür sie zeigte, <supplied reason="undefined" resp="#editor">wie</supplied>
 <lb n="5"/> er bald aber durch gottgesandte Schläge und von
 Züchtigungen wie durch Stricke diejenigen zur Umkehr
 auf das von ihm besorgte Gute nicht achteten; und nicht nur dies, sondern
-(wie) er auch durch häufige Blitze und Brände,
-(verhängt wurden), welche sie für Götter ihren Irrtum heilte,
+<supplied reason="undefined" resp="#editor">wie</supplied> er auch durch häufige Blitze und Brände,
+<supplied reason="undefined" resp="#editor">verhängt wurden</supplied>, welche sie für Götter ihren Irrtum heilte,
 <lb n="10"/> sodaß auch durch die Hinterlist der Menschen die Tempel
-brannten mitsamt denen, welche sie zu Göttern machten, und (so) offenkunding <milestone unit="altnumbering" n="82"/>
+brannten mitsamt denen, welche sie zu Göttern machten, und <supplied reason="undefined" resp="#editor">so</supplied> offenkunding <milestone unit="altnumbering" n="82"/>
 eine Widerlegung dieses Irrtums den Zuschauern zeigten. Aber
 obwohl eben jene Götterverehrer die früheren
 für sie nichts anderes als die Aufrechterhaltung ihres Frevels.</p>
@@ -4039,22 +4043,22 @@ für sie nichts anderes als die Aufrechterhaltung ihres Frevels.</p>
 <div type="textpart" subtype="chapter" n="87">
 <p><lb n="15"/> Da sie aber auch ferner an die Götter glaubten, die
 bekannten, nichts tun zu können außer dem, was
-das Schicksal ist (nach ihrer Meinung) die Ursache des Alls — verstanden
+das Schicksal ist <supplied reason="undefined" resp="#editor">nach ihrer Meinung</supplied> die Ursache des Alls — verstanden
 und erwogen sie nicht, daß, weil das Schicksal sie
 die Götter beherrschte, die Meinung über diejenigen eitel ist,
 <lb n="20"/> Menschen weder unterstützen
 das Schicksal zu ehren, da es die Ursache des Alls ist, nur wenn man
 muß? Indessen aber auch dieser unwandelbare Zwang hatte
-Macht über sich selbst, sondern (diese Macht besaß nur) der, den
-als Herrn dieses (Schicksals) und auch des Alls anerkennt, indem er
-<lb n="25"/> bald durch die Versorgung mit allerlei guten (Dingen) Kenntnis seiner
+Macht über sich selbst, sondern <supplied reason="undefined" resp="#editor">diese Macht besaß nur</supplied> der, den
+als Herrn dieses <supplied reason="undefined" resp="#editor">Schicksals</supplied> und auch des Alls anerkennt, indem er
+<lb n="25"/> bald durch die Versorgung mit allerlei guten <supplied reason="undefined" resp="#editor">Dingen</supplied> Kenntnis seiner
 selbst gewährt, bald aber den Irrtum der
-durch Donner und Blitz widerlegte. Sogleich aber (lehrt) die Geschichte,
+durch Donner und Blitz widerlegte. Sogleich aber <supplied reason="undefined" resp="#editor">lehrt</supplied> die Geschichte,
 daß der üher ühmte Tempel des Pythiers
 einen Brand erlitt. Die aber richteten, da sie bei ihrem Irrtum verharrten,
 <lb n="30"/> harrten, ihn auch zum zweiten Male auf. Als Gott ihn zum zweiten
 Male vernichtete, erneuerten sie ihn sogar zum dritten Male. Der aber
-(zerstörte) nicht mehr den Tempel, sondern trieb
+<supplied reason="undefined" resp="#editor">zerstörte</supplied> nicht mehr den Tempel, sondern trieb
 der in seinem Innern wohnte, völlig auf der Stelle durch
 aus, sodaß dort hinfort keine Orakelstätte mehr ist noch
 <note type="footnote">27 vgl. Praep. IV 2 8; Stellensaininlung bei Pomtow. Die Brände des
@@ -4069,7 +4073,7 @@ früher die Griechen verführte.</p>
 <div type="textpart" subtype="chapter" n="88">
 <p>Der Tempel der Artemis
 in Ephesos ging dreimal zu Grunde, einmal als ihn die Amazonen in
-Brand steckten, das andere Mal durch *Herostratos, einen Einwohner
+Brand steckten, das andere Mal durch <corr resp="#editor">Herostratos</corr>, einen Einwohner
 zu Ephesos, zuletzt durch den allmächtigen Gott, sodaß
 nach der Erscheinung unseres Erlösers auch dort nichts weiter existiert <lb n="5"/>
 noch gesehen wird als das große Siegeszeichen der Zersörung.</p>
@@ -4096,7 +4100,7 @@ waren, wiederum durch den Blitz vernichtet wurde.</p>
 
 <div type="textpart" subtype="chapter" n="92">
 <p>Ferner
-aber fiel einmal in das bei ihnen (so)genannte Kapitol ein Donner von <lb n="15"/>
+aber fiel einmal in das bei ihnen <supplied reason="undefined" resp="#editor">so</supplied>genannte Kapitol ein Donner von <lb n="15"/>
 oben vom Himmel und zerstörte das Allerheiligste.</p>
 </div>
 
@@ -4107,7 +4111,7 @@ Und nicht nur dies, sondern er unterwies sie auch früher durch
 gottgeziemende Lehren, seinen Vater zu loben, und warf lebenspendende <lb n="20"/>
 Belehrung, göttliche Gesetze Gesetze und gerechte Worte nach Art guter Kräuter
 und Heilmittel zur Erlösung der vernünftigen
-Geschlecht. So also rief er früher durch *(gewisse) Propheten
+Geschlecht. So also rief er früher durch <corr resp="#editor"><supplied reason="undefined" resp="#editor">gewisse</supplied></corr> Propheten
 Hebräern, die am göttlichen Geiste teil hatten,
 früher durch andere gottliebende <add>Männer</add> und ferner nach diesen durch <lb n="25"/>
 die späteren Gottbekleideten Gottbekleideten die dem Tode Preisgegebenen zu ihrer
@@ -4128,7 +4132,7 @@ Ermahnuug und der vielerlei Lehren und der . . . . Worte der Zukunft“</note>
 
 <pb n="v.3.pt.2.p.124"/>
 Ermahnung und durch allerlei Lehren und voraussagende und propheeiende
-Worte der Zukunft den Anfang und die *(Grund)linien zu einem
+Worte der Zukunft den Anfang und die <corr resp="#editor"><supplied reason="undefined" resp="#editor">Grund</supplied></corr>linien zu einem
 gottesfürchtigen Leben in die Seele der Menschen. Von
 fortan wie aus einer Quelle auch durch alle Teile der Welt die vernünftigen
 <lb n="5"/> Samen und Sitten. Fortan sah man bei allen Völkern
@@ -4139,8 +4143,8 @@ irrung der Väter in geringster Nichtachtung war, vielmehr die Verehrung
 <lb n="10"/> der Gottesliebe von den Jüngern verkündet und die Wahrheit
 gesucht wurde. Groß aber war die Spaltung hierüber
 die Kämpfe und die Differenzen derer, die über Lehren
-zeigten die (Dinge) der Vorsehung, die über die Menschen in Menge
-von aller Ewigkeit her (ergingen), einen jedermann geziemenden und
+zeigten die <supplied reason="undefined" resp="#editor">Dinge</supplied> der Vorsehung, die über die Menschen in Menge
+von aller Ewigkeit her <supplied reason="undefined" resp="#editor">ergingen</supplied>, einen jedermann geziemenden und
 <lb n="15"/> entsprechenden Fürsorger.</p>
 </div>
 <div type="textpart" subtype="chapter" n="94">
@@ -4162,8 +4166,8 @@ möglich, durch Worte, die das vollkommene Wissen Gottes
 besonnen zu machen, die auf den Gipfel des Bösen getrieben waren.
 Daher wie Arzte denjenigen, die krank und durch schwere, schmerzliche
 Leiden geschwächt sind, keineswegs die gesunde, den
-Nahrung verordnen, sondern durch Kummer und *Schmerz verursachende
-<lb n="35"/> (Dinge) Heilung bringen (und), wenn es nötig
+Nahrung verordnen, sondern durch Kummer und <corr resp="#editor">Schmerz</corr> verursachende
+<lb n="35"/> <supplied reason="undefined" resp="#editor">Dinge</supplied> Heilung bringen <supplied reason="undefined" resp="#editor">und</supplied>, wenn es nötig
 verzichten, Brenneisen und bittere Tránke zur Hemmung
 anzuwenden, aber keineswegs die Speisen, die für die
 <note type="footnote">2 „(Grund)linien“] „Liebe" Σ στοιχεῖα L; 1. <foreign xml:lang="abbr">ABBREV</foreign> nach Σ 35 13 3 1.
@@ -4179,34 +4183,34 @@ zuführen,</p>
 <div type="textpart" subtype="chapter" n="95">
 <p>so also auch unterwies der
 <milestone unit="altnumbering" n="85"/> aller wie ein guter Hirt und Arzt seine vernünftigen
-Erden, die *durch Wahnsinn Wahnsinn zu Myriaden vieler Götter gekommen <lb n="5"/>
+Erden, die <corr resp="#editor">durch</corr> Wahnsinn Wahnsinn zu Myriaden vieler Götter gekommen <lb n="5"/>
 waren und in unseliger Geistesverblendung und Wildheit rasten,
 vor seiner letzten Theophanie durch bittere Strafen, durch Seuchen,
 Hungersnöte und häufige Kriege wider einander, ferner
 vielen Regen und Vorenthaltung des Regens, und beseitigte durch unheilvolle
-Blitzschläge jene schweren (Anstöße d. h. die Tempel) und <lb n="10"/>
-gab auch den Dämonenverehrern (Gelegenheit),
-der polytheistischen Verirrung (und) durch die Strafe der Blitzschläge
-ihre eigenen Götzenbilder zu sehen (und in ihrem wahren
-zu lernen).</p>
+Blitzschläge jene schweren <supplied reason="undefined" resp="#editor">Anstöße d. h. die Tempel</supplied> und <lb n="10"/>
+gab auch den Dämonenverehrern <supplied reason="undefined" resp="#editor">Gelegenheit</supplied>,
+der polytheistischen Verirrung <supplied reason="undefined" resp="#editor">und</supplied> durch die Strafe der Blitzschläge
+ihre eigenen Götzenbilder zu sehen <supplied reason="undefined" resp="#editor">und in ihrem wahren
+zu lernen</supplied>.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="96">
 <p>Er aber unterwies ferner so wie ein guter Vater
 die Toren und gab ihnen eben durch reiche Versorgung mit reichlichen <lb n="15"/>
 Gütern Geschenke von sich aus: Regen zu rechter Zeit,
-Früchte, Wechsel der (Jahres)zeiten, Fortpflanzung der Tiere
+Früchte, Wechsel der <supplied reason="undefined" resp="#editor">Jahres</supplied>zeiten, Fortpflanzung der Tiere
 Mittel jeder Art der Künste, deren Samen und
 in die Seelen der Menschen warf. Er säte ferner auch den
 göttlichen Worte und der gottesfürchtigen Lehre, die Einführung. die <lb n="20"/>
-(Grund) linien und Anfänge der göttlichen Gesetze,
+<supplied reason="undefined" resp="#editor">Grund</supplied> linien und Anfänge der göttlichen Gesetze,
 Menschen frommte, durch Propheten, die bei den Hebräern berühmt
 waren. Er gab ferner auch durch viele andere eine für
 Menschen passende Hilfe infolge seiner eigenen Vorsehung.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="97">
-<p>Weil also infolge dieser (Dinge) fortan das Leben der Menschen zur <lb n="25"/>
+<p>Weil also infolge dieser <supplied reason="undefined" resp="#editor">Dinge</supplied> fortan das Leben der Menschen zur <lb n="25"/>
 Friedlichkeit und Ruhe sich änderte und bereit war, die vollkommene
 Lehre über Gott aufzunehmen, zeigte wiederum der gemeinsame Erlöser
 aller, das eingeborene Wort Gottes, der König des Alls,
@@ -4227,15 +4231,15 @@ fortan in Friedlichkeit und Ruhe änderte und bereit war, die vollkommene
 Lehre über Gott zu empfangen, so tat mit Recht wiederum
 <lb n="5"/> der gemeinsame Erlöser aller, der eingeborne Logos Gottes,
 zu passender Zeit seine göttliche Offenbarung in Werken
-auf der Stelle (und) auf eiumal, als er in der Welt erschien, *nahmen
-die alten (Greuel) ämonischer Wirksamkeit wie durch mechanische Zerstörung
+auf der Stelle <supplied reason="undefined" resp="#editor">und</supplied> auf eiumal, als er in der Welt erschien, <corr resp="#editor">nahmen</corr>
+die alten <supplied reason="undefined" resp="#editor">Greuel</supplied> ämonischer Wirksamkeit wie durch mechanische Zerstörung
 ein Ende, die Gutes offenbarenden Frohbotschaften wurden allen
-<lb n="10"/> Völkern gepredigt und der über alles (waltende) Gott ward
+<lb n="10"/> Völkern gepredigt und der über alles <supplied reason="undefined" resp="#editor">waltende</supplied> Gott ward
 den Menschen verkündigt. Der ganze Irrtum
 wurde vernichtet, und aufgelöst wurden auf der Stelle alle
 Dämonen. Fernerhin gab es nicht mehr Menschenopfer
-die Welt *verderbenden Menschenmorde, fernerhin gab es nicht mehr
-<lb n="15"/> (Stadt) äter, Vielherrscher, Tyrannen und Volksregierungen. Fernerhin
+die Welt <corr resp="#editor">verderbenden</corr> Menschenmorde, fernerhin gab es nicht mehr
+<lb n="15"/> <supplied reason="undefined" resp="#editor">Stadt</supplied> äter, Vielherrscher, Tyrannen und Volksregierungen. Fernerhin
 gab es nicht mehr die deswegen in jeder Stadt und an jedem Orte bestehenden
 Verwüstungen
 ward allen gepredigt und Ein Königreich
@@ -4255,15 +4259,15 @@ das ganze Königreich der Römer und tiefer
 
 <pb n="v.3.pt.2.p.127"/>
 Blüten des Guten unter den Menschen auf: die fromme Lehre und
-Reich der Römer. Denn *vor diesem knechtete
+Reich der Römer. Denn <corr resp="#editor">vor</corr> diesem knechtete
 die Völker schwer, und da alles in Myriaden
-<milestone unit="altnumbering" n="87"/> war, *so herrschten die einen gesondert über Syrien, während andere
+<milestone unit="altnumbering" n="87"/> war, <corr resp="#editor">so</corr> herrschten die einen gesondert über Syrien, während andere
 üher Asien regierten, andere aber über Makedonien. Ägypten teilten <lb n="5"/>
-andere und hatten (es) inne, andere wiederum ebenso das Land Arabien.
+andere und hatten <supplied reason="undefined" resp="#editor">es</supplied> inne, andere wiederum ebenso das Land Arabien.
 Ferner beherrschte das Geschlecht der Juden Palästina und
 Dörfern, allen Städten und an jedem Ort kümmerten sie sich um Kriege
 und Kämpfe, als ob sie infolge eines Wahnsinns gegen
-(Mord)gierige und in Wahrheit Dámonische (wären). Über das Frühere <lb n="10"/>
+<supplied reason="undefined" resp="#editor">Mord</supplied>gierige und in Wahrheit Dámonische <supplied reason="undefined" resp="#editor">wären</supplied>. Über das Frühere <lb n="10"/>
 ist genügend geredet.</p>
 </div>
 
@@ -4272,7 +4276,7 @@ ist genügend geredet.</p>
 Mächte hervor, machten alles friedlich und führten
 indem das monarchische Reich der Römer seitdem
 die ihm helfende Kraft des Erlösers aller, indem sie zumal und auf eins <lb n="15"/>
-mit einander *sproßten und bestanden. Denn
+mit einander <corr resp="#editor">sproßten</corr> und bestanden. Denn
 unsers Erlösers zerstörte die Macht
 und verkündete Ein Reich Gottes allen Menschen, Griechen
 und denen an den Enden der Erde. Das Römerreich
@@ -4281,11 +4285,11 @@ Herrscher waren, alles, was da war, und bemühte sich eifrigst, das
 Geschlecht zu Einer Übereinstimmung und Einheit zusammenzufügen,
 und verband fortan die Vielheit der Völker. Es sollte aber
 an die Enden der Erde reichen, indem die Lehre unseres Erlösers mit
-göttlicher Kraft Kraft ihm alles vorher *bereitete und in Einheit *hinstellte. <lb n="25"/>
+göttlicher Kraft Kraft ihm alles vorher <corr resp="#editor">bereitete</corr> und in Einheit <corr resp="#editor">hinstellte</corr>. <lb n="25"/>
 Dies ist also ein großes Wunder für diejenigen, die ihren
-einrichten und (die) das Schöne nicht
+einrichten und <supplied reason="undefined" resp="#editor">die</supplied> das Schöne nicht
 Denn es wurde zugleich die Verirrung der bösen Dämonen widerlegt
-und zugleich auch die seit Ewigkeit (bestehende) Feindschaft und Krieg(slust)
+und zugleich auch die seit Ewigkeit <supplied reason="undefined" resp="#editor">bestehende</supplied> Feindschaft und Krieg<supplied reason="undefined" resp="#editor">slust</supplied>
 der Völker aufgehoben. Ferner wurde zugleich Ein Gott und Ein <lb n="30"/>
 Wissen desselben durch die Belehrung unsers Erlösers allen
 zugleich auch Ein Königreich der Römer
@@ -4301,28 +4305,28 @@ L wurde geschickt" Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> Lee</note>
 <pb n="v.3.pt.2.p.128"/>
 und zumal das ganze Geschlecht der Menschen zum Frieden verändert,
 und alle bekannten einander als Brüder und lernten die
-(keimen). Auf der Stelle aber, als ob sie von Einem Vater abstammten
+<supplied reason="undefined" resp="#editor">keimen</supplied>. Auf der Stelle aber, als ob sie von Einem Vater abstammten
 und Söhne Eines Gottes und Einer Mutter,
-<lb n="5"/> (seien), empfingen sie einander friedlich mit dem Gruße, sodaß die ganze
-Schöpfung seitdem nichts Geringeres war als Ein Haus(gesinde) und ein <milestone unit="altnumbering" n="88"/>
+<lb n="5"/> <supplied reason="undefined" resp="#editor">seien</supplied>, empfingen sie einander friedlich mit dem Gruße, sodaß die ganze
+Schöpfung seitdem nichts Geringeres war als Ein Haus<supplied reason="undefined" resp="#editor">gesinde</supplied> und ein <milestone unit="altnumbering" n="88"/>
 wohlgeordnetes Geschlecht und dem, der Lust hatte, μὁγλιψη
 reisen und zu gehen, wohin nur immer jemand wollte, mit vieler Leichtigkeit,
 sodaß jene ohne Unfall aus dem Westen nach dem Osten
 <lb n="10"/> und wiederum diese <add>von</add> hier nach dort wie in ihr
 entsprechend den alten Weissagungsworten und den prophetischen
-*Verkündigungen, — (sowohl) Myriaden andere, die wir
-Muße haben aufzuzählen, indessen aber (auch)
+<corr resp="#editor">Verkündigungen</corr>, — <supplied reason="undefined" resp="#editor">sowohl</supplied> Myriaden andere, die wir
+Muße haben aufzuzählen, indessen aber <supplied reason="undefined" resp="#editor">auch</supplied>
 und über den göttlichen Logos so ausrufen: „Er
 <lb n="15"/> von Meer zu Meer und von den Strömen bis zu den Enden
-und wiederum: „Es wird *aufsprossen in seinen Tagen die Gerechtigkeit
-und die *Fülle des Friedens“,
+und wiederum: „Es wird <corr resp="#editor">aufsprossen</corr> in seinen Tagen die Gerechtigkeit
+und die <corr resp="#editor">Fülle</corr> des Friedens“,
 Schwerter zerschmettern zu Pflugscharen und ihre Lanzen zu Sicheln,
-und nicht wird ein Volk wider das andere (mehr) das Schwert ergreifen
-<lb n="20"/> noch werden sie (fernerhin) den Krieg lernen“.</p>
+und nicht wird ein Volk wider das andere <supplied reason="undefined" resp="#editor">mehr</supplied> das Schwert ergreifen
+<lb n="20"/> noch werden sie <supplied reason="undefined" resp="#editor">fernerhin</supplied> den Krieg lernen“.</p>
 </div>
 <div type="textpart" subtype="chapter" n="3">
 <p>Dies wurde vorausgesagt und durch die Worte der Hebräer
-seit langer Zeit (voraus) verkündigt. Indem dies jetzt zu
+seit langer Zeit <supplied reason="undefined" resp="#editor">voraus</supplied> verkündigt. Indem dies jetzt zu
 in Taten gesehen wird, bestätigt es die Zeugnisse der
 Du aber, wenn du zum Überfluß andere Beweise der Wahrheit willst,
 <lb n="25"/> daß er keineswegs eine sterbliche Natur war, sondern daß
@@ -4341,39 +4345,39 @@ vor <foreign xml:lang="abbr">ABBREV</foreign> 6 μιᾶς εὐνομουμέν
 σαυτῷ λόγισαι L] „sammle dich sehr bei dir und überlege Σ</note>
 
 <pb n="v.3.pt.2.p.129"/>
-und als ob du einen andern (fragtest,) frage (und) so erforsche die Natur
+und als ob du einen andern <supplied reason="undefined" resp="#editor">fragtest,</supplied> frage <supplied reason="undefined" resp="#editor">und</supplied> so erforsche die Natur
 der Dinge.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="4">
 <p>Welcher sterbliche Mensch jemals von denen, die von Ewigkeit
-her (gelebt haben): König <add>oder Fürst</add> oder Philosoph
-oder Prophet, Grieche oder Barbare, hat soviel Tugend (davon)getragen,
+her <supplied reason="undefined" resp="#editor">gelebt haben</supplied>: König <add>oder Fürst</add> oder Philosoph
+oder Prophet, Grieche oder Barbare, hat soviel Tugend <supplied reason="undefined" resp="#editor">davon</supplied>getragen,
 nicht nach dem Tode, sondern noch lebend und atmend und <lb n="5"/>
 vieles vermögend, sodaß er auf der ganzen Erde verkündet wurde und
 Ohr und Zunge aller Völker auf der Oberfläche
-mit seinem Namen füllte? Aber dies tat *keiner außer
+mit seinem Namen füllte? Aber dies tat <corr resp="#editor">keiner</corr> außer
 der seinen Jüngern ein Wort sagte und es durch die Tat
 „Gehet hin und lehret alle Völker“, sagte er zu ihnen. Indem <lb n="10"/>
 er vorher sagte und vorher offenbarte, seine Botschaft Botschaft müsse in der
 ganzen Schöpfung verkündet werden zum Zeugnis für alle Völker,
-brachte er mit dem Worte (zugleich) auch die Tat. Denn auf der Stelle
-<milestone unit="altnumbering" n="89"/>und nicht in (weiter Zeit)ferne wurde die ganze Schöpfung mit seinen
+brachte er mit dem Worte <supplied reason="undefined" resp="#editor">zugleich</supplied> auch die Tat. Denn auf der Stelle
+<milestone unit="altnumbering" n="89"/>und nicht in <supplied reason="undefined" resp="#editor">weiter Zeit</supplied>ferne wurde die ganze Schöpfung mit seinen
 Worten erfüllt.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="5">
 <p>Was also giebt es dagegen zu sagen für den, der <lb n="15"/>
-wider die Wahrheit (den Sinn) zu richten sich erdreistet, da ja besser
-als alle Worte das mit den Augen (sichtbare) Zeugnis ist? Aber, indem
-du vom ersten (Beweis) weitergehst, komme (auch) zum andern und
+wider die Wahrheit <supplied reason="undefined" resp="#editor">den Sinn</supplied> zu richten sich erdreistet, da ja besser
+als alle Worte das mit den Augen <supplied reason="undefined" resp="#editor">sichtbare</supplied> Zeugnis ist? Aber, indem
+du vom ersten <supplied reason="undefined" resp="#editor">Beweis</supplied> weitergehst, komme <supplied reason="undefined" resp="#editor">auch</supplied> zum andern und
 überlege bei dir selbst:</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="6">
 <p>Welche sterbliche Natur ist von aller Ewigkeit
 an erschienen wie diese, die fromme und keusche Gebote nur mit <lb n="20"/>
-dem Worte ohne (jede) Schrift auferlegte und diese durch seine Jünger
+dem Worte ohne <supplied reason="undefined" resp="#editor">jede</supplied> Schrift auferlegte und diese durch seine Jünger
 von den Enden der Erde bis zum Anfang der Welt Gefestigte und
 seine Schulen auf der ganzen Erde eröffnete, sodaß in die
 Menschen, Barbaren zumal und Griechen, genügend und leicht
@@ -4386,7 +4390,7 @@ uns sagen, die wir lernen wollen:</p>
 
 <div type="textpart" subtype="chapter" n="7">
 <p>Wer jemals von denen, die bei
-den Menschen wegen (ihrer) Weisheit gepriesen wurden, hat barbarische <lb n="30"/>
+den Menschen wegen <supplied reason="undefined" resp="#editor">ihrer</supplied> Weisheit gepriesen wurden, hat barbarische <lb n="30"/>
 <note type="footnote">2 ff. vgl. Euseb. Hist. eccles. X 4 17 10 = Matth 28 19 11 vgl. Matth
 24 14 19 ff. vgl. Euseb. Hist. eccles. X 417 29 ff. vgl. Euseb. Hist. eccles. X 418</note>
 <note type="footnote">1 καὶ ὡς παρ’ ἑτέρου πυνθάνου L „und als ob du von einem anderen gefragt
@@ -4398,40 +4402,40 @@ den Menschen, die berühmt waren wegen Weisheit“ Σ</note>
 
 <pb n="v.3.pt.2.p.130"/>
 und wilde Sitten barbarischer ölker durch seine freundlichen
-aufgehoben, sodaß diejenigen unter den Skythen, die *von
+aufgehoben, sodaß diejenigen unter den Skythen, die <corr resp="#editor">von</corr>
 Jüngern gemacht waren, keine Menschenfresser mehr
-(die) unter den Persern ihre Mütter heirateten, noch andere
+<supplied reason="undefined" resp="#editor">die</supplied> unter den Persern ihre Mütter heirateten, noch andere
 <lb n="5"/> den Hunden vorwarfen, noch andere die Altgewordenen der Erdrosselung
-übergaben, noch andere diesen verwandte wilde und tierische (Dinge)
-bei anderen geschahen. Aber dies sind (nur) geringe Beweise der
+übergaben, noch andere diesen verwandte wilde und tierische <supplied reason="undefined" resp="#editor">Dinge</supplied>
+bei anderen geschahen. Aber dies sind <supplied reason="undefined" resp="#editor">nur</supplied> geringe Beweise der
 göttlichen Offenbarung des Erlösers unser aller. Sieh
 indem du bei dir überlegst:</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="8">
 <p>Welcher sterbliche Mensch jemals,
-<lb n="10"/> mit dem in so viel Zeiten *alle Herrscher zumal und Könige, Heere
+<lb n="10"/> mit dem in so viel Zeiten <corr resp="#editor">alle</corr> Herrscher zumal und Könige, Heere
 und Bürger Mengen und Völker, füge aber hinzu: die bei
 vielen als Götter Geltenden, gekämpft haben und zu jeder Zeit
-kämpfen, *hat eine übermenschliche Tüchtigkeit
+kämpfen, <corr resp="#editor">hat</corr> eine übermenschliche Tüchtigkeit
 Lehre von Tag zu Tag blühte und neu wurde in der ganzen Welt?</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="9">
 <p><lb n="15"/> Wer anders von Ewigkeit her, seit das Leben der Menschen <milestone unit="altnumbering" n="90"/>
 existiert, der ein Volk auf seinen Namen aufrichten wollte, was völlig
-unerhört ist, *hat dies nicht in einem Winkel irgendwo auf
+unerhört ist, <corr resp="#editor">hat</corr> dies nicht in einem Winkel irgendwo auf
 verborgen, sondern überall unter der Sonne wohnen lassen <add>und</add> kraft
-göttlicher Vollmacht seinem Willen *die Erfüllung
-<lb n="20"/> die Kenntnis des Einen Gottes, der jenseits des Himmels (ist), des
+göttlicher Vollmacht seinem Willen <corr resp="#editor">die</corr> Erfüllung
+<lb n="20"/> die Kenntnis des Einen Gottes, der jenseits des Himmels <supplied reason="undefined" resp="#editor">ist</supplied>, des
 Königs der ganzen Welt, und die Furcht vor ihm allen
 der Oberfläche der ganzen Erde, barbarischen und
 überliefert?</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="10">
-<p>Wer jemals, der sich vornahm zu lehren. *hat
-(dann), nachdem er sich ein derartiges Ziel vorgenommen hatte, das
+<p>Wer jemals, der sich vornahm zu lehren. <corr resp="#editor">hat</corr>
+<supplied reason="undefined" resp="#editor">dann</supplied>, nachdem er sich ein derartiges Ziel vorgenommen hatte, das
 <lb n="25"/> Werk in die Tat umgesetzt und fast durch seine Wirksamkeit sein
 Werk als gottgeliebt geoffenbart, was besonders jedes unverschämte
 <note type="footnote">2 ff. vgl. Theoph. II 81 9 ff. vgl. Euseb. Hist. eccles. X 418 15 ff. vgl.
@@ -4458,35 +4462,35 @@ und durch Taten bestätigt wurden.</p>
 <div type="textpart" subtype="chapter" n="11">
 <p>Wer anders von jemals
 her, der die Seelen der Menschen mit seinem vernünftigen Lichte erleuchtet
-hat, *hat sie ausgerüstet, den dämonischen Irrtum ihrer Väter
+hat, <corr resp="#editor">hat</corr> sie ausgerüstet, den dämonischen Irrtum ihrer Väter
 zu verlachen und fernerhin den Hölzern, den Steinen und der seelenlosen
-Hyle den göttlichen Namen nicht (mehr) beizulegen?</p>
+Hyle den göttlichen Namen nicht <supplied reason="undefined" resp="#editor">mehr</supplied> beizulegen?</p>
 </div>
   
 <div type="textpart" subtype="chapter" n="12">
-<p>Ägypter aber, die mehr als alle Menschen in Dämonenfurcht (befangen)
-waren (und) von denen der Irrtum des Polytheismus auch zu den
-Griechen kam, — wer anders außer unser Erlöser hat (sie) überredet
+<p>Ägypter aber, die mehr als alle Menschen in Dämonenfurcht <supplied reason="undefined" resp="#editor">befangen</supplied>
+waren <supplied reason="undefined" resp="#editor">und</supplied> von denen der Irrtum des Polytheismus auch zu den
+Griechen kam, — wer anders außer unser Erlöser hat <supplied reason="undefined" resp="#editor">sie</supplied> überredet
 nicht mehr verächtlich zu handeln und nicht mehr den Tieren, dem <lb n="15"/>
 Gewürm und den unansehnlichten unvernünftigen Tieren den verehrungswürdigen
 Namen zu geben, sondern nur den Einen höher als alle
-(stehenden) Gott anzuerkennen und trotz aller Todesarten für die Frömmigkeit
+<supplied reason="undefined" resp="#editor">stehenden</supplied> Gott anzuerkennen und trotz aller Todesarten für die Frömmigkeit
 zu kämpfen?</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="13">
 <p>Wer aber von Ewigkeit her hat
 und verderblichen Stamm der Dämonen, der einst das ganze <lb n="20"/>
-Geschlecht der Menschen weidete (beherrschte) und durch die Bewegung
-<milestone unit="altnumbering" n="91"/> (d. h. den Antrieb) der Götzenbilder viele Verirrungen unter
+Geschlecht der Menschen weidete <supplied reason="undefined" resp="#editor">beherrschte</supplied> und durch die Bewegung
+<milestone unit="altnumbering" n="91"/> <supplied reason="undefined" resp="#editor">d. h. den Antrieb</supplied> der Götzenbilder viele Verirrungen unter
 zeigte, unsichtbar und mit mächtiger Hand und durch
 der überral verkündigten wie böse Tiere
 Menschen fortgetrieben, sodaß fernerhin die Dämonen an deu Sprudeln <lb n="25"/>
-und Quellen nicht (mehr) weissagten, noch die irdischen und die
-die Welt *verführenden Geister das Geschlecht der Menschen
+und Quellen nicht <supplied reason="undefined" resp="#editor">mehr</supplied> weissagten, noch die irdischen und die
+die Welt <corr resp="#editor">verführenden</corr> Geister das Geschlecht der Menschen
 Irreleiteten? Es schwieg also der kastalische Quell und der andere, der
 kolophonische Quell, es schwiegen die anderen Orakelquellen: der pythische,
-klarische und nemeische. Und der (Gott) in Delphi und Milet, der in <lb n="30"/>
+klarische und nemeische. Und der <supplied reason="undefined" resp="#editor">Gott</supplied> in Delphi und Milet, der in <lb n="30"/>
 Kolophon und in Lebadia, der früher berühmt war,
 Lehre des Erlösers. Wo sind Amphilochos und Mopsos?
 keinen irgendwo. Wo sind Amphiareos und Asklepios? Wo der in
@@ -4500,7 +4504,7 @@ wurde, weil er das bei Gott Geliebte wollte, . . . . gewürdigt“ Σ
 
 <pb n="v.3.pt.2.p.132"/>
 Erde gekrochen, fortgescheucht durch den Namen unseres Erlösers,
-entsprechend den Herrschern (d. h. Dämonen), die die
+entsprechend den Herrschern <supplied reason="undefined" resp="#editor">d. h. Dämonen</supplied>, die die
 Gottheit nicht ertrugen, als er unter den Menschen wandelte, und gewaltig
 aufschrieen, indem sie riefen: “Was haben wir mit dir gemein,
 <lb n="5"/> Jesus, du Sohn Gottes?" und sagten: „Bist du vor der Zeit gekommen,
@@ -4518,7 +4522,7 @@ ward, wurde bei jedermann gepriesen.</p>
 <div type="textpart" subtype="chapter" n="14">
 <p>Wer aber anders als
 <lb n="15"/> unser Erlöser hat, durch seine Anrufung und durch
-Gebete, die durch ihn zu dem über allem (stehenden) Gott geschickt
+Gebete, die durch ihn zu dem über allem <supplied reason="undefined" resp="#editor">stehenden</supplied> Gott geschickt
 werden, die Überbleibsel der bösen Dämonen
 Leibe zu vertreiben Vollmacht gegeben denen, die rein und ungeschminkt
 dem besseren Leben der von ihm überlieferten Weisheit
@@ -4526,11 +4530,11 @@ dem besseren Leben der von ihm überlieferten Weisheit
 </div>
 
 <div type="textpart" subtype="chapter" n="15">
-<p>Vernünftige (und)
+<p>Vernünftige <supplied reason="undefined" resp="#editor">und</supplied>
 die in Gebeten und geheimen göttlichen Worten
-anders überlieferte den ihm Nahestehenden, (sie) auszuüben,
+anders überlieferte den ihm Nahestehenden, <supplied reason="undefined" resp="#editor">sie</supplied> auszuüben,
 allein? Deswegen bestanden in der ganzen Menschen weit feuerlose
-äre *gottgeziemender (Gottes)dienste und Weihgeschenke der Kirchen <milestone unit="altnumbering" n="92"/>
+äre <corr resp="#editor">gottgeziemender</corr> <supplied reason="undefined" resp="#editor">Gottes</supplied>dienste und Weihgeschenke der Kirchen <milestone unit="altnumbering" n="92"/>
 <lb n="25"/> und geistige und vernünftige Opfer, die
 dem Einen Gotte allein, dem Allkönig, von
 gebracht werden.</p>
@@ -4539,7 +4543,7 @@ gebracht werden.</p>
 <div type="textpart" subtype="chapter" n="16">
 <p>Die Opfer aber, die durch Blut, Unreinheit,
 Rauch und Feuer vollendet werden, die grausamen und wahnsinnigen
-Menschenmorde und Menschenopfer — wer hat (sie) heimlich und mit
+Menschenmorde und Menschenopfer — wer hat <supplied reason="undefined" resp="#editor">sie</supplied> heimlich und mit
 <lb n="30"/> unsichtbarer Kraft öscht und bewirkt, daß sie fernerhin
 mehr geschehen, sodaß es auch die Geschichte der Griechen bezeugt,
 <note type="footnote">4 = Matth 829 5 = Mark 124 14—8. 140, 9 = Laus 2531—250z</note>
@@ -4562,13 +4566,13 @@ Erlösers unser aller bestätigen, wessen Seele wäre so eisern, nieht die <lb n
 Wahrheit zu bezeugen und seine göttliche Kraft und
 Leben zu bekennen? Denn es sind die Werke Lebendiger und keineswegs
 Toter, und man sagt, daß das, was sichtbar ist, die
-sei, was fern (von jeder Gestalt und unsichtbar) ist.</p>
+sei, was fern <supplied reason="undefined" resp="#editor">von jeder Gestalt und unsichtbar</supplied> ist.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="18">
 <p>Auf der
-Stelle aber gestern und vorgestern (noch) verwirrte das mit Gott kämpfende <lb n="10"/>
-Geschlecht (der Dämmonen) das Leben der
+Stelle aber gestern und vorgestern <supplied reason="undefined" resp="#editor">noch</supplied> verwirrte das mit Gott kämpfende <lb n="10"/>
+Geschlecht <supplied reason="undefined" resp="#editor">der Dämmonen</supplied> das Leben der
 verführte es und vermochte viel. Als es aber aus den
 wurde, wurde es aufs Land geworfen, verächtlicher
 ohne Atem, ohne Bewegung, ohne Stimme, und nicht mehr gab es ihr
@@ -4581,15 +4585,15 @@ derjenige, der nicht mehr ist, ist nichts. Und wer nichts ist, tut auch
 nichts. Wer aber zu jeder Zeit handelt und in jeder Stunde wirkt und
 mehr als die Lebendigen vermag, wie sollte man den für nichtseiend
 halten? Denn wenn er auch von den Augen des Leibes nicht gesehen
-wird, so (beruhte doch das Kriterium nicht auf den Sinnen. Denn nicht <lb n="20"/>
+wird, so <supplied reason="undefined" resp="#editor">beruht</supplied> doch das Kriterium nicht auf den Sinnen. Denn nicht <lb n="20"/>
 einmal die kunstgerechten Worte noch die lehrhaften Theorien prüfen
 wir mit den Sinnen des Leibes, noch hat jemals jemand den Verstand
 des Menschen, geschweige denn Gott und die Kraft Gottes mit Augen
-gesehen, sondern (nur) aus den Werken können wir
+gesehen, sondern <supplied reason="undefined" resp="#editor">nur</supplied> aus den Werken können wir
 Deswegen ziemt es sich, auch bei dem Erlöser unser aller die verborgene <lb n="25"/>
 <milestone unit="altnumbering" n="93"/> Kraft aus seinen Werken zu erkennen und zu beurteilen, mag
 es nun nötig sein zu gestehen, das. was bis jetzt von ihm
-sei (Sache) eines Lebendigen, oder mag man sagen, es sei (Sache) eines
+sei <supplied reason="undefined" resp="#editor">Sache</supplied> eines Lebendigen, oder mag man sagen, es sei <supplied reason="undefined" resp="#editor">Sache</supplied> eines
 Nichtseienden. Oder ist die Frage töricht und ungereimt?
 der nichts ist, ist nach allgemeinem Urteil offenbar nichtseiend und nichts <lb n="30"/>
 vermögend, weder zu wirken noch zu handeln. Denn das ist
@@ -4606,13 +4610,13 @@ Diels 15 vgl. die Lehre des Xenophanes in Praep. I 84</note>
 <p>Fortan ist es Zeit, zu prüfen die Werke unseres Erlüsers in unsern
 Tagen und die lebendigen Werke des lebendigen Gottes zu betrachten.
 Dom solcherlei Großtaten sind die lebendigen Werke eines
-(zwar) eines solchen, der in Wahrheit Gottes Leben lebt. Dn fragst, welches
-<lb n="5"/> diese (Werke) seien? Lerne!</p> 
+<supplied reason="undefined" resp="#editor">zwar</supplied> eines solchen, der in Wahrheit Gottes Leben lebt. Dn fragst, welches
+<lb n="5"/> diese <supplied reason="undefined" resp="#editor">Werke</supplied> seien? Lerne!</p> 
 </div>
 
 <div type="textpart" subtype="chapter" n="20">
 <p>Einige mit Gott kämpfende
-(Kaiser) zertörten vor kurzem die für die
+<supplied reason="undefined" resp="#editor">Kaiser</supplied> zertörten vor kurzem die für die
 mit vieler Streitlust, mit gewaltiger Kraft und mächtiger Hand
 von Grund aus, indem sie sie ausgruben, machten seine Kirchen unsichtbar
 und bekämpften auf alle Weise den, der mit den
@@ -4621,7 +4625,7 @@ der Unsichtbare aber schützte sich unsichtbar vor
 aber wann sie nicht mehr auf Einen Wink Gottes, sie, die vor kurzem
 üppig und glückselig gl"uckselig waren, die von
 gepriesen wurden, die im Kreislauf vieler Jahre ihr Reich glänzend
-<lb n="15"/> regierten, solange ihnen das lieb und friedlich war, was in späterer (Zeit)
+<lb n="15"/> regierten, solange ihnen das lieb und friedlich war, was in späterer <supplied reason="undefined" resp="#editor">Zeit</supplied>
 bekämpft wurde. Als sie sich aber änderten und mit Gott
 sich erfrechten und ihre Götter dem unsrigen
 sie ihnen Beschützer und Vorkämpfer seien, da
@@ -4634,9 +4638,9 @@ ganzen Erde und schmückte die ganze Schöpfung
 <lb n="25"/> mit Tempeln, die rein und wie für die Gebete bestimmt
 er in jedem Dorf, in jeder Stadt, an allen Orten und in der Wüste
 der Barbaren heilige und geweihte Stätten für
-Allkönig, den Herrn des Alls heiligte, woher (auch) das,
+Allkönig, den Herrn des Alls heiligte, woher <supplied reason="undefined" resp="#editor">auch</supplied> das,
 wurde, des Namens des Herrn gewürdigt wurde, und nicht
-<lb n="30"/> seiten der Menschen eignete ihnen zufällig *dieser Beiname,
+<lb n="30"/> seiten der Menschen eignete ihnen zufällig <corr resp="#editor">dieser</corr> Beiname,
 <note type="footnote">23 ff. vgl. Praep. V 1 7</note>
 <note type="footnote">3 ἧ γὰρ οὐ ζῶντος καὶ θεοῦ ζωὴν ὡς ἀληθῶς ζῶντος ἔργα ζῶντα τυγχάνει
 τὰ τοιαδὶ κατορθώματα; L Vom Σ in Aussage verwandelt: „Denn die lebendigen
@@ -4653,11 +4657,11 @@ auch von seiten des Herrn des Alls. Deswegen wurden sie des Namens
 <p>Oder wer will, mag in die Mitte treten und lehren: Wer hat nach
 einer so großen großen Zertörung und Verödung
 ganzen Welt vom Erdboden in die Höhe errichtet, wer hat das, dem <lb n="5"/>
-jede Hoffnung abgeschnitten war, einer *zweiten, viel besseren Erneuerung
+jede Hoffnung abgeschnitten war, einer <corr resp="#editor">zweiten</corr>, viel besseren Erneuerung
 gewürdigt als früher? Das größte
 sie erneuerte keineswegs nach dem Tode der mit Gott kämpfenden
-(Kaiser), sondern während die noch am Leben waren, die
-<add>sodaß</add> sie durch ihren (eigenen) Mund und durch ihre <lb n="10"/>
+<supplied reason="undefined" resp="#editor">Kaiser</supplied>, sondern während die noch am Leben waren, die
+<add>sodaß</add> sie durch ihren <supplied reason="undefined" resp="#editor">eigenen</supplied> Mund und durch ihre <lb n="10"/>
 Schrift den Widerruf ihrer Frechheit verkündeten. Dies taten
 während sie in Ergötzung
 Geist, wie jemand meinen möchte, sondern durch Gottes Hiebe angetrieben.</p>
@@ -4666,20 +4670,20 @@ Geist, wie jemand meinen möchte, sondern durch Gottes Hiebe angetrieben.</p>
 <div type="textpart" subtype="chapter" n="21">
 <p>Er aber hat auch nach all diesen Wintern der Verfolgung
 und auf dem Gipfel des Unheils Myriaden Männer, die Liehber <lb n="15"/>
-(sind) eines Lebens der Weisheit, und weibliche Priesterinnen und
+<supplied reason="undefined" resp="#editor">sind</supplied> eines Lebens der Weisheit, und weibliche Priesterinnen und
 Scharen von Jungfrauen, die in vollkommener Heiligkeit die ganze Zeit
-ihres Lebens *existieren, durch die Lehre der göttlichen
+ihres Lebens <corr resp="#editor">existieren</corr>, durch die Lehre der göttlichen
 und in der ganzen Welt zusammengebracht.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="22">
 <p>Enthaltung
-aber (zu üben) von Speisen und viele Tage (lang) ohne Essen und ohne <lb n="20"/>
+aber <supplied reason="undefined" resp="#editor">zu üben</supplied> von Speisen und viele Tage <supplied reason="undefined" resp="#editor">lang</supplied> ohne Essen und ohne <lb n="20"/>
 Wein und mit Lagern auf der Erde willig auszuhalten und die Ausdauer
 eines festen und kräftigen Lebens mit Besonnenheit
-wer überredete (dazu) die Weiber und Myriaden von Kindern und
+wer überredete <supplied reason="undefined" resp="#editor">dazu</supplied> die Weiber und Myriaden von Kindern und
 Mengen von Männern, sodaß er durch das
-(Schrift) bewirkte, daß sie den vernünftigen <lb n="25"/>
+<supplied reason="undefined" resp="#editor">Schrift</supplied> bewirkte, daß sie den vernünftigen <lb n="25"/>
 Speisen gegen die leiblichen Speisen eintauschten?</p>
 </div>
 
@@ -4700,11 +4704,11 @@ Wein" Σ 25 „daß sie ünftige Speisen anstatt der leiblichen Speisen vernünf
 Seelen einander “ Σ. Viellelicht <foreign xml:lang="abbr">ABBREV</foreign> zu lesen.</note>
 
 <pb n="v.3.pt.2.p.136"/>
-Myriaden Sklaven <add>und</add> *Mengen der Völker,
+Myriaden Sklaven <add>und</add> <corr resp="#editor">Mengen</corr> der Völker,
 und überzeugt zu sein, daß die Seele unsterblich
 der Gerechtigkeit" offenbar ein Aufseher der gerechten und frevlen
-Taten der Menschen sei, und das Gericht Gottes zu erwarten, (und)
-<lb n="5"/> daß es nötig, sei, um dieser (Dinge) willen
+Taten der Menschen sei, und das Gericht Gottes zu erwarten, <supplied reason="undefined" resp="#editor">und</supplied>
+<lb n="5"/> daß es nötig, sei, um dieser <supplied reason="undefined" resp="#editor">Dinge</supplied> willen
 keusches Leben zu kümmern. Denn sonst, wenn sie
 sei es unmöglich, sich dem Joch
 wird von dem, der von uns allein Gott genannt wird, bis jetzt
@@ -4724,7 +4728,7 @@ sondern aus geistiger und vernünftiger Seele und sprich, indem
 <p>Wer anders jemals von denen, die seit
 Ewigkeit gepriesen wurden, wurde wie der, der von uns Gott genannt
 wird, durch Prophetenworte von oben her vor Myriaden Zeiten erkannt
-und *vorher verkündigt bei den vor alters gottgeliebten Kindern
+und <corr resp="#editor">vorher</corr> verkündigt bei den vor alters gottgeliebten Kindern
 der Hebräer, die auch den Ort seiner Offenbarung, die Zeit seines
 <lb n="20"/> Kommens, die Art seines Lebens, seine Kraft, seine Worte und Taten
 vorher in den göttlichen Schriften beschrieben haben?</p>
@@ -4741,7 +4745,7 @@ mit seinen Heiligtümen zu Boden stürzte?</p>
   
 <div type="textpart" subtype="chapter" n="27">
 <p>Wer hat Vorherverkündigungen
-über eben *diese, die (erwähnten) gottlosen Männer
+über eben <corr resp="#editor">diese</corr>, die <supplied reason="undefined" resp="#editor">erwähnten</supplied> gottlosen Männer
 <note type="footnote">2 vgl. Fragm. Trag. Adesp. 421; Praep. XIII 13 47 15—21 = 2. Bruchstüch
 der griech. Theoph.</note>
 <note type="footnote">1 παῖδας καὶ οἰκετῶν γένη πλήθη τε μυρία μυρίων ἐθνῶν L „und Myriaden
@@ -4757,10 +4761,10 @@ gr. „und bestand und wurde ündigt” Σ 1. <foreign xml:lang="abbr">ABBREV</f
 καταλλήλους τοῖς πράγμασιν ἀποφθεγξάμενος L „über eben dies" Σ 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.137"/>
-und über die von ihm in der ganzen Welt gegründete Kirche *eben
+und über die von ihm in der ganzen Welt gegründete Kirche <corr resp="#editor">eben</corr>
 den Werken entsprechend vorhergesagt und ihre Wahrheit durch seine
 Werke erwiesen wie unser Erlöser, der über den Tempel der gottlosen
-(Juden) sagte: „Siehe! Euer Haus wird öde gelassen werden“, und
+<supplied reason="undefined" resp="#editor">Juden</supplied> sagte: „Siehe! Euer Haus wird öde gelassen werden“, und
 „Nicht soll ein Stein auf dem andern bleiben an diesem Orte, der nicht <lb n="5"/>
 aufgelöst würde“? Über seine Kirche aber sagte er: „Auf diesen Felsen
 will ich meine Kirche bauen und die Riegel des Scheol sollen sie nicht
@@ -4776,7 +4780,7 @@ zu Menschenfischern machte und so große
 gab, daß sie sogar Schriften verfaßten
 diese so bestätigte, daß sie in der ganzen Welt in alle Sprachen der <lb n="15"/>
 <milestone unit="altnumbering" n="96"/> Griechen und Barbaren übersetzt und bei allen Völkern
-und (daß) man glaubte, die in ihnen geschriebenen Worte seien göttlich?</p>
+und <supplied reason="undefined" resp="#editor">daß</supplied> man glaubte, die in ihnen geschriebenen Worte seien göttlich?</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="29">
@@ -4790,14 +4794,14 @@ und die schwersten Qualen ertragen sollten?</p>
 <p>Dies aber, daß
 auch willig machte, dies zu ertragen, und mit den Waffen der Frömmigkeit so
 tcappnete, daß sie in bezug auf ihre Seelen fester als Diamant
-Kämpfen gegen ihre Widersacher erschienen, wie sollte (dies)
+Kämpfen gegen ihre Widersacher erschienen, wie sollte <supplied reason="undefined" resp="#editor">dies</supplied>
 Wort übersteigen?</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="31">
 <p>Und daß er nicht nur denjenigen, die ihm an- <lb n="25"/>
-sondern auch denjenigen, die von ihnen (die Lehre) empfingen und
-wiederum auch denjenigen, die (noch) später (Jünger) wurden und den-
+sondern auch denjenigen, die von ihnen <supplied reason="undefined" resp="#editor">die Lehre</supplied> empfingen und
+wiederum auch denjenigen, die <supplied reason="undefined" resp="#editor">noch</supplied> später <supplied reason="undefined" resp="#editor">Jünger</supplied> wurden und den-
 <note type="footnote">4 = Matth 2338 5 = Matth 242 6 = Matth 16 18 9 ff. vgl. Matth
 418 ff. 20 vgl. Matth 1018 21 ff. vgl. Euseb. Hist. eccles. X 419</note>
 <note type="footnote">2 „offenbar (καταδήλως?) und mit Werken“ Σ. Das <foreign xml:lang="abbr">ABBREV</foreign> vor <foreign xml:lang="abbr">ABBREV</foreign> streiche
@@ -4812,18 +4816,18 @@ so fest ihre Seele wappneten, daß sie erschienen in
 wie übersteigt (dies) nicht alle Worte?“ Σ</note>
 
 <pb n="v.3.pt.2.p.138"/>
-jenigen, die bis jetzt zu unserer Zeit (Christen sind), die Kraft in ihrer
+jenigen, die bis jetzt zu unserer Zeit <supplied reason="undefined" resp="#editor">Christen sind</supplied>, die Kraft in ihrer
 Seele so befestigte, daß sie. obwohl sie nichts Todeswürdiges
 Strafen und alle Arten der Foltern gern um der Gerechtigkeit des oberhalb
-von allem (stehenden) Gottes willen ertrugen, wie sollte das nicht
+von allem <supplied reason="undefined" resp="#editor">stehenden</supplied> Gottes willen ertrugen, wie sollte das nicht
 <lb n="5"/> jedes Wunder übersteigen?</p>
 </div>
 <div type="textpart" subtype="chapter" n="32">
 <p>Aber wer jemals von den Königen, der so lange Zeit
-seiner Herrschaft (war), vollendete (dies)? Wer siegte so nach seinem
+seiner Herrschaft <supplied reason="undefined" resp="#editor">war</supplied>, vollendete <supplied reason="undefined" resp="#editor">dies</supplied>? Wer siegte so nach seinem
 Tode und richtete das Siegeszeichen über sein Feinde auf und unterwarf
 alle Orter, Plätze und Städte der Griechen
-<lb n="10"/> mit verborgener Kraft *und mit unsichtbarer Rechte *seinen
+<lb n="10"/> mit verborgener Kraft <corr resp="#editor">und</corr> mit unsichtbarer Rechte <corr resp="#editor">seinen</corr>
 Widersacher?</p>
 </div>
 
@@ -4832,17 +4836,17 @@ Widersacher?</p>
 der Friede, der durch seine Macht auf der ganzen Erde besorgt wurde,
 über den wir das Geziemende vorher gesagt haben, welches Lästermaul
 sollte er nicht stopfen, indem so in der Tat mit seiner Lehre die Liebe
-<lb n="15"/> und Einheit unter allen Völkern (nebenher) und (indem)
+<lb n="15"/> und Einheit unter allen Völkern <supplied reason="undefined" resp="#editor">nebenher</supplied> und <supplied reason="undefined" resp="#editor">indem</supplied>
 durch die Propheten Gottes der Friede der Völker in
 Welt vorher verkündigt ward und das von ihm in alle Völker
 Wort.</p>
-<p>Aber (zu) klein wäre Ein Tag, um zu versuchen,
+<p>Aber <supplied reason="undefined" resp="#editor">zu</supplied> klein wäre Ein Tag, um zu versuchen,
 <lb n="20"/> Beweise der göttlichen Kraft des Logos Gottes, des Erlösers aller, die <milestone unit="altnumbering" n="97"/>
-bis jetzt *gesehen werden, zu sammeln und zu zeigen, das niemals
-und von Ewigkeit her keiner, weder bei Griechen *noch bei Barbaren,
+bis jetzt <corr resp="#editor">gesehen</corr> werden, zu sammeln und zu zeigen, das niemals
+und von Ewigkeit her keiner, weder bei Griechen <corr resp="#editor">noch</corr> bei Barbaren,
 eine derartige vorzügliche und göttliche Kraft
 bei jedermann als Erlöser des Alls und eingeborner Logos
-<lb n="25"/> von allem (stehenden) Gottes verkündigt wird. Was aber rede
+<lb n="25"/> von allem <supplied reason="undefined" resp="#editor">stehenden</supplied> Gottes verkündigt wird. Was aber rede
 Menschen, da ja nicht einmal von denen, die bei allen Völkern Götter
 genannt werden, eine Natur wie diese auf Erden erschienen ist! Oder
 wer will, möge es zeigen. Es möge
@@ -4858,17 +4862,17 @@ gezeigt “ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 22 „noch bei Barba
 
 <pb n="v.3.pt.2.p.139"/>
 es gibt, und uns sagen, von welchem Gott oder Heros von aller Ewigkeit
-her *jenials gehört wurde, daß er die Lehren, die ein ewiges Lehen
+her <corr resp="#editor">jenials</corr> gehört wurde, daß er die Lehren, die ein ewiges Lehen
 und ein himmlisches Reich verursachen, den Menschen überliefert habe
 wie unser Erlöser, der bewirkte, daß Myriaden Mengen in der ganzen
-Welt durch seine weisen Lehren geübt (erzogen) wurden, und <lb n="5"/>
+Welt durch seine weisen Lehren geübt <supplied reason="undefined" resp="#editor">erzogen</supplied> wurden, und <lb n="5"/>
 sie überredete, tiberredete, einem himmlischen Leben nachzujagen, dies zetiliche
 Leben aber zu verachten und die himmlischen Wohnplätze zu erhoffen
 die für die gottliebenden Seelen aufbewahrt sind.</p>
 </div>
   
 <div type="textpart" subtype="chapter" n="34">
-<p>Welcher Gott oder Heros hat völlig von Sonnenaufgang *bis zu
+<p>Welcher Gott oder Heros hat völlig von Sonnenaufgang <corr resp="#editor">bis</corr> zu
 bald so schnell wie der Lauf der Sonne, mit den glänzenden <lb n="10"/>
 Strahlen seiner Lehre die Erde erhellt und erleuchtet, sodaß
 auf der ganzen Erde dem Einen Gott Einen und denselben Gottesdienst
@@ -4880,7 +4884,7 @@ vollendeten?</p>
 und Heroen der Griechen und Barbaren verdrängt und ein
 daß keiner von jenen für einen Gott gehalten werde und, mach- <lb n="15"/>
 er das Gesetz gegeben hatte, sie überzeugt? Als dann aber alle
-mit ihm kämpften, hat er, obwohl er (nur) Einer war, das
+mit ihm kämpften, hat er, obwohl er <supplied reason="undefined" resp="#editor">nur</supplied> Einer war, das
 entgegenstehende Heer vernichtet und ist besser erschienen als
 alle Götter und Heroen von Ewigkeit her, sodaß
 Menschenwelt der eingeborne Logos Gottes von allen Menschen genannt <lb n="20"/>
@@ -4893,7 +4897,7 @@ Völkern, die auf dem großen στοιχεῖον der
 auf Erden und denen im Meere, überliefert, in jeder Woche an dem
 Tage, der bei den Griechen der Sonntag heißt, ein Fest zu
 Heiligkeit der Seele und des Leibes und sich zusammen zu vereinigen, <lb n="25"/>
-<milestone unit="altnumbering" n="98"/> und hat sie zubereitet, nicht die Leiber zu *mästen, sondern
+<milestone unit="altnumbering" n="98"/> und hat sie zubereitet, nicht die Leiber zu <corr resp="#editor">mästen</corr>, sondern
 durch die göttliche Lehre zu beleben?</p>
 </div>
 
@@ -4913,8 +4917,8 @@ und wie die Schnelligkeit des Laufes der Sonne" Σ 11 τὴν (scil. γῆν) �
 „hören“ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> PSm</note>
 
 <pb n="v.3.pt.2.p.140"/>
-streiten, er aber hat ungesehen (und) verborgen sie vernichtet und die
-Seinen mit den *göttlichen Häusern zu großem
+streiten, er aber hat ungesehen <supplied reason="undefined" resp="#editor">und</supplied> verborgen sie vernichtet und die
+Seinen mit den <corr resp="#editor">göttlichen</corr> Häusern zu großem
 ist es nötig, durch Worte die göttlichen
 die besser sind als jedes Wort, sammeln zu wollen, da ja auch, wenn
 <lb n="5"/> wir schwiegen, die Dinge schreien würden zu denen, die
@@ -4922,32 +4926,32 @@ Seele besitzen,</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="38">
-<p>(daß) dies seltsam ist in Wahrheit und
-das nicht wahrscheinlich ist, und (daß) von Ewigkeit her die Welt
-Menschen dies Eine Ding (hervor)brachte und einst der in Wahrheit
+<p><supplied reason="undefined" resp="#editor">daß</supplied> dies seltsam ist in Wahrheit und
+das nicht wahrscheinlich ist, und <supplied reason="undefined" resp="#editor">daß</supplied> von Ewigkeit her die Welt
+Menschen dies Eine Ding <supplied reason="undefined" resp="#editor">hervor</supplied>brachte und einst der in Wahrheit
 einzige Sohn Gottes denen auf Erden erschien, durch den das ganze
 <lb n="10"/> Menschengeschlecht den Zugang zur wahren Frömmigkeit vermöge
-seiner (des Logos) Natur empfing, sodaß fortan in der ganzen
-(Plätze (für das Anhören) ören) der Worte und für
+seiner <supplied reason="undefined" resp="#editor">des Logos</supplied> Natur empfing, sodaß fortan in der ganzen
+welt Plätze <supplied reason="undefined" resp="#editor">für das Anhören</supplied> der Worte und für
 richt in der göttlichen Lehre bestanden und barbarische und
 Menschen ihren Sinn zur Friedfertigkeit änderten, sodaß die vernünftige
-<lb n="15"/> Beschaffenheit ihrer Seele eben seine (des Logos) Tüchtigkeit
-durch die sie ihren Vater im *Himmel, den Erlöser aller, den
+<lb n="15"/> Beschaffenheit ihrer Seele eben seine <supplied reason="undefined" resp="#editor">des Logos</supplied> Tüchtigkeit
+durch die sie ihren Vater im <corr resp="#editor">Himmel</corr>, den Erlöser aller, den
 Logos Gottes, den Allkönig erkannten und eben ihm
 durch ihn dem, der die Ursache alles Guten ist, die schuldigen Hymnen
 und Segnungen und die gebührenden Bekenntnisse darbrachten,
 <lb n="20"/> fortan fromme Hymnen und Bekenntnisse, die zu denen der Engelscharen
 im Himmel stimmen, auch von den Bewohnern des στοιχεῖον
-der Erde jeden Tag und jede Nacht *geschickt wurden.</p>
+der Erde jeden Tag und jede Nacht <corr resp="#editor">geschickt</corr> wurden.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="39">
 <p>Die erlösenden und der Welt helfenden Taten
-des göttlichen Logos unter den Menschen (waren) also
-<lb n="25"/> Myriaden andere (Dinge) wie sie, um derentwillen er, (als) er in die
+des göttlichen Logos unter den Menschen <supplied reason="undefined" resp="#editor">waren</supplied> also
+<lb n="25"/> Myriaden andere <supplied reason="undefined" resp="#editor">Dinge</supplied> wie sie, um derentwillen er, <supplied reason="undefined" resp="#editor">als</supplied> er in die
 Welt der Menschen kam, keineswegs das tat, was seiner Gewohnheit
-entsprach, er der unkörperlich (ist) und verborgen durch die
-*geht, der eben in Werken, denen im Himmel und denen auf Erden,
+entsprach, er der unkörperlich <supplied reason="undefined" resp="#editor">ist</supplied> und verborgen durch die
+<corr resp="#editor">geht</corr>, der eben in Werken, denen im Himmel und denen auf Erden,
 <note type="footnote">25—S 141. 6 — 2418—15</note>
 <note type="footnote">1 ὁ δ’ ἀφανὴς ἀφανῶς L 2 τοὺς οἰκείοις αὐτοῖς ἱεροῖς οἴκοις ( „eben durch
 die heiligen Häuser“) ἐπὶ μέγα δόξης προῆγεν L] 1. <foreign xml:lang="abbr">ABBREV</foreign> 6 Hauptsatz Σ]
@@ -4962,31 +4966,31 @@ nach Σ 16 1. <foreign xml:lang="abbr">ABBREV</foreign> mit HS (Druckfehler) 22 
 <pb n="v.3.pt.2.p.141"/>
 <milestone unit="altnumbering" n="99"/> seine gewaltigen Taten zeigt, sondern in neuer und in einer seiner
 Gewohnheit fremden Weise. Denn durch ein sterbliches Instrument
-(d. h. den Leib) hielt er, wie der König durch einen
-seine Reden (zu) und seinen Umgang mit den Menschen, indem
+<supplied reason="undefined" resp="#editor">d. h. den Leib</supplied> hielt er, wie der König durch einen
+seine Reden <supplied reason="undefined" resp="#editor">zu</supplied> und seinen Umgang mit den Menschen, indem
 er sich bemühte, das Sterbliche durch das ihm Ähnliche lebendig zu <lb n="5"/>
-machen (zu erlösen).</p>
-<p>Aber da es ersichtlich ist, daß keineswegs Ein (Grund),
+machen <supplied reason="undefined" resp="#editor">zu erlösen</supplied>.</p>
+<p>Aber da es ersichtlich ist, daß keineswegs Ein <supplied reason="undefined" resp="#editor">Grund</supplied>,
 Gründe vorhanden waren, um derentwillen der Erlöser
 unter den Menschen veranstaltete, so ist es nötig,
-(Dingen) auch in kurzem zu sagen, aus welchem Grunde er ein menschliches <lb n="10"/>
+<supplied reason="undefined" resp="#editor">Dingen</supplied> auch in kurzem zu sagen, aus welchem Grunde er ein menschliches <lb n="10"/>
 Gefäß gebrauchte und zu dem Verkehr unter die
 Und wie sollte sonst die göttliche, verborgene, unsichtbare
 οὐσία, eben der unleibliche und unkörperliche Verstand,
 Gottes, den leiblichen Menschen, die in die Tiefe des Bösen eingetaucht
 waren und im Werden und auf Erden Gott suchten, und anders <lb n="15"/>
 den Schöpfer der Schöpfung des Alls
-schauen können oder wollen, — (wie sollte sie sonst) sich
+schauen können oder wollen, — <supplied reason="undefined" resp="#editor">wie sollte sie sonst</supplied> sich
 in menschlicher Zusammensetzung und Gestalt, die uns bekannt wird
 wie durch einen Dolmetscher? Denn wie sollten die leiblichen Augen
 anders das Unkörperliche Gottes sehen? Wie sollte aber die sterbliehe <lb n="20"/>
 Natur den Verborgenen, Unsichtbaren entdecken, ihn, den sie aus Myriaden
 Werken nicht erkannt hat? Deswegen also bedurfte er eines
-sterblichen Instrumentes und eines passenden Hilfs(mittels) für
+sterblichen Instrumentes und eines passenden Hilfs<supplied reason="undefined" resp="#editor">mittels</supplied> für
 unter den Menschen, weil ihnen dies lieb war. Denn man sagt,
 daß alle das lieben, was ihnen gleicht. Denn wie der Großkönig
 Dolmetscher sehr nötig hat, der die Worte des Königs
-verschieden sind an Gehör (d. h. in der Sprache), und
+verschieden sind an Gehör <supplied reason="undefined" resp="#editor">d. h. in der Sprache</supplied>, und
 so hat auch der göttliche Logos, der die Seelen im Leibe
 zu heilen bereit war und sich auf Erden zeigen wollte, ein Medium,
 gleichsam einen Dolmetscher und ein körperliches Vehikel nötig. Es <lb n="30"/>
@@ -5003,16 +5007,16 @@ ziehen. Man erwartet etwa δήμοις πολυγλώσσοις καὶ πό�
 <pb n="v.3.pt.2.p.142"/>
 war dies ein menschliches Instrument, durch das er die Beschaffenheit
 der geheimen Tiefen der Gottheit den Menschen offenbarte. Und nicht
-nur (dies), sondern auch denen, die sich über die (Sinnes)wabrnehmung
+nur <supplied reason="undefined" resp="#editor">dies</supplied>, sondern auch denen, die sich über die <supplied reason="undefined" resp="#editor">Sinnes</supplied>wabrnehmung
 dessen, was man sieht, freuen und in Bildern und Schnitzarbeiten
-<lb n="5"/> (γλυφαί) seelenloser Götzen Götter suchen und (die) phantasieren, Gott sei
-in ὕλη und in Körpern und (die) um ihrer Schwäche
+<lb n="5"/> <supplied reason="undefined" resp="#editor">γλυφαί</supplied> seelenloser Götzen Götter suchen und <supplied reason="undefined" resp="#editor">die</supplied> phantasieren, Gott sei
+in ὕλη und in Körpern und <supplied reason="undefined" resp="#editor">die</supplied> um ihrer Schwäche
 Wahnsinns willen sterbliche Menschen von Natur Götter
-(ihnen) zeigte sich gerade so auch der (menschen)freundliche Logos
-Gottes. Deswegen machte er sich als allerheiligsten Tempel *ein körpernliches <milestone unit="altnumbering" n="100"/>
-<lb n="10"/> Instrument, *eine sinnlich wahrnehmbare Wohnung für
-Kraft, *ein reines und ganz vorzügliches
-alle seelenlosen Götzen. Denn das aus seelenloser ὕλη (bestehende)
+<supplied reason="undefined" resp="#editor">ihnen</supplied> zeigte sich gerade so auch der <supplied reason="undefined" resp="#editor">menschen</supplied>freundliche Logos
+Gottes. Deswegen machte er sich als allerheiligsten Tempel <corr resp="#editor">ein</corr> körpernliches <milestone unit="altnumbering" n="100"/>
+<lb n="10"/> Instrument, <corr resp="#editor">eine</corr> sinnlich wahrnehmbare Wohnung für
+Kraft, <corr resp="#editor">ein</corr> reines und ganz vorzügliches
+alle seelenlosen Götzen. Denn das aus seelenloser ὕλη <supplied reason="undefined" resp="#editor">bestehende</supplied>
 das nach Art des Erzes und Eisens, des Goldes und Elfenbeins, der
 Steine und Hölzer in ὕλη zum Irrtum der Toren durch
 <lb n="15"/> Männer gefertigt ist, war als
@@ -5021,14 +5025,14 @@ geschmückt war, hatte am Leben und an der geistigen οὐσία
 Bild voll jeglicher Tugend, ein göttliches Bild als Wohnung
 Logos und als heiliger Tempel des heiligen Gottes, das durch die
 <lb n="20"/> Kraft des heiligen Geistes bereitet war. Der in ihm wohnende Logos
-war mit den Sterblichen durch das ihnen Verwandte (d. h. durch den
-Leib) wie durch einen Dolmetscher zusammen und wurde (dadurch) erkannt,
+war mit den Sterblichen durch das ihnen Verwandte <supplied reason="undefined" resp="#editor">d. h. durch den
+Leib</supplied> wie durch einen Dolmetscher zusammen und wurde <supplied reason="undefined" resp="#editor">dadurch</supplied> erkannt,
 keineswegs aber verfiel er ihnen gleich den Leiden, noch war er
 nach Art der menschlichen Seele an den Leib gebunden, noch änderte
 <lb n="25"/> er sich in seiner Gottheit, indem er an sich geringer erschien. Denn
 wie die Strahlen des Sonnenlichtes nichts leiden, wenn sie das All erfüllen
-und *tote und unreine Körper berühren,
-Kraft *des Logosgottes in ihrer οὐσία noch viel weniger und wird
+und <corr resp="#editor">tote</corr> und unreine Körper berühren,
+Kraft <corr resp="#editor">des</corr> Logosgottes in ihrer οὐσία noch viel weniger und wird
 <note type="footnote">3—S. 145, 7 = Laus 241 24—244 11 25—143, 2 = Dem. IV 131</note>
 <note type="footnote">7 1. <foreign xml:lang="abbr">ABBREV</foreign> Schultheß mit HS | ἀνηγόρευσαν ἀναγορεύουσι
 καὶ ταύτῃ πη L 9 ff. „und ein" Σ streiche das <foreign xml:lang="abbr">ABBREV</foreign> ebenso vor den folgenden
@@ -5042,38 +5046,38 @@ L „ sterbliche" Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 28 τοῦ θ�
 der Logosgott" Σ 1. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.143"/>
-nicht geschädigt, noch wird sie jemals geringer als sie selbst (ist),
+nicht geschädigt, noch wird sie jemals geringer als sie selbst <supplied reason="undefined" resp="#editor">ist</supplied>,
 sie unkörperlich einen Kürper berührt.</p>
 <p>So also bot sich der Erlöser aller selbst als hilfreich
 jedermann dar durch das menschliche Instrument, das er zeigte, indem
 er wie ein musikalischer Mensch durch die Leier seine Weisheit <lb n="5"/>
 zeigen will. Ein griechischer Mythus aber lehrt, daß
-seinem Gesange allerlei Tiere *bezauberte und den Grimm der Wilden
+seinem Gesange allerlei Tiere <corr resp="#editor">bezauberte</corr> und den Grimm der Wilden
 besänftigte, indem die Saiten an dem Instrument mit dem
 wurden, und dies wird in der Schar der Griechen besungen und
-geglaubt, daß eine seelenlose Leier die Tiere bändigte und (dab) sogar Bäume <lb n="10"/>
+geglaubt, daß eine seelenlose Leier die Tiere bändigte und <supplied reason="undefined" resp="#editor">dab</supplied> sogar Bäume <lb n="10"/>
 und Eichen umänderte das, was der Musik ähnlich
 der allweise und ganz vorzügliche Logos Gottes den Seelen
 die in mannigfaches Lnheil verstrickt waren, allerlei Heilungen, ergriff
-das musikalische Instrument, das Werk seiner Weisheit, *den Menschen
+das musikalische Instrument, das Werk seiner Weisheit, <corr resp="#editor">den</corr> Menschen
 mit Händen <add>und</add> stimmte durch ihn Gesünge und Besehwürungen für <lb n="15"/>
 die vernünftigen, aber nicht für
 <milestone unit="altnumbering" n="101"/> heilte jede wilde Sitte der Griechen und der Barbaren und die rohen
 und tierischen Leidenschaften der Seelen mit den Heilmitteln göttlicher
 Lehre und zeigte den kranken Seelen, die Gott im Werden und in den
 Körpern suchen, wie ein vorzüglicher Arzt durch ein  ihnen verwandtes <lb n="20"/>
-und Hilfs(mittel) Gott im Menschen. Und ferner kümmerte
+und Hilfs<supplied reason="undefined" resp="#editor">mittel</supplied> Gott im Menschen. Und ferner kümmerte
 er sich um die Leiber nicht weniger als um die Seelen und bereitete
 für die leiblichen Augen der Menschen das, was er durch
 zu sehen: staunenswerte Wunder und göttliche Zeichen
 dem leiblichen Ohre aber ferner verkündete er die Lehren durch Zunge <lb n="25"/>
-*und Fleisch, alles dies aber vollendete er durch den Leib, den er trug,
+<corr resp="#editor">und</corr> Fleisch, alles dies aber vollendete er durch den Leib, den er trug,
 wie durch einen Dolmetscher für diejenigen, die nicht anders
 so seine Gottheit wahrnehmen können.
 Dies aber wurde verrichtet nach dem Willen seines Vaters, indem
-er selbst wiederum, ohne ὕλη und ohne Körper blieb, wie er (auch) <lb n="30"/>
+er selbst wiederum, ohne ὕλη und ohne Körper blieb, wie er <supplied reason="undefined" resp="#editor">auch</supplied> <lb n="30"/>
 vordem bei seinem Vater war, ohne daß er in seinem
-und ohne daß (etwas) von seiner Xatur vernichtet ward und
+und ohne daß <supplied reason="undefined" resp="#editor">etwas</supplied> von seiner Xatur vernichtet ward und
 <note type="footnote">3—6 = Dein. IV 13 3.4 19—21 = Dem. IV 135—10</note>
 <note type="footnote">8 ἐν ὀργάνῳ πλήκτρῳ κρουομένων χορδῶν L „durch das befestigte (= πηκτῷ)
 Instrument, indem die Saiten an ihm geschlagen wurden" Σ 12 „ganz vorzügliche“
@@ -5090,13 +5094,13 @@ erfüllte er das All, war mit dem Vater und war in ihm und
 <lb n="5"/> damals für alles zugleich, für das was im Himmel und
 nach unserer Art von der Allgegenwart ausgeschlossen noch in
 seinem gewohnten göttlichen Handeln gehemmt, sondern
-er zwar von sich aus dem Menschen, (d. h. dem Leibe), andererseits
+er zwar von sich aus dem Menschen, <supplied reason="undefined" resp="#editor">d. h. dem Leibe</supplied>, andererseits
 aber empfing er nichts von dem Menschen, und unterstützte
 <lb n="10"/> göttlicher Kraft das Sterbliche, nahm aber nichts auf aus
 des Sterblichen. Nicht wurde der Unkörperliche befleckt,
 Körper geboren ward, noch litt er, der ohne Leiden ist,
 Wesen, als das Sterbliche wieder von ihm getrennt wurde, deswegen
-weil nicht einmal, wenn es so (sichträfe), sobald eine Leier zerborchen
+weil nicht einmal, wenn es so <supplied reason="undefined" resp="#editor">sichträfe</supplied>, sobald eine Leier zerborchen
 <lb n="15"/> wird oder ihre Saiten zerrissen werden, derjenige etwas leidet, der sie
 schlägt, noch würden würdern wir mit Recht sagen,
 Mannes bestraft wird, daß die Weisheit des Weisen oder die
@@ -5126,7 +5130,7 @@ Fülle. Deswegen verbrachte er das ganze Leben derartig, indem
 ἂν εἴη τῶν σωμάτων ἀλλότριος D τῶν σωμάτων &lt; L</note>
 
 <pb n="v.3.pt.2.p.145"/>
-sein Bild(Leib) in uns ähnlichen Leiden zeigte, bald aber den Logosgott
+sein Bild <supplied reason="undefined" resp="#editor">Leib</supplied> in uns ähnlichen Leiden zeigte, bald aber den Logosgott
 offenbarte in gewaltigen Taten und staunenswerten Werken gleichwie
 Gott, und indem er durch Weissagungen voraussagte, was kommen
 wird, und den für viele unsichtbaren Logos Gotes eben
@@ -5136,7 +5140,7 @@ Seelen der Menschen nach oben zur himmlischen Stadt zu führen, daß
 sie zu den Bürgern droben eilen wie zu Brüdern
 ihren Vater im Himmel erkennen, und die die Vorzüglichkeit ihrer Art:
 die verständige und vernünftige οὐσία lehren, damit sie nicht irren, <lb n="10"/>
-und (indem er) sie so ermahnte, auf der Stelle in aller Keuschheit und
+und <supplied reason="undefined" resp="#editor">indem er</supplied> sie so ermahnte, auf der Stelle in aller Keuschheit und
 Heiligkeit so zu leben, daß sie ihre Auswanderung von hier
 leicht und ungehindert vollziehen könnten und
 das ewige Leben bei Gott, dem Königh des Alls,
@@ -5162,9 +5166,9 @@ verborgene, niemals gehörte Worte überliefert und die Erinnerung an <lb n="30"
 das Leben bei Gott und an den himmlischen Vater der auf Erden gottliebenden
 Seelen, den er auch im Gebet sie anstachelte, anzurufen und
 zu sagen: „Unser Vater im Himmel", und die Einsicht in ihre Art droben
-(im Himmel) ward überliefert durch das, was er lehrte, damit sie es
+<supplied reason="undefined" resp="#editor">im Himmel</supplied> ward überliefert durch das, was er lehrte, damit sie es
 verständen. Wenn du aber liebst, auch an der Theorie dieser Diuge <lb n="35"/>
-teilzuhaben, so (ist) reichlich (Gelegenheit), dich dem Hören der
+teilzuhaben, so <supplied reason="undefined" resp="#editor">ist</supplied> reichlich <supplied reason="undefined" resp="#editor">Gelegenheit</supplied>, dich dem Hören der
 <note type="footnote">33 = Matth 69</note>
 <note type="footnote">6 διδασκαλίαις ἐνθέοις ὄνω πρὸς τὸν ὑπερουράνιον τόπον τὰς ψυχὰς παρασκευάζεσθαι
 προαγούσαις L</note>
@@ -5173,10 +5177,10 @@ teilzuhaben, so (ist) reichlich (Gelegenheit), dich dem Hören der
 seiner Jünger zuzuwenden und die Schrift nach allen Seiten kennen
 zu lernen über seine Taten und über seine Worte, sodaß du du in Wahrheit
 Gott siehst und den göttlichen Logos, wie er durch einen Dolmetscher mit
-den Menschen, (uns) ähnlich an Leiden (zusammen) war, und wie der
+den Menschen, <supplied reason="undefined" resp="#editor">uns</supplied> ähnlich an Leiden <supplied reason="undefined" resp="#editor">zusammen</supplied> war, und wie der
 <lb n="5"/> Unsterbliche mit den Sterblichen redete, und wie Unkörperliche ein
 Bild aus menschlicher Natur anzog, und wie der Gott in ihm sein Bild
-antrieb, und wie der Erlöser aller (göttliche) Reden losieß und göttliche
+antrieb, und wie der Erlöser aller <supplied reason="undefined" resp="#editor">göttliche</supplied> Reden losieß und göttliche
 Lehre vortrug und alle Krankheiten und Schmerzen heilte, und wie der,
 in dem kein Falsch war, zu guten Werken bereit war, und wie er das,
 <lb n="10"/> was kein Auge je gesehen und in keines Menschen Ohr gekommen
@@ -5185,16 +5189,16 @@ Anfang der Vorzüglicheit bei Gott nahe und machte sie weise mit unaussprechlich
 Kraft und bereitete sie zu wahren Herolden seiner Gottheit.
 So heilte er ferner diejenigen, deren Seelen durch allerleiSüdnen Südnen
 <lb n="15"/> verderbt waren, indem er bald für die Leiden die entsprechende Hilfe <milestone unit="altnumbering" n="104"/>
-(Arznei) gewährte, bald aber die mystische Theorie der göttlichen Lehre
+<supplied reason="undefined" resp="#editor">Arznei</supplied> gewährte, bald aber die mystische Theorie der göttlichen Lehre
 denen überlieferte, die sie aufnehmen können. Was aber habe ich nötig
 zu sagen, wie er die Feinde der Wahrheit mit gebührender Widerlegung
 schön und freundlich aufnahm, indem er auch sie zumal heilte und
 <lb n="20"/> durch die Freimut seiner Worte unterwies, und wie er sich jedermann
 demütig darbot als ein hilfreicher, langmütiger und gefühlvoller Arzt aller
 nur der Seelen, sondern auch der Leiber? Deswegen hatte das hebräische
-(Propheten)wort die Bezeichnung mit dem Namen Jesus vorher
-für unsern Erlöser geprägt, indem es (das Wort) Jesus als Arzt aller
-<lb n="25"/> auffaßte. Die Bezeichnung aber mit (dem Begriff) der Heilung für Jesus
+<supplied reason="undefined" resp="#editor">Propheten</supplied>wort die Bezeichnung mit dem Namen Jesus vorher
+für unsern Erlöser geprägt, indem es <supplied reason="undefined" resp="#editor">das Wort</supplied> Jesus als Arzt aller
+<lb n="25"/> auffaßte. Die Bezeichnung aber mit <supplied reason="undefined" resp="#editor">dem Begriff</supplied> der Heilung für Jesus
 bewährte er durch Taten, indem er die Seelen der Menschen in der
 himmlischen Lehre unterwies und alle Leiden, Schmerzen und Krankheiten
 der Leiber mit der Kraft des heilenden Wortes heilte. Bald
@@ -5203,7 +5207,7 @@ reinigte er die, die aussätzig waren, an ihrem Leibe, bald trieb er durch
 er reichliche Heilung denen, die durch Krankheit gequält wurden, bald
 sagte er dem, dessen Leib schlaff und dessen Glieder insgesamt gelähmt
 waren, nur mit einem Worte: „Stehe auf, nimm dein Bett und wandle“,
-der aber tat, was er ihm auftrug. Den Blinden wiederum zu (anderer)
+der aber tat, was er ihm auftrug. Den Blinden wiederum zu <supplied reason="undefined" resp="#editor">anderer</supplied>
 <lb n="35"/> Zeit verschaffte er den Anblick des Lichtes. So entschloß sich ferner
 <note type="footnote">10 vgl. I Kor 29 24 vgl. Dem. IV 10 18. 19 28—S. 147, 25 = Dem. III 421—26
 33 = Matth 96 35 vgl. Matth 9 20 ff.</note>
@@ -5216,35 +5220,35 @@ vom Schmerz gequält war, — als sie sah, daß
 und ihr nicht gestatteten, zu knieen und um Befreiung von ihrem Schmerz zu
 bitten, — wenn auch nur den Zipfel seines Gewandes zu berühren,
 schlich heran, ergriff den Zipfel seines Gewandes und ergriff zugleich auch <lb n="5"/>
-die Heilung von (ihrem) Übel und ward im selben Augenblick gesund, indem
+die Heilung von <supplied reason="undefined" resp="#editor">ihrem</supplied> Übel und ward im selben Augenblick gesund, indem
 sie den größten Beweis der Kraft des Logosgottes davontrug.
 Mann aber, ein Sklave des Königs, fiel, als es seinem
 ging, vor ihm nieder und empfing es sogleich gesund, ein anderer
 wiederum seine Tochter — es war ein Synagogenvorsteher der Juden — <lb n="10"/>
-aber dieser (empfing sie gesund), nachdem sie (bereits) gestorben war.
+aber dieser <supplied reason="undefined" resp="#editor">empfing sie gesund</supplied>, nachdem sie <supplied reason="undefined" resp="#editor">bereits</supplied> gestorben war.
 Was habe ich nötig zu sagen, wie ein anderer Toter nach
 durch die Kraft des Erlösers aller auferstand, als er nur
 <milestone unit="altnumbering" n="105"/> mit dem ihn der alles lebendigmachende Logos rief? Oder wie er auf dem
 Meere gleichwie auf der trockenen Erde seinen Weg nahm und oben <lb n="15"/>
 auf dem Rücken der W asser sein Instrument
 ließ? Oder wie er, als seine Jünger segelten und
-kam, das Meer, das Unwetter und den Wind bedrohte und (nur) mit einem
+kam, das Meer, das Unwetter und den Wind bedrohte und <supplied reason="undefined" resp="#editor">nur</supplied> mit einem
 Worte befahl, die aber sofort schwiegen, erschreckt wie von der Stimme
 ihres Herrn? Daß er aber fünf
 Schar von Myriaden Weibern und Kindern mit ihnen war, von Broten
 an der Zahl fünf vollständig sättigte, daß
 empfingen als ausreichend war, um zwölf Körbe zu füllen,—wer sollte
-(darüber) nicht staunen und (wen sollte das nicht) mit
+<supplied reason="undefined" resp="#editor">darüber</supplied> nicht staunen und <supplied reason="undefined" resp="#editor">wen sollte das nicht</supplied> mit
 zur Erforschung seiner verborgenen Kraft?</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="41">
-<p>Aus (diesen und) vielen <lb n="25"/>
+<p>Aus <supplied reason="undefined" resp="#editor">diesen und</supplied> vielen <lb n="25"/>
 andern gewaltigen Wundern also empfängt, wer will, den
 und offenkundigen Beweis für
 noch mehr aber daraus, wenn er aucb bedenkt, daß
 vorauswußte <add>und</add> vorausverkündigte, daß die
-göttliche Kraft *in gewaltigem Wechsel zur Vorzüglichkeit kommen <lb n="30"/>
+göttliche Kraft <corr resp="#editor">in</corr> gewaltigem Wechsel zur Vorzüglichkeit kommen <lb n="30"/>
 werde, und daß er sich als den Täter dieses
 durch Werke seine Verheißung bewahrheitete.
 Dinge demgemäß wird jemand im Überflusse finden, wenn er
@@ -5257,9 +5261,9 @@ seiner Gottheit prüft, die auch wir zu passender Zeit erwägen werden.</p>
 vorauswußte“ Σ. Aber das <foreign xml:lang="abbr">ABBREV</foreign> steht besser vor <foreign xml:lang="abbr">ABBREV</foreign> als vor <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.148"/>
-<p>Aber für jetzt möge, damit sich *uns nicht
-Ferne über alle seinegroßen Werke erstrecke, *sein Tod vor Augen
-*bleiben, den der Dolmetscher, das Gewand des Logos Gottes und das
+<p>Aber für jetzt möge, damit sich <corr resp="#editor">uns</corr> nicht
+Ferne über alle seinegroßen Werke erstrecke, <corr resp="#editor">sein</corr> Tod vor Augen
+<corr resp="#editor">bleiben</corr>, den der Dolmetscher, das Gewand des Logos Gottes und das
 Bild, das geoffenbart wurde, ertrug, wie jedermann bekennt.</p>
 </div>
 
@@ -5280,7 +5284,7 @@ erhöth.</p>
 <p>Er aber rief laut und sagte, daß er seinem Vater seinen <milestone unit="altnumbering" n="106"/>
 Geist übergebe, wurde frei von sich selbst und vollzog die Auswanderung
 <lb n="15"/> aus dem Leibe. Deswegen überlieferte er seinen Jüngern
-Tode eben dies (Wort), lehrte und sagte: „Niemand nimmt meine Seele
+Tode eben dies <supplied reason="undefined" resp="#editor">Wort</supplied>, lehrte und sagte: „Niemand nimmt meine Seele
 von mir, &lt;aber ich
 ich habe Vollmacht sie zu nehmen“. Und ferner:
 der gute Hirte und kenne die Meinen und die Meinen kennen mich“,
@@ -5297,7 +5301,7 @@ derart bei seinem Tode überlieferte, wurde er von sich selbst frei
 sein Leib von seinen Jüngern herabgenommen
 Grabe übergeben; wiederum aber am dritten Tage nahm er es, er der
 vorher freiwillig aus ihm ausgewandert war, und wiederum zeigte er
-sich im Leibe und im Körper als eben jenen, wie er (auch)
+sich im Leibe und im Körper als eben jenen, wie er <supplied reason="undefined" resp="#editor">auch</supplied>
 <note type="footnote">1—8. 151, 11 = 3. Bruchstück der griech. Theoph. 8. 49—723 1—15—Dem.
 III 426 27 13 vgl. Luk 23 46 16 = Joh 10 18 18 = Job. 10 14 20 = Joh
 1013 21 = Joh 12 24 25—S 149, 5 = Dem. III 428. 29</note>
@@ -5311,38 +5315,38 @@ III 426 27 13 vgl. Luk 23 46 16 = Joh 10 18 18 = Job. 10 14 20 = Joh
 
 <pb n="v.3.pt.2.p.149"/>
 seinen Jüngern, mit denen er etwas redete und kurze
-war. (Dann) stieg er auf dorthin, wo(her) er war, und vollzog vor ihren
-Augen seinen Lauf und seinen Aufstieg zum Himmel , (vor seinen
-Jüngern), denen er auch Lehren für ihr Tun überlieferte
+war. <supplied reason="undefined" resp="#editor">Dann</supplied> stieg er auf dorthin, wo<supplied reason="undefined" resp="#editor">her</supplied> er war, und vollzog vor ihren
+Augen seinen Lauf und seinen Aufstieg zum Himmel , <supplied reason="undefined" resp="#editor">vor seinen
+Jüngern</supplied>, denen er auch Lehren für ihr Tun überlieferte
 Lehrern der Gottesfurcht Gottesfurcht für alle Völker unachte.</p>
 </div>
   
 <div type="textpart" subtype="chapter" n="45">
-<lb n="5"/><p>Was also bleibt nach diesen (Ausführungen) übrig als eben
+<lb n="5"/><p>Was also bleibt nach diesen <supplied reason="undefined" resp="#editor">Ausführungen</supplied> übrig als eben
 die Hauptsache zu sagen, welchen Grund er hatte, ich meine aber das
 von jedermann besprochene Ende seines Lebens und die Art seines
 Leidens und das große Wunder seiner Auferstehung nach
-Nach der Betrachtung dieser (Dinge) werden wir ferner zu den Beweisen <lb n="10"/>
+Nach der Betrachtung dieser <supplied reason="undefined" resp="#editor">Dinge</supplied> werden wir ferner zu den Beweisen <lb n="10"/>
 kommen und eben diese durch offenkundige Zeugnisse bestätigen. Indem
 er also ein sterbliches Instrument wegen der vorher genannten
 Gründe gleichsam als gottgeziemendes Bild gebrauchte und
-seiner (Hilfe) wie ein Großkönig vermittelst des Dolmetschers in
+seiner <supplied reason="undefined" resp="#editor">Hilfe</supplied> wie ein Großkönig vermittelst des Dolmetschers in
 der Menschen einzog, tat er alles würdig der göttlichen Kraft.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="46">
 <lb n="15"/><p>Wenn er also in anderer Weise nach seiner Lebensführung
-<milestone unit="altnumbering" n="107"/> Menschen unsichtbar *geworden worden und plötzlich davongeflogen wäre
+<milestone unit="altnumbering" n="107"/> Menschen unsichtbar <corr resp="#editor">geworden</corr> worden und plötzlich davongeflogen wäre
 heimlich seinen Dolmetscher gestohlen und sich bemüht hätte, sein
-Bild durch die Flucht dem Tode zu entziehen, *und dann von sich aus
+Bild durch die Flucht dem Tode zu entziehen, <corr resp="#editor">und</corr> dann von sich aus
 das Sterbliche Verderben und Untergang hätte berühren lassen, so wäre <lb n="20"/>
 er den meisten einer Halluzination gleich geworden.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="47">
 <p>Weder
-hätte er sich (dann) etwas Würdiges getan, da er
-Gottes und die Kraft Gottes ist, (trotzdem) aber seinen eigenen Dolmetscher
+hätte er sich <supplied reason="undefined" resp="#editor">dann</supplied> etwas Würdiges getan, da er
+Gottes und die Kraft Gottes ist, <supplied reason="undefined" resp="#editor">trotzdem</supplied> aber seinen eigenen Dolmetscher
 dem Untergang und Verderben überlieferte,</p>
 </div>
 
@@ -5365,7 +5369,7 @@ Natur als der Tod,</p>
 
 <div type="textpart" subtype="chapter" n="51">
 <p>noch hätte er das Sterbliche von seiner eigenen
-Natur befreit, <add>noch wäre er in der ganzen Menschenwelt gehört (und <lb n="30"/>
+Natur befreit, <add>noch wäre er in der ganzen Menschenwelt gehört <supplied reason="undefined" resp="#editor">und <lb n="30"/>
 <note type="footnote">6—8. 151, 9 — Laus 24412—2464</note>
 <note type="footnote">2 ἄνεισιν ὅθεν καὶ παρῆν Th. gr. 4 ὑποθήκας] „Pfänder“ Σ 8 „das
 von jedermann besprochene Ende"j τὸ πολυθρύλλητον . . . . τέλος Th. gr. 17 ἀφανὴς
@@ -5375,11 +5379,11 @@ dann" Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 27 „fortgehend“ Σ χ�
 ἠκούσθη Th. gr. &lt; Σ wohl mit unrecht, l. <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.150"/>
-bekannt) geworden</add></p>
+bekannt</supplied> geworden</add></p>
 </div>
   
 <div type="textpart" subtype="chapter" n="52">
-<p>noch hätte er seine *Jünger überredet, den Tod
+<p>noch hätte er seine <corr resp="#editor">Jünger</corr> überredet, den Tod
 zu verachten,</p>
 </div>
 
@@ -5389,7 +5393,7 @@ nach dem Tode für diejenigen hingestellt, die seiner Lehre nachfolgen,</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="54">
-<p>noch hätte er die *Verheißungen seiner Worte erfüllt, noch hätte
+<p>noch hätte er die <corr resp="#editor">Verheißungen</corr> seiner Worte erfüllt, noch hätte
 <lb n="5"/> er den Prophezeiungen, die über ihn vorhergesagt waren, die entsprechende
 Erfüllung geboten,</p>
 </div>
@@ -5399,17 +5403,17 @@ Erfüllung geboten,</p>
 Kampf gesiegt. Dieser war gegen den Tod.</p>
 <p>Wegen aller dieser Dinge, da vor allem dem sterblichen Instrument,
 nachdem es den Dienst vollendet hatte, den es dem Logos Gottes leistete,
-<lb n="10"/> ein gottgeziemendes Ennde zustoßen mußte, wurde es in dieser (Weise)
-dem Tode eingereiht. Denn zwei (Dinge) blieben übrig beim Ende:
+<lb n="10"/> ein gottgeziemendes Ennde zustoßen mußte, wurde es in dieser <supplied reason="undefined" resp="#editor">Weise</supplied>
+dem Tode eingereiht. Denn zwei <supplied reason="undefined" resp="#editor">Dinge</supplied> blieben übrig beim Ende:
 entweder das Ganze dem Verderben und dem Untergange preiszugeben
 und den schimpflichsten <del>Lebens</del>ausgang des ganzen Kampfes zu veranstalten,
 oder sich besser als den Tod zu zeigen und mit göttlicher
 <lb n="15"/> Kraft das Sterbliche unsterblich hinzustellen. Das erste aber war nicht
-der *Verheißung entsprechend. Denn nicht ist es Sache
+der <corr resp="#editor">Verheißung</corr> entsprechend. Denn nicht ist es Sache
 kalt zu machen, noch des Lichtes, finster zu machen. So ist es auch <milestone unit="altnumbering" n="108"/>
 nicht Sache des Lebens zu töten, noch des Logos
 zu handeln. Welchen Grund also hatte der, der anderen das Leben
-<lb n="20"/> verhieß, die Vernichtung seines (eigenen) Instrumentes
+<lb n="20"/> verhieß, die Vernichtung seines <supplied reason="undefined" resp="#editor">eigenen</supplied> Instrumentes
 sein Bild dem Untergange preiszugeben und den Dolmetscher seiner
 Gottheit dem Verderben des Todes darzubieten, er, der denen, die zu
 ihm ihre Zuflucht nahmen, das ewige Leben <del>vorher</del> anriet? Also war
@@ -5431,10 +5435,10 @@ Das Wortspiel mit λόγος gibt Σ nicht wieder 23 προμνώμενον L<
 
 <pb n="v.3.pt.2.p.151"/>
 kündet und von jedermann gehört wurde, bot es allen Menschen die
-Hilfe, die aus dem Wunder (kommt). Mit Recht also floh er, da er
+Hilfe, die aus dem Wunder <supplied reason="undefined" resp="#editor">kommt</supplied>. Mit Recht also floh er, da er
 sein Instrument besser als den Tod zeigen mußte und dies
-Verborgenen, sondern (nur) vor den Augen der Menschen tun (durfte),
-den Tod nicht. Denn er wäre (sonst) für geige und für schlechter als <lb n="5"/>
+Verborgenen, sondern <supplied reason="undefined" resp="#editor">nur</supplied> vor den Augen der Menschen tun <supplied reason="undefined" resp="#editor">durfte</supplied>,
+den Tod nicht. Denn er wäre <supplied reason="undefined" resp="#editor">sonst</supplied> für geige und für schlechter als <lb n="5"/>
 der Tod gehalten. Durch den Kampf mit dem Tode aber wie mit
 einem Ringkämpfer stellte er das Sterbliche als unsterblich
 er den letzten Kampf für die Erlösung
@@ -5444,14 +5448,14 @@ Vernichtung der polytheistischen Verirrung. Als er begann unter den
 Menschen anerkannt zu werden und er bald vorzüglich unter
 der Menschen wandeln sollte, erschien es ihm notwendig, vor allem die
 Feinde und Hasser der Menschen, eben sie, die früher fälschlich für
-Götter gehalten wurden, als die Fürsten des Bösen und (als) wilde Tiere <lb n="15"/>
+Götter gehalten wurden, als die Fürsten des Bösen und <supplied reason="undefined" resp="#editor">als</supplied> wilde Tiere <lb n="15"/>
 zu vertreiben. Auf der Stelle aber führte der göttliche Logos sein
 Instrument in das Land der Feinde und Hasser, das die Schrift
-mystisch „Wüste“ (und frei) von allem Guten nennt. Dort handelte
+mystisch „Wüste“ <supplied reason="undefined" resp="#editor">und frei</supplied> von allem Guten nennt. Dort handelte
 er vierzig Tage und ebensoviele Nächte und tat das, was
 Sterblichen gewußt und kein Auge des Menschen gesehen hat. Die prophetischen <lb n="20"/>
-Zeugnisse aber lehren (es), mit denen die Erfüllung der
-*göttlichen Schriften übereinstimmt, in denen geschrieben
+Zeugnisse aber lehren <supplied reason="undefined" resp="#editor">es</supplied>, mit denen die Erfüllung der
+<corr resp="#editor">göttlichen</corr> Schriften übereinstimmt, in denen geschrieben
 wurde vom heiligen Geist in die Wüste
 zu werden, und er war dort vierzig Tage und vierzig Nächte
 und war mit den Tieren zusammen." Was waren diese Tiere anders) <lb n="25"/>
@@ -5461,7 +5465,7 @@ ihrer Bosheit mit Bezug auf ihn so nannte und sprach: „Auf
 die Schlange und die Natter wirst du treten und den Löwen
 Drachen zermalmen.“ Das andere aber, was in der Wüste geschah, zeigte <lb n="30"/>
 das Wort an, indem es so mit Bezug auf das Instrument, das er trug,
-sagt: „Mit einer Waffe wird dich umgeben seine *Wahrheit. Nicht
+sagt: „Mit einer Waffe wird dich umgeben seine <corr resp="#editor">Wahrheit</corr>. Nicht
 wirst du dich fürchten vor der Furcht der Nacht und vor dem Ge-
 <note type="footnote">18 Matth 4 1 20 vgl. I Kor 2 9 22 = Matth 42 Mark 1 13 28 Psalni
 91 (LXX 90) 13 32 ebd. 4—7</note>
@@ -5488,23 +5492,23 @@ die ganze Schar der Feinde nicht wie Gott mit unkörperlicher,
 <lb n="10"/> nackter Kraft, sondern durch den Leib, den er trug. Deswegen, weil
 früher das ganze Geschlecht der Menschen ihnen
 war, deswegen besonders machte er alle Familien der Dämonen diesem
-(Menschen) Untertan, weil es nämlich notwendig war, eben
+<supplied reason="undefined" resp="#editor">Menschen</supplied> Untertan, weil es nämlich notwendig war, eben
 besiegt and den Feinden nicht mit Recht Untertan war, nicht
 <lb n="15"/> nur zum Befreier, sondern auch zum Sieger über seine Feinde zu
 machen und zu zeigen, daß besser als
 Götter gehalten wurden, wegen der Gemeinschaft mit
 sein Geliebter sei, den er nach seinem Bilde und Gleichnis gemacht
-hatte, wie in den Worten (der Schrift) mystisch geschrieben ist.</p>
+hatte, wie in den Worten <supplied reason="undefined" resp="#editor">der Schrift</supplied> mystisch geschrieben ist.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="57">
 <p><lb n="20"/>Als also der Kampf gegen diese ein Ende fand, da stieg fortan siegbekleidet
-der Erlöser von uns allen (aus der Wüste)
+der Erlöser von uns allen <supplied reason="undefined" resp="#editor">aus der Wüste</supplied>
 Leben unter den Menschen und befreite ihre Seelen, indem er sie aus
 den Fesseln der Dämonen löste und
 Verborgene offenbarte, vor allem das, was er gegen die unsichtbaren
-<lb n="25"/> Feinde tat. Er sagt aber so und stellt (folgende Worte) hin: „Fasset
-Mut! Ich habe die Welt besiegt“, und (auch) die Art seines
+<lb n="25"/> Feinde tat. Er sagt aber so und stellt <supplied reason="undefined" resp="#editor">folgende Worte</supplied> hin: „Fasset
+Mut! Ich habe die Welt besiegt“, und <supplied reason="undefined" resp="#editor">auch</supplied> die Art seines
 lehrte er durch das, was er seinen Jüngern im Gleichnis
 mand kann eintreten in das Haus des Starken und seine Gefäße rauben, <milestone unit="altnumbering" n="110"/>
 wenn er nicht zuvor den Starken fesselt, dann aber wird er auch sein
@@ -5520,8 +5524,8 @@ erste Kampf gegen die Dämonen wurde am Anfang
 und" Σ vermutlich = ἄλλως τε καἰ</note>
 
 <pb n="v.3.pt.2.p.153"/>
-<p>Der zweite Kampf aber fand statt *zur Auflösung der Herrschaft
-des Todes. Denn es war notwendig, daß er (der Leib) besser was als
+<p>Der zweite Kampf aber fand statt <corr resp="#editor">zur</corr> Auflösung der Herrschaft
+des Todes. Denn es war notwendig, daß er <supplied reason="undefined" resp="#editor">der Leib</supplied> besser was als
 der gottlose und dämonische Irrtum und eine dem Logosott entsprechende
 und eine seines Werkes würdige Ehre: den Sieg wider
 empfing. Denn die Dämonen, die wider ihn sich scharten, und ihr Fürst <lb n="5"/>
@@ -5533,7 +5537,7 @@ und hofften, daß der Tod des Sterblichen nach Art aller Menschen sein <lb n="10
 werde. Denn niemals erwarteten sie, daß eine sterbliche
 sei als der Tod, sondern daß der Tod der
 derer sei, die zu Einer Zeit die Geburt der Sterblichen erfahren
-haben. (Während) sie aber glaubten, daß von
+haben. <supplied reason="undefined" resp="#editor">Während</supplied> sie aber glaubten, daß von
 Schlimmste sei, dem niemand entfliehe noch entrinne, rang er nach dem <lb n="15"/>
 ersten Siegeszeichen wider die Dämonen sogleich auch mit
 Wie aber jemand, wenn er ein Gefäß unverbrennbar und
@@ -5543,9 +5547,9 @@ es dann heil und unversehrt aus dem Feuer herausnimmt, demgemäß <lb n="20"/>
 lenkte auch der alles lebendig machende Logos Gottes — da er das
 sterbliche Instrument, dessen er sich zur Erlösung unter
 bediente, besser als den Tod auftveisen und teilhaftig seines Lebens und 
-(seiner) Unsterblichkeit zeigen wollte — mit Recht und vorzüglich, wie
-es nützlich ist, die Sache (so): Er verließ den Leib kurze Zeit und gab <lb n="25"/>
-das Sterbliche dem Tode preis zum Beweise seiner eigenen (sterblichen)
+<supplied reason="undefined" resp="#editor">seiner</supplied> Unsterblichkeit zeigen wollte — mit Recht und vorzüglich, wie
+es nützlich ist, die Sache <supplied reason="undefined" resp="#editor">so</supplied>: Er verließ den Leib kurze Zeit und gab <lb n="25"/>
+das Sterbliche dem Tode preis zum Beweise seiner eigenen <supplied reason="undefined" resp="#editor">sterblichen</supplied>
 Natur, dann aber kurz darauf erhöhte er das Sterbliche aus dem Tode
 <note type="footnote">1—8. 160, 2 = 3. Bruchstück der griech.
 = Laus 246 4 16</note>
@@ -5570,28 +5574,28 @@ Beweis der im Leibe wohnenden göttlichen Kraft. Denn weil die
 <lb n="5"/> Menschen früher diejenigen, die vom Tode besiegt waren — sterbliche
 Männer in Wahrheit, die das gemeinsame Ende empfangen hatten — zu
 Göttern machten und Heroen und Götter diejenigen nannten, die vom
-Tode beherrscht waren, so zeigte sich auch in diesem (Punkte) mit
-Recht *wegen dieser Ursache der freundliche Logos Gottes (und) zeigte
-<lb n="10"/> den Menschen eine Natur, die besser (ist) als der Tod, und führte das
+Tode beherrscht waren, so zeigte sich auch in diesem <supplied reason="undefined" resp="#editor">Punkte</supplied> mit
+Recht <corr resp="#editor">wegen</corr> dieser Ursache der freundliche Logos Gottes <supplied reason="undefined" resp="#editor">und</supplied> zeigte
+<lb n="10"/> den Menschen eine Natur, die besser <supplied reason="undefined" resp="#editor">ist</supplied> als der Tod, und führte das
 Sterbliche nach seiner Auflösung zu einem zweiten Leben und ließ
 jedermann das Siegeszeichen der Unsterblichkeit wider den Tod sehen
 und lehrte allein den bekennen, der im Tode wahrhaftiger Gott ist, der
 den Siegeskranz wider den Tod auf sein Haupt gebunden hat.</p>
 </div>
 <lb n="15"/> <div type="textpart" subtype="chapter" n="59">
-<p>Eine dritte Ursache des *erlösenden Todes ist diejenige, welche
-die geheimen Worte (der Schrift) enthalten. Welche sind das? Er war
-ein Opfer, das (als Ersatz) für die Seelen des ganzen Geschlechts dargebracht
-wurde, ein Opfer, das für die *Herde aller Menschen getötet
+<p>Eine dritte Ursache des <corr resp="#editor">erlösenden</corr> Todes ist diejenige, welche
+die geheimen Worte <supplied reason="undefined" resp="#editor">der Schrift</supplied> enthalten. Welche sind das? Er war
+ein Opfer, das <supplied reason="undefined" resp="#editor">als Ersatz</supplied> für die Seelen des ganzen Geschlechts dargebracht
+wurde, ein Opfer, das für die <corr resp="#editor">Herde</corr> aller Menschen getötet
 wTurde, ein Abwehropfer der dämonischen Verirrung. Ein Opfer also
 <lb n="20"/> und eine große Opfergabe, der hochheilige Leih unsers Erlösers, wurde
 ähnlich einem Schafe für das ganze Geschlecht der Menschen geschlachtet
-und (als Ersatz) für die Seelen aller Völker, die im Frevel dämonischer
-Verirrung ihrer *Väter befangen waren, geweiht. (Daher) war fortan die
+und <supplied reason="undefined" resp="#editor">als Ersatz</supplied> für die Seelen aller Völker, die im Frevel dämonischer
+Verirrung ihrer <corr resp="#editor">Väter</corr> befangen waren, geweiht. <supplied reason="undefined" resp="#editor">Daher</supplied> war fortan die
 ganze unreine und unheilige Kraft der Dämonen vernichtet, und aufgelöst
 <lb n="25"/> und zerstört war auf der Stelle mit besserer Kraft der ganze eitle
 und irdische Irrtum. Das erlösende Opfer also aus den Menschen, das
-leibliche Instrument des göttlichen Logos, wurde für die *Herde aller
+leibliche Instrument des göttlichen Logos, wurde für die <corr resp="#editor">Herde</corr> aller
 Menschen geschlachtet. Dies aber war das Opfer, das durch die Verleumdung
 <note type="footnote">3—S. 155, 22 = Laus 247 15—248 23 15 ff. vgl. Dem. IV 12 7 21 vgl.
 Jes 53 7</note>
@@ -5615,14 +5619,14 @@ Ursache lehrt sie, indem sie sagt: „Wahrhaftig, unsere Sünden
 ertragen und unsere Schmerzen hat er erduldet. Wir aber achteten ihn
 für zerzaust, geschlagen von Gott und gedemütigt.
 um unserer Sünde willen
-willen. Die Zucht unseres Friedens (ist) auf ihm und durch seine <lb n="10"/>
+willen. Die Zucht unseres Friedens <supplied reason="undefined" resp="#editor">ist</supplied> auf ihm und durch seine <lb n="10"/>
 Wunden werden wir geheilt. Wir alle irrten wie die Schafe und. wandten
 uns ein jeder seines Weges, und der Herr hat ihn treffen lassen die
 Sünden unser aller." Das leibliche Instrument
 also wurde wegen dieser Ursachen geopfert, der Hohepriester aber, der
 von Gott, dem König des Alls und dem Herrn des Alls, zum Priester <lb n="15"/>
 geweiht ist. der ein anderer ist neben dem Opfer, der Logos Gottes,
-die Kraft Gottes und die Weisheit Gottes, * führte kurz
+die Kraft Gottes und die Weisheit Gottes, <corr resp="#editor">führte</corr> kurz
 Sterbliche herauf aus dem Tode und stellte es als den Erstling der Erlösung
 von uns allen und als teilhaftig des unsterblichen Lebens bei
 Gott hin, und richtete es als ein siegbekleidetes Zeichen wider den Tod <lb n="20"/>
@@ -5636,9 +5640,9 @@ Hebräer betreffs des kund.</p>
 </div>
 <div type="textpart" subtype="chapter" n="60">
 <p>Außer dem, was gesagt ist, gibt es noch
-Grund für den *erlösenden Tod, der (im
+Grund für den <corr resp="#editor">erlösenden</corr> Tod, der <supplied reason="undefined" resp="#editor">im folgenden</supplied> genannt wird.
 Denn da es für seine Jünger notwendig war, mit
-Wiedergeburt *des Lebens nach dem Tode offenkundig zu sehen, auf
+Wiedergeburt <corr resp="#editor">des</corr> Lebens nach dem Tode offenkundig zu sehen, auf
 die ihre Hoffnung richten er sie lehrte und um derentwillen er sie auch
 <note type="footnote">2 = Joh 1 29 4 = Jes 53 7 6 = Jes 53 4–6 17 vgl. I Kor 1
 13 ff. vgl. Dem. IV 10 16 ff. 15 6ff. 30—S. 156, 17 = Laus 246 17—247 8</note>
@@ -5653,18 +5657,18 @@ Leben nach dem Tode, die Wiedergeburt“ Σ l.<foreign xml:lang="abbr">ABBREV</f
 antrieb, sich an das Joch der Frömmigkeit zu halten,
 mit Recht mit eigenen Augen sehen. Denn diejenigen, die einem
 frommen Leben nachgehen sollten, mußten vor
-Lehre durch deutliches Schauen (in sich) aufnehmen, und noch viel mehr
+Lehre durch deutliches Schauen <supplied reason="undefined" resp="#editor">in sich</supplied> aufnehmen, und noch viel mehr
 <lb n="5"/> jene, die ihn bald in der ganzen Welt verkündigen und
 allen Völkern dargebotene Gotteserkenntnis
 lassen sollten. Es war notwendig, daß gerade sie eine gewaltige Überzeugung <milestone unit="altnumbering" n="113"/>
 des Lebens nach dem Tode empfingen, damit sie ohne Furcht
 und Zagen vor dem Tode den ἀγών wider die polytheistische Verirrung
-<lb n="10"/> *willig unternähmen. Denn wenn
+<lb n="10"/> <corr resp="#editor">willig</corr> unternähmen. Denn wenn
 Tod zu verachten, wären sie auch niemals bereit
 entgegenzugehen. Deswegen bewaffnete er sie notwendig gegen die
 Herrschaft des Todes, indem er nicht mit Reden und Worten ihnen die
 Lehre übergab, noch überzeugend und aus Wahrscheinlichkeitsgründen
-<lb n="15"/> mit Worten, den Menschen gleich, (einen Befehl) über die Unsterblichkeit
+<lb n="15"/> mit Worten, den Menschen gleich, <supplied reason="undefined" resp="#editor">einen Befehl</supplied> über die Unsterblichkeit
 der Seele anordnete, sondern indem er ihnen eben durch die Tat
 die Siegeszeichen wider den Tod zeigte.</p>
 </div>
@@ -5674,16 +5678,16 @@ die Siegeszeichen wider den Tod zeigte.</p>
 ganzes sterbliches Geschlecht verderbte, und seine Herrschaft wurde für
 <lb n="20"/> eine Auflösung der ganzen menschlichen Natur, der
 des Leibes, gehalten und niemand hat jemals vermocht, dies Furchtbare
-von den Menschen (zu entfernen und) zu vertilgen. Alle vielmehr waren
+von den Menschen <supplied reason="undefined" resp="#editor">zu entfernen und</supplied> zu vertilgen. Alle vielmehr waren
 sie Wehklager, Kleine und Große,
-zumal und Massen und Scharen und *aller Völker, aus Furcht
+zumal und Massen und Scharen und <corr resp="#editor">aller</corr> Völker, aus Furcht
 <lb n="25"/> vor dem Tode, und es gab keinen Trost für die Menschen gegenüber
 diesem Übel, kein Wort, keine Sitte, kein Leben, keinen Gedanken der
 Weisen, keine Schriften der Vorfahren, keine Weissagungen der Propheten
-und keine Offenbarungen der Engel. Besser als alle und höher als alle war (der Tod), und es hatte den Sieg inne gegen alle der *hohe,
+und keine Offenbarungen der Engel. Besser als alle und höher als alle war <supplied reason="undefined" resp="#editor">der Tod</supplied>, und es hatte den Sieg inne gegen alle der <corr resp="#editor">hohe</corr>,
 <lb n="30"/> ruhmredige, übermütige Tod, durch den das ganze sterbliche Geschlect
 geknechtet war und in allerlei Freveln sich wälzte, in Besudelungen
-mit Blut, in unrechten *Taten und im Irrtum jeder Art der bösen, gott-
+mit Blut, in unrechten <corr resp="#editor">Taten</corr> und im Irrtum jeder Art der bösen, gott-
 <note type="footnote">6 „leuchten lassen“ Σ καταγγέλλειν Th. gr. 10 προθύμως] „in ihrem lrrtum“Σ (Schreibfehler) l. <foreign xml:lang="abbr">ABBREV</foreign> 12 „notwedig“] genauer „besonders“
 Σ ἀναγκαίως Th. gr. 15 οὐδὲ λόγοις. . . . τὸν περὶ ψυχῆς ἀθανασίας . . .
 συντάττων Th. gr. 24 „alle Scharen der Völker, und Familien“ Σ l. <foreign xml:lang="abbr">ABBREV</foreign>
@@ -5692,7 +5696,7 @@ oberhalb von allen“) Σ (=τὴν πάντων ν. ἐπ-εῖχεν?) | ὑ�
 321. <foreign xml:lang="abbr">ABBREV</foreign> mit HS</note>
 
 <pb n="v.3.pt.2.p.157"/>
-losen Bosheit; denn aller dieser (Dinge) Ursache war der Tod. Denn
+losen Bosheit; denn aller dieser <supplied reason="undefined" resp="#editor">Dinge</supplied> Ursache war der Tod. Denn
 da sie nach dem Tode nicht mehr existierten, so taten sie in ihren
 Lebensführungen das, was vieler Tode würdig war, und
 einer Rechenschaft nicht unterwarfen, so lebten sie wegen der Auflösung
@@ -5700,13 +5704,13 @@ infolge des Todes ein Leben, das kein Leben war, nahmen weder Gott <lb n="5"/>
 in ihr Denken auf, das gerechte Gericht Gottes,
 noch belebten sie die Erinnerung an die ändige οὐσία ihrer
 sondern hatten den Tod als den Einen harten Herrscher <del>im Gebrauch</del>
-und redeten sich selbst ein, ß das aus ihm (stammende)
-<milestone unit="altnumbering" n="114"/> <add>der Leiber</add> eine ösung des ganzen (Menschen) sei, und nannten <lb n="10"/>
-den Tod den reichen Gott, daher (der Name) Pluton. Und nicht nur
-der Tod war ihnen ein Gott, sondern auch die kostbaren (Dinge) vor
+und redeten sich selbst ein, ß das aus ihm <supplied reason="undefined" resp="#editor">stammende</supplied>
+<milestone unit="altnumbering" n="114"/> <add>der Leiber</add> eine ösung des ganzen <supplied reason="undefined" resp="#editor">Menschen</supplied> sei, und nannten <lb n="10"/>
+den Tod den reichen Gott, daher <supplied reason="undefined" resp="#editor">der Name</supplied> Pluton. Und nicht nur
+der Tod war ihnen ein Gott, sondern auch die kostbaren <supplied reason="undefined" resp="#editor">Dinge</supplied> vor
 ihm, die ihnen passen zu einem Leben der Lust. Ein Gott also war
 ihnen die Lust der Leiber, ein Gott die Nahrung, ein Gott der Same,
-der in die Erde fällt, ein Gott der Trieb dieses (Samens), ein Gott die <lb n="15"/>
+der in die Erde fällt, ein Gott der Trieb dieses <supplied reason="undefined" resp="#editor">Samens</supplied>, ein Gott die <lb n="15"/>
 Blüte der Fruchtbäume, ein
 ein Gott die Liebe der Leiber, ein Gott ihre Lust. Daher die Mysterien
 der Demeter und der Persephone und der Raub der Kore zur Unterwelt
@@ -5715,11 +5719,11 @@ Herakles, vom Rausch wie von einem stärkeren Gott besiegt, daher die <lb n="20"
 ehebrecherischen Mysterien des Eros und der Aphrodite! Daher Zeus,
 der hinter den Weibern herrast und den Ganymedes liebt, <add>und</add> das
 Mythengefasel von den Göttern, die die Lust lieben
-Leidenschaften! Aller dieser (Dinge) Ursache aber war der Tod. Denn
+Leidenschaften! Aller dieser <supplied reason="undefined" resp="#editor">Dinge</supplied> Ursache aber war der Tod. Denn
 sie glaubten, daß der Tod das Ende und die Vollendung des Alls, die Auflösung <lb n="25"/>
 und die Vernichtung der Seelen zumal und der Leiber sei, und
 daß es kein anderes Leben gebe als das des Leibes
-<add>und</add> führten (daher) ein Leben schlechter als
+<add>und</add> führten <supplied reason="undefined" resp="#editor">daher</supplied> ein Leben schlechter als
 Tiere.</p>
 <p>Mit ihnen hatte Mitleid der König des Alls, der Logos Gottes, <lb n="30"/>
 <note type="footnote">1—5 vgl. Laus 212 32—213 2 5—24 = Laus 213 2—18</note>
@@ -5731,11 +5735,11 @@ nach <foreign xml:lang="abbr">ABBREV</foreign> 22 „und" &lt; Σ 1. <foreign xm
 ἀσελγῆ μύθων ἀναπλάσματα L 28 „und" &lt; Σ l. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.158"/>
-<add>und</add> auf den freundlichen Wink seines Vaters eilte er, *um ihnen zu
-helfen, <add>und</add> ersann wie ein sehr freundlicher König *die
+<add>und</add> auf den freundlichen Wink seines Vaters eilte er, <corr resp="#editor">um</corr> ihnen zu
+helfen, <add>und</add> ersann wie ein sehr freundlicher König <corr resp="#editor">die</corr>
 des Todes durch eine menschliche Natur. Obwohl er selbst das Leben
 und der Logos Gottes und die Kraft Gottes war, so beschloß er dennoch,
-<lb n="5"/> nicht ohne den (Menschen), dem geholfen wurde, das zu widerlegen, was
+<lb n="5"/> nicht ohne den <supplied reason="undefined" resp="#editor">Menschen</supplied>, dem geholfen wurde, das zu widerlegen, was
 den Menschen furchtbar war. Deshalb benutzte er eine menschliche
 Waffe und einen sterblichen Leib, er der unkörperlich war, und besiegte
 den Tod durch das Sterbliche. Daher wurde eben sein erstes Mysterium
@@ -5750,18 +5754,18 @@ weder von den Menschen noch von den Dämonen noch von <milestone unit="altnumber
 den besseren Kräften verborgen sei, was geschah.
 genau das Sterbliche sehen, wie es gleichsam in einem großen Theater
 die eigene Natur bekannte, damit hinterher der Tod komme wie ein
-<lb n="20"/> wildes Tier und sich als das erweise, was er war, (damit) dann aber
+<lb n="20"/> wildes Tier und sich als das erweise, was er war, <supplied reason="undefined" resp="#editor">damit</supplied> dann aber
 nach dem Tode die Kraft des Lebens komme und wiederum jedermann
 den Sieg wider den Tod hinstelle, indem sie das Sterbliche unsterblich
 zeigt. Es verließ also auf kurze Zeit den Leib die Kraft
-Gottes, die ihn beherrschte. Der (Leib) aber wurde ans Holz gehängt
+Gottes, die ihn beherrschte. Der <supplied reason="undefined" resp="#editor">Leib</supplied> aber wurde ans Holz gehängt
 <lb n="25"/> und war <add>nach</add> kurzer Zeit tot. Aber keineswegs war der Logos, der
 Lebendigmacher aller, das Tote, sondern das Sterbliche bekannte seine
 eigene Natur. Und darauf wurde das Tote, das jetzt vom Tode beherrscht
 ward, von den Menschen herahgenommen und der gebräuchlichen
 Fürsorge gewürdigt. Einem Grabe aber
 <lb n="30"/> den Gesetzen der Menschen. Das Grab aber war eine Höhle, die jüngst
-(erst) ausgehauen war, eine Höhle, die kürzlich
+<supplied reason="undefined" resp="#editor">erst</supplied> ausgehauen war, eine Höhle, die kürzlich
 <note type="footnote">10 vgl. Luk 22 19 I Kor 1124 30 vgl. Matth 27 60</note>
 <note type="footnote">1 „hatte Mitleid . . . . auf den Wink seines Vaters und eilte wie ein König
 und ersann7 Σ ὡς δὴ κατελεήσας ὁ . . . . λόγος, τῴ . . . νεύματι ἔσπευσεν, ἴ’
@@ -5772,27 +5776,27 @@ und ersann7 Σ ὡς δὴ κατελεήσας ὁ . . . . λόγος, τῴ 
 l. + <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.159"/>
-war und noch keinen andern Leib erfahren (d h. aufgenommen) hatte.
+war und noch keinen andern Leib erfahren <supplied reason="undefined" resp="#editor">d h. aufgenommen</supplied> hatte.
 Denn sie mußte für ihn allein Sorge den allein wunderbaren
 Toten. Staunenswert zu sehen war aber auch, wie der Fels auf ebenem
 Lande allein aufrecht stand und nur Eine Höhle in
-er nicht, wenn viele (Höhlen) in ihm wáren, das Wunder dessen verberge, <lb n="5"/>
+er nicht, wenn viele <supplied reason="undefined" resp="#editor">Höhlen</supplied> in ihm wáren, das Wunder dessen verberge, <lb n="5"/>
 der den Tod besiegt hatte. Es lag also tot da, das Instrument
 des lebendigen Gottes, und ein gewaltiger Stein verschloß die Höhle
 und der Tod prahlte sehr darüber, als hätte er auch
 von Ewigkeit her unter seine Hand getan, aber noch war keine dreitägige
-Zeit vorüber, als (auch schon) das Leben sich wieder zeigte nach <lb n="10"/>
+Zeit vorüber, als <supplied reason="undefined" resp="#editor">auch schon</supplied> das Leben sich wieder zeigte nach <lb n="10"/>
 genügender Widerlegung des Todes. Denn wenn er vorher, schneller
 auferstanden wäre, so wäre er
-nachdem er wahrhaftig (ans Kreuz) erhöht und
-war Τι· in (kurzer) Zeit den Tod wahrhaftig erduldet hatte, dann erst
+nachdem er wahrhaftig <supplied reason="undefined" resp="#editor">ans Kreuz</supplied> erhöht und
+war Τι· in <supplied reason="undefined" resp="#editor">kurzer</supplied> Zeit den Tod wahrhaftig erduldet hatte, dann erst
 zeigte der Logos Gottes, der Lebendigmacher aller, die allen Menschen <lb n="15"/>
 aufbewahrte Hoffnung durch die Wiedergeburt des Sterblichen.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="62">
 <p>Was also geschah nachdem? Ich möchte dir
-mehr sein für das, was geschah. *Diejenigen aber, die
+mehr sein für das, was geschah. <corr resp="#editor">Diejenigen</corr> aber, die
 <milestone unit="altnumbering" n="116"/> sahen, sie möchten bessere, glaubwürdigere Zeugen sein,
 ihr Blut und durch ihr Leben, durch den Anblick der Taten die Wahrheit <lb n="20"/>
 bestätigten und die ganze Welt durch die Kraft
@@ -5819,13 +5823,13 @@ durch ihre “ Σ 28 τὸ ἐναργὲς Th. gr.] ἐναργῶς Σ l. viel
 sie die Bestätigung des unsterblichen Lebens von
 hatten. So atmete aber auch das ganze sterbliche Geschlecht späterhin
 auf von dem Zittern vor dem Tode, deswegen weil er, der früher gefürchtet
-war, vor jedermann widerlegt war und (weil) das Leben nach
+war, vor jedermann widerlegt war und <supplied reason="undefined" resp="#editor">weil</supplied> das Leben nach
 <lb n="5"/> dem Tode wahrhaftige Bestätigung empfangen hatte nicht
-nach der Kunst der Sophisten (d. b. Schönredner) und auch nicht
+nach der Kunst der Sophisten <supplied reason="undefined" resp="#editor">d. b. Schönredner</supplied> und auch nicht
 Auffinden überzeugender Worte, sondern durch Taten, die es ans Licht
 brachten.</p>
 <p>Fernerhin fürchteten sie sich nicht mehr wie früher
-<lb n="10"/> sondern lachten viel und kräftig im Spiel mit dem Schreckmittel (des
+<lb n="10"/> sondern lachten viel und kräftig im Spiel mit dem Schreckmittel <supplied reason="undefined" resp="#editor">des Todes</supplied>,
 sodaß sie sogar dem Tode nachjagten aus der Liebe
 Leben.</p>
 </div>
@@ -5848,10 +5852,10 @@ den Vätern Vátern her überlieferte Verirrung.</p>
 <p>Daben wurden die <milestone unit="altnumbering" n="117"/>
 Menschen fortan in der himmlischen Lehre und in den Worten der
 Gotteserkenntnis unterrichtet, sodaß sie die mit den leiblichen
-<lb n="25"/> sichtbare Welt nicht mehr anstaunten (und verehrten), noch, indem sie
+<lb n="25"/> sichtbare Welt nicht mehr anstaunten <supplied reason="undefined" resp="#editor">und verehrten</supplied>, noch, indem sie
 nach oben blickten und Sonne, Mond und Sterne sahen, bis zu ihnen
-ihre Bewunderung erhoben (und sie darauf beschräkten),
-wurden belehrt, den jenseits von diesen (Waltenden), den Verborgenen
+ihre Bewunderung erhoben <supplied reason="undefined" resp="#editor">und sie darauf beschräkten</supplied>,
+wurden belehrt, den jenseits von diesen <supplied reason="undefined" resp="#editor">Waltenden</supplied>, den Verborgenen
 und Unsichtbaren, den Schöpfer alles dessen, was existiert,
 <lb n="30"/> des Alls, zu bekennen und ihn allein zu fürchten.</p>
 </div>
@@ -5876,7 +5880,7 @@ ihm gelehrt war, daß die Vörzüglichkeit seiner
 <pb n="v.3.pt.2.p.161"/>
 seiner eigenen Leidenschaften, noch ward er von lüsternen Leidenschaften
 besiegt — damals aber war er besiegt worden, ohne zu siegen
-— noch machte er (sie) sich ferner zu Göttern, da ihm
+— noch machte er <supplied reason="undefined" resp="#editor">sie</supplied> sich ferner zu Göttern, da ihm
 das Böse und alle böse Lust und Torheit mit
 Denken und aus seiner Seele auszurotten, sodaß er nicht einmal wagte, <note type="marginal">5</note>
 ein Weib in schändlicher Lust anzublicken.</p>
@@ -5884,10 +5888,10 @@ ein Weib in schändlicher Lust anzublicken.</p>
 
 <div type="textpart" subtype="chapter" n="67">
 <p>Fenerhin staunte
-er nicht mehr wie früher über den Dolmetscher seiner Seele (d. h. den
-Körper), noch wagte er ihn Gott zu nennen, noch nannte er jetzt seinen
-Geist Athene, noch andere (Dinge) dem entsprechend, sondern er erkannte
-an und segnete (pries) allein den, der jenseits von allem ist, den <lb n="10"/>
+er nicht mehr wie früher über den Dolmetscher seiner Seele <supplied reason="undefined" resp="#editor">d. h. den
+Körper</supplied>, noch wagte er ihn Gott zu nennen, noch nannte er jetzt seinen
+Geist Athene, noch andere <supplied reason="undefined" resp="#editor">Dinge</supplied> dem entsprechend, sondern er erkannte
+an und segnete <supplied reason="undefined" resp="#editor">pries</supplied> allein den, der jenseits von allem ist, den <lb n="10"/>
 göttlichen Logos, den Künstler des Alls, die Weisheit des Allgottes als
 seinen Erlöser.</p>
 </div>
@@ -5897,25 +5901,25 @@ seinen Erlöser.</p>
 an wie früher als Heroen und Götter sterbliche Menschen, die in
 schimpflichem Ausgang aus dem Leben schieden und dem Tode Macht
 über ihr Leben gewährten, sondern er bekannte ihn allein, der besser ist <note type="marginal">15</note>
-als der Tod, *den Sieger, der das Siegeszeichen wider die Macht des
-Todes (in den Händen) hält, aks seinen Erlöser.</p>
+als der Tod, <corr resp="#editor">den</corr> Sieger, der das Siegeszeichen wider die Macht des
+Todes <supplied reason="undefined" resp="#editor">in den Händen</supplied> hält, aks seinen Erlöser.</p>
 </div>
   
 <div type="textpart" subtype="chapter" n="69">
 <p>Fernerhin staunte
 er nicht mehr wie früher die seelenlosen Götzen an, noch verehrte er
-die unvernünftige Natur *der Tiere in widernatürlicher Dämonenfurcht,
+die unvernünftige Natur <corr resp="#editor">der</corr> Tiere in widernatürlicher Dämonenfurcht,
 <milestone unit="altnumbering" n="118"/>sondern er lachte über den Irrtum seiner Vorfahren und wandte sein <lb n="20"/>
-Angesicht ab von ihrer Art (der Verehrung), die ohne Gotteserkenntnis
-und ohne (Gottes)lehre (war).</p>
+Angesicht ab von ihrer Art <supplied reason="undefined" resp="#editor">der Verehrung</supplied>, die ohne Gotteserkenntnis
+und ohne <supplied reason="undefined" resp="#editor">Gottes</supplied>lehre <supplied reason="undefined" resp="#editor">war</supplied>.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="70">
 <p>Fernerhin staunte er nicht mehr
 wie früher das Bild böser Dämonen an, noch die irrige Halluzination
-irdischer Geister, (den Satan), der durch die mächtige Macht des Einen
-Logos, des önigs, gebunden ist, *da ihm gelehrt ist, durch sie das <note type="marginal">25</note>
-ganze Geschlecht der den Menschen nachstellenden (Dämonen) aufzulösen
+irdischer Geister, <supplied reason="undefined" resp="#editor">den Satan</supplied>, der durch die mächtige Macht des Einen
+Logos, des önigs, gebunden ist, <corr resp="#editor">da</corr> ihm gelehrt ist, durch sie das <note type="marginal">25</note>
+ganze Geschlecht der den Menschen nachstellenden <supplied reason="undefined" resp="#editor">Dämonen</supplied> aufzulösen
 und zu vernichten und aus den Leibern und Seelen eben jene
 Schäden zu vertreiben.</p>
 </div>
@@ -5936,7 +5940,7 @@ Eusebius III*.</note>
 
 <pb n="v.3.pt.2.p.162"/>
 Verstande, an Reinheit der Seele und Heiligkeit des Lebenswandels,
-*an rauchlosen, unblutigen Opfern, deren Darbringung der Erlöser
+<corr resp="#editor">an</corr> rauchlosen, unblutigen Opfern, deren Darbringung der Erlöser
 in der ganzen Menschenwelt zu seinem Gedächtnis durch
 Worte angeordnet hat.</p>
 </div>
@@ -5952,7 +5956,7 @@ seines Erlösers gelehrt ist, seine Glieder auf Erden zu töten.</p>
 <p>Fernerhin wurde er nicht mehr erregt, wenn er vom Tode hörte, noch
 fürchtete er die Auflösung seiner Seele mitsamt dem Leibe, noch
 <lb n="10"/> nannte er den Tod Gott, sondern er bekannte nur den Einen, der oberhalb
-von allem (ist), den lebendig machenden Logos Gottes als seinen
+von allem <supplied reason="undefined" resp="#editor">ist</supplied>, den lebendig machenden Logos Gottes als seinen
 öser und als den Besieger des Todes.</p>
 </div>
 
@@ -5963,8 +5967,8 @@ der neuen Lehre erzogen ist, die er nicht einmal denen preisgibt, die
 im Geist gegen Feuer und Eisen, ist standhaft gegen wilde Tiere, gegen
 die Tiefen des Meeres und gegen die übrigen Schrecken des Todes. Es
 spielen mit dem Tode, der früher furchtbar war und von dem zu hören
-man sich scheute, (solche, die) Kinder und Weiber ihrer Natur nach <milestone unit="altnumbering" n="119"/>
-<lb n="20"/> (sind). Barbaren aber und Griechen zumal, die inbetreff des unsterblichen
+man sich scheute, <supplied reason="undefined" resp="#editor">solche, die</supplied> Kinder und Weiber ihrer Natur nach <milestone unit="altnumbering" n="119"/>
+<lb n="20"/> <supplied reason="undefined" resp="#editor">sind</supplied>. Barbaren aber und Griechen zumal, die inbetreff des unsterblichen
 Lebens volle Überzeugung durch die Auferstehung unsers Erlösers
 gewonnen haben, jagen einem Leben vorzüglicher Weisheit und
 Gottesfurcht nach, indem sie das Siegeszeichen wider den Tod und das
@@ -5975,9 +5979,9 @@ ewige, künftige Leben ihrem Erlöser zuschreiben.</p>
 <p>Deswegen
 <lb n="25"/> handelt fortan eben dasselbe Geschlecht der vernünftigen Menschen
 — dem ja deswegen zu teil geworden ist, auf Erden zu wohnen —
-(handelt) eben dasselbe seiner Natur gemäß, *da es gelehrt ist,
+<supplied reason="undefined" resp="#editor">handelt</supplied> eben dasselbe seiner Natur gemäß, <corr resp="#editor">da</corr> es gelehrt ist,
 Erinnerung an den allguten Gott zu leben und den Prophetieen der Pro-
-pheten *zu entsprechen, die früher vor Myriaden Jahren
+pheten <corr resp="#editor">zu</corr> entsprechen, die früher vor Myriaden Jahren
 <lb n="30"/> „Es sollen sich erinnern und umkehren zum Herrn, ihrem
 Gott, alle Enden der Erde und vor ihm niederfallen alle Familien der
 Völker; denn dem Herrn gehört das Reich und
@@ -5986,7 +5990,7 @@ der Völker.“</p>
 
 <div type="textpart" subtype="chapter" n="76">
 <p>Daher bestehen in der
-(Lehr)orte und Schulen und (daher) werden die Worte Gottes und die
+<supplied reason="undefined" resp="#editor">Lehr</supplied>orte und Schulen und <supplied reason="undefined" resp="#editor">daher</supplied> werden die Worte Gottes und die
 <note type="footnote">3 vgl. Luk 22 19 I Kor 11 25 7 vgl. Kol 35 30 = Ps 22 (LXX 21)28 f.
 33 ᾖ. vgl. Laus 22428 222 22</note>
 <note type="footnote">2 „und an" Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 10 „schrieb" Σ = ἐπιγράφομαι 27 1. <foreign xml:lang="abbr">ABBREV</foreign>
@@ -6001,7 +6005,7 @@ aller Völker verkündigt.</p>
 
 <div type="textpart" subtype="chapter" n="77">
 <p>Daher ehren in jeder stadt und an
-jedem Orte Scharen von (über)all (her) den Logos Gottes, den lebendigmacher
+jedem Orte Scharen von <supplied reason="undefined" resp="#editor">über</supplied>all <supplied reason="undefined" resp="#editor">her</supplied> den Logos Gottes, den lebendigmacher
 aller, mit Siegeshymnen.</p>
 </div>
 
@@ -6011,21 +6015,21 @@ Menschengeschlecht dem Allkönig Gott Gesänge dar, die mit denen der <lb n="5"/
 Engelscharen im Himmel übereinstimmen. Fortan senden zumal mit
 denen, die um den allerhöchsten Gott kreisen: den Geistern verständigen,
 unköperlichen kräften, auch sie, denen zu teil geworden ist,
-unten auf dem στοιχεῖον der Erde zu wohnen, *die vernünftigen
+unten auf dem στοιχεῖον der Erde zu wohnen, <corr resp="#editor">die</corr> vernünftigen
 Seelen der Gerechten, durch den Leib, mit dem sie bekleidet sind, wie <lb n="10"/>
 durch ein musikalisches Instrument die gebührenden Gesänge und
 schuldigen Segenslieder dem Einen Erlöser und der Ursache alles
-Guten. Was (früher) niemals stattfand — jetzt läßt das ganze Geschlecht
+Guten. Was <supplied reason="undefined" resp="#editor">früher</supplied> niemals stattfand — jetzt läßt das ganze Geschlecht
 der Menschen in der ganzen Menschenwelt die Gott, dem König es
 Alls, schuldige Frucht an jedem Tage zu denselben Stunden und in den <lb n="15"/>
-gleichen Zeiten wie auf Eine Verabredung *sprießen.</p>
+gleichen Zeiten wie auf Eine Verabredung <corr resp="#editor">sprießen</corr>.</p>
 </div>
 <milestone unit="altnumbering" n="120"/> <div type="textpart" subtype="chapter" n="79">
 <p>Jetzt sind die Familien der Dämonen und die Mythen der
 Götter, die längst vernichtet sind, bald vergessen, erneut aber ist bei
 jedermann und verjüngt das Wort Christi. Jetzt werden die göttlichen
 Gesetze und Lektionen auf der ganzen Erde verkündigt und machen alle <lb n="20"/>
-Menschen keusch, und von gottesfürchtiger Zucht *sind erfüllt in Wahrheit
+Menschen keusch, und von gottesfürchtiger Zucht <corr resp="#editor">sind</corr> erfüllt in Wahrheit
 alle Plätze der Barbaren und Griechen. Jetzt senden fremdsprachige und
 vielsprachige Zungen in Einer Lebensart und nach Einer Verabredung
 übereinstimmende Segenssprüche an den Schöpfer des Alls und hängen
@@ -6034,7 +6038,7 @@ und derselben Lebensführung an. Jetzt ist Eine Harmonie der Seelen
 und Übereinstimmung der Lehre in der ganzen Welt geschaffen, und
 auf der Stelle loben zugleich mit denen, die im Osten wohnen, diejenigen,
 denen es zu teil geworden ist, im Sonnenuntergang zu wohnen, in Einem
-Augenblicke mit denselben Lehren den Einen jenseits von allem (waltenden) <lb n="30"/>
+Augenblicke mit denselben Lehren den Einen jenseits von allem <supplied reason="undefined" resp="#editor">waltenden</supplied> <lb n="30"/>
 Gott, den Herrn der ganzen Welt, und es bekennen keinen andern denn
 nur den Christus Gottes als die Ursache ihrer Hülfe und nennen ihn
 Erlöser zugleich mit denen, die im Süden wohnen, diejenigen, die den
@@ -6049,12 +6053,12 @@ dem Griechen zu unterscheiden, und daß der Grieche kein anderer sei
 der Barbare. Denn bei Gott gibt es weder Barbare noch Grieche. Denn jeder,
 der Gott ürchtet, ist ein Weiser. Jetzt sind die Ägypter, Syrer, Skythen,
 Italer, Mauren, Perser, Inder, sie allzumal weise geworden durch die Lehre
-Christi, sind in denselben (Dingen) weise und allzumal übt, den Tod zu
+Christi, sind in denselben <supplied reason="undefined" resp="#editor">Dingen</supplied> weise und allzumal übt, den Tod zu
 <lb n="5"/> verachten und dies Leben gering zu ätzen, bieten vielmehr Eine gute
 Hoffnung durch die ßung des Logos, unsers ösers, dar. Aber sie
 haben auch gelernt, ß sie das unsterbliche Leben der Seele in der Wohnung
 des ölbes und das Reich Gottes empfangen üden, das er als
-ein Pfand denen ß, die von hier (dieser Erde) Lebewohl gesagt
+ein Pfand denen ß, die von hier <supplied reason="undefined" resp="#editor">dieser Erde</supplied> Lebewohl gesagt
 <lb n="10"/> haben. Eben durch Werke ätigte ihr öser die Verheißung:
 durch den Kampf mit dem Tode, wodurch er seinen üngern die Nichtigkeit
 des bei jedermann ürchteten Todes zeigte und das von ihm
@@ -6087,14 +6091,14 @@ Unterschrift stammt nicht von Eusebius her</note>
 <pb n="v.3.pt.2.p.165"/>
 <head>Das vierte Buch des äsareensers.</head>
 <milestone unit="altnumbering" n="122"/> <div type="textpart" subtype="chapter" n="1">
-<p>Schön ist es, fortan von dem gemeinsamen öser aller (selbst)
+<p>Schön ist es, fortan von dem gemeinsamen öser aller <supplied reason="undefined" resp="#editor">selbst</supplied>
 zu ören, der mit den Menschen redete und nach Art eines guten Vaters
 mit seinen öhnen gleichsam Kind ward und durch das äß, das er nahm,
 wie durch einen Dolmetscher Antworten gab, soweit es die Natur der <lb n="5"/>
 Sterblichen zu ören vermochte. Denn als er seine Theophanie unter
 den Menschen veranstaltete, zeigte er zwar viele andere offenbare Beweise
 der Kraft seiner Gottheit durch Taten, — wenn jemand will,
-kann er (sie) aus den üchern über ihn sammeln, — aber wiederum ist
+kann er <supplied reason="undefined" resp="#editor">sie</supplied> aus den üchern über ihn sammeln, — aber wiederum ist
 auch dies kein geringer, ür seine Wahrheit eintretender Beweis, der in <lb n="10"/>
 seinen eigenen Worten besteht. Eben sie üssen wir denen nahe bringen,
 die nicht leicht seinen wunderbaren öttlichen Taten beistimmen, damit
@@ -6109,54 +6113,54 @@ oder Mannes, ob es die Stimme eines Weisen und ünftigen oder <lb n="20"/>
 im Gegenteil eines Toren und Idioten ist, äß aber auch: selbst
 wenn wir ällig nicht vor Augen haben och sehen jene göttlichen
 Taten, die der öttliche Logos vollbrachte, als er auf Erden seinen
-Umgang hielt, sondern selbst (wenn wir auch nur) <add>urteilen</add> aus der
+Umgang hielt, sondern selbst <supplied reason="undefined" resp="#editor">wenn wir auch nur</supplied> <add>urteilen</add> aus der
 Lehre seiner eigenen Worte, deren Stimme seltsam ist und das gemeine <lb n="25"/>
 Denken übersteigt, und aus dem Vorherwissen der ünftigen Dinge
 die er voraussagte, und aus dem was er auch in äteren Zeiten zu Zeiten
-tun versprach, und aus der üllung der vorausgesagten Dinge, *deren
+tun versprach, und aus der üllung der vorausgesagten Dinge, <corr resp="#editor">deren</corr>
 Vollendung bis jetzt vor unseren eigenen Augen infolge seiner Kraft
 <milestone unit="altnumbering" n="123"/> gewirkt wird, — äß) ist nicht gering der Beweis, der sich inbetreff <lb n="30"/>
 der Dinge ergibt, welche seine Gottheit bezeugen. Denn die
-von ihm geschehenen Wunder verteilen sich auf (zwei) Zeiten: auf die-
+von ihm geschehenen Wunder verteilen sich auf <supplied reason="undefined" resp="#editor">zwei</supplied> Zeiten: auf die-
 <note type="footnote">24 Man ßt ein Verbum, etwa <foreign xml:lang="abbr">ABBREV</foreign> 28 „und deren" Σ str. (??)</note>
 
 <pb n="v.3.pt.2.p.166"/>
 jenige, die vergangen ist, in der er seinen Umgang auf Erden
-hielt, wie (in den Evangelien) berichtet ist, und (zweitens) auf die ätere
-(Periode), die sich bis zu uns selber erstreckt. Denn die gewaltigen
+hielt, wie <supplied reason="undefined" resp="#editor">in den Evangelien</supplied> berichtet ist, und <supplied reason="undefined" resp="#editor">zweitens</supplied> auf die ätere
+<supplied reason="undefined" resp="#editor">Periode</supplied>, die sich bis zu uns selber erstreckt. Denn die gewaltigen
 Taten, die er üher vollbrachte, als er auf Erden mit den Menschen
 <lb n="5"/> zusammen war, konnten diejenigen offenkundig sehen, mit denen er
 in jener Zeit ällig zusammentraf. zusammentraf. Eben sie aber sind uns verborgen
-und liegen (nur) ungesehen (vor uns). So konnten hinwieder auch die
+und liegen <supplied reason="undefined" resp="#editor">nur</supplied> ungesehen <supplied reason="undefined" resp="#editor">vor uns</supplied>. So konnten hinwieder auch die
 Dinge, die zu unserer Zeit nach seinen voraussagenden Worten in ihrer
-Ordnung üllt wurden und (die) eben in ihren Wirkungen bis jetzt
+Ordnung üllt wurden und <supplied reason="undefined" resp="#editor">die</supplied> eben in ihren Wirkungen bis jetzt
 <lb n="10"/> von uns gesehen werden, von denen, die damals und in jener Zeit
-(lebten), wo sie vorausgesagt wurden, noch nicht in ihrem örigen
+<supplied reason="undefined" resp="#editor">lebten</supplied>, wo sie vorausgesagt wurden, noch nicht in ihrem örigen
 Ausgang ßt werden, und vielleicht erschien ihre Erfüllung den
 äubigen öglich. Aber es ist wahrscheinlich, daß auch damals
-*diejenigen, die ihrer Art nach Leute von Verstand waren, obwohl sie
+<corr resp="#editor">diejenigen</corr>, die ihrer Art nach Leute von Verstand waren, obwohl sie
 <lb n="15"/> den Ausgang der voraussagenden Worte nicht sahen, dennoch sie um
 seiner übrigen Taten willen glaubten. Denn wie sollte es nicht wahrscheinlich
 sein, ß diejenigen, welche mit ihren eigenen Augen die
 offenbaren öttlichen äfte, Zeichen, Wundertaten und werke, die
 jede sterbliche Natur übertrafen, sahen, ß sie) nicht nur an das, was
-<lb n="20"/> man damals sah, sondern infolge dieser (Dinge) auch an das bereitwillig
-glaubten, was ür spätere Zeiten das Vorherwissen *verbürgte? Daher
+<lb n="20"/> man damals sah, sondern infolge dieser <supplied reason="undefined" resp="#editor">Dinge</supplied> auch an das bereitwillig
+glaubten, was ür spätere Zeiten das Vorherwissen <corr resp="#editor">verbürgte</corr>? Daher
 wiederum ört es sich auch ür uns selber, infolge Wunder, die
 wir mit unseren eigenen Augen wahrnehmen, auch jenen damaligen beizustimmen,
-die von seinen üngern bezeugt sind. Denn jene (Dinge),
+die von seinen üngern bezeugt sind. Denn jene <supplied reason="undefined" resp="#editor">Dinge</supplied>,
 <lb n="25"/> die uns von den Vorfahren nur überliefert sind, weil sie es örten,
 werden mit unseren eigenen Augen • und ügen denen,
 Geist unverdorben ist, ß sie Beweise sind zum Siegel ür Geschriebene.
 Was das ür Dinge sind, die damals noch nicht waren und
 noch nicht bestanden und noch nicht ins ßtsein der Menschen getreten,
-<lb n="30"/> (wohl) aber von ihm öttlichem Vorherwissen
+<lb n="30"/> <supplied reason="undefined" resp="#editor">wohl</supplied> aber von ihm öttlichem Vorherwissen
 und ür ätere Zeiten überliefert waren und bis jetzt in unserer eigenen
-Zeit sichtbar sind, (sie) aus folgendem kennen zu lernen, ist tunlich.</p>
+Zeit sichtbar sind, <supplied reason="undefined" resp="#editor">sie</supplied> aus folgendem kennen zu lernen, ist tunlich.</p>
 </div>
    
 <div type="textpart" subtype="chapter" n="2">
-<p>Es gab (einmal) einen ühmten Mann im Heere, der einen
+<p>Es gab <supplied reason="undefined" resp="#editor">einmal</supplied> einen ühmten Mann im Heere, der einen
 Rang und eine Machtstellung bei den ömern inne hatte. Da sein geliebter
 <lb n="35"/> Sklave, dem die Glieder ähmt waren, zu Hause <milestone unit="altnumbering" n="124"/>
 und da er sah, welche äfte unser öser an anderen zeigte, wie er
@@ -6217,22 +6221,22 @@ gewesen wäre,</add> wie sollte das nicht beweisen, daß in Wahrheit Gott
 glaublich ält wegen des Übermaßes des Wunders, so ürde er dennoch
 nicht geziemend die Vorhersagung als Vorwand gebrauchen önnen, da
 durch sie der Beweis ür sein Tun ößer erscheint, wenn er sich zu
-Herzen nimmt, wie damals (nur) Ein ömer es war, der zu unserm
+Herzen nimmt, wie damals <supplied reason="undefined" resp="#editor">nur</supplied> Ein ömer es war, der zu unserm
 <lb n="10"/> öser kam, ein Chiliarch, der ein ößeres und besseres Bekenntnis
-ür ihn zeigte als das Volk der Juden, (wie) aber unser Erlöser weissagte,
+ür ihn zeigte als das Volk der Juden, <supplied reason="undefined" resp="#editor">wie</supplied> aber unser Erlöser weissagte,
 ß viele anstatt des Einen sein werden, die gleich jenem sich
 ihm nahen ürden von denen, die im Sonnenaufgang und in den
 Gegenden des Ostens und im Sonnenuntergang wohnen, die durch die
 <lb n="15"/> Erkenntnis und durch das Bekenntnis zu ihm bei Gott an Ehre gleich
 ürdigt werden mit den Vorfahren der äer. Weil aber auch
-der Vorfahr jener, (eben) der gepriesene Abraham, der von ötzendienerischen
+der Vorfahr jener, <supplied reason="undefined" resp="#editor">eben</supplied> der gepriesene Abraham, der von ötzendienerischen
 ätern abstammte, sein Leben änderte, von dem Irrtum
-der vielen Götter <add>zurückwich</add> und Einen über alles (regierenden) Gott
-<lb n="20"/> erkannte, *so sagte dieser (Jesus) voraus, ß ihm und seinen Kindern,
+der vielen Götter <add>zurückwich</add> und Einen über alles <supplied reason="undefined" resp="#editor">regierenden</supplied> Gott
+<lb n="20"/> erkannte, <corr resp="#editor">so</corr> sagte dieser <supplied reason="undefined" resp="#editor">Jesus</supplied> voraus, ß ihm und seinen Kindern,
 Isaak und Jakob, Myriaden gleich sein ürden in der ganzen Menschenwelt,
-und (zwar) besonders diejenigen ölker, die im Osten, und diejenigen
-(Leute), die im Westen wohnen, und er ügt diesen (Worten)
-auch das ößte seiner ßung hinzu. Die Juden selber (sagt er),
+und <supplied reason="undefined" resp="#editor">zwar</supplied> besonders diejenigen ölker, die im Osten, und diejenigen
+<supplied reason="undefined" resp="#editor">Leute</supplied>, die im Westen wohnen, und er ügt diesen <supplied reason="undefined" resp="#editor">Worten</supplied>
+auch das ößte seiner ßung hinzu. Die Juden selber <supplied reason="undefined" resp="#editor">sagt er</supplied>,
 <lb n="25"/> die öhne jener Gottgeliebten, die stolz sind auf Abraham, Isaak und
 Jakob, sollen, weil sie sich wider ihn erhoben und nicht an ihn glaubten,
 als des Lichtes der Erkenntnis Beraubte „hinausgehen in die äußerste
@@ -6255,7 +6259,7 @@ wie die Juden, die sich rühmen, des Geschlechts jener genannten
 gottgeliebten Männer zu sein, ausgestoßen sind nicht nur aus
 dem Reiche Gottes, sondern auch aus ihrer eigenen heiligen und königlichen
 Hauptstadt, in welcher sie allein, wie das Gesetz es bestimmte, ihren <lb n="5"/>
-glänzenden Gottesdienst vollziehen sollten, und (wie) sie Knechte wurden
+glänzenden Gottesdienst vollziehen sollten, und <supplied reason="undefined" resp="#editor">wie</supplied> sie Knechte wurden
 <milestone unit="altnumbering" n="126"/> aus Freien, früher Söhne vorzüglicher Väter, und vermischt mit fremden
 Völkern — was ihnen nicht gestattet war — in einem Lande, das nicht
 ihr eigen war, umherirrten, sodaß ihnen nicht einmal erlaubt war, aus
@@ -6277,7 +6281,7 @@ aus allen Völkern, nicht Chiliarchen allein, sondern auch die Menge der <lb n="
 römischen Truppen wie auch Myriaden von Herrschern und ἡγεμόνες,
 die über Völker und Länder mächtig sind, und andere, soviele an Ehre
 und Rang viel höher sind als diese, eben diejenigen, die im Königshause
-stolz sind, — (kamen) gleich jenem Chiliarchen zum Christus
+stolz sind, — <supplied reason="undefined" resp="#editor">kamen</supplied> gleich jenem Chiliarchen zum Christus
 Gottes, erkannten durch seine Lehre den Gott derer, die bei den <lb n="25"/>
 Hebräern als gottgeliebte Menschen glänzten, und wurden in gleicher
 Weise wie sie des Geschenkes von Gott, dem König des Alls, gewürdigt.
@@ -6286,7 +6290,7 @@ und Kirchen es in Myriaden Mengen im Lande der Perser und der Inder
 geben soll, die im Sonnenaufgang wohnen, und wie durch die Worte <lb n="30"/>
 unsers Erlösers bei diesen Weiber, liebende Jungfrauen und Männer
 zur vollendeten Heiligkeit übergehen und zur Enthaltsamkeit eines
-philosophischen und züchtigen Lebens, und (wie) Myriaden Bekenner
+philosophischen und züchtigen Lebens, und <supplied reason="undefined" resp="#editor">wie</supplied> Myriaden Bekenner
 Gottes eben unter ihnen leben,</p>
 </div>
 
@@ -6300,9 +6304,9 @@ mißverstandenes ὡς</note>
 
 <pb n="v.3.pt.2.p.170"/>
 neue Geburt in ihm Kinder Abrahams geworden sind und eben das
-vorhersagende Wort unsers ösers versiegeln, (wie) gerade ebenso
+vorhersagende Wort unsers ösers versiegeln, <supplied reason="undefined" resp="#editor">wie</supplied> gerade ebenso
 aber auch in den westlichen Teilen der Welt alle Spanier und Gallier <milestone unit="altnumbering" n="127"/>
-und (wie man) <add>in</add> den ändern der Mauren und Afrer, sogar im Ozean:
+und <supplied reason="undefined" resp="#editor">wie man</supplied> <add>in</add> den ändern der Mauren und Afrer, sogar im Ozean:
 <lb n="5"/> <del>und</del> in Britannien Christus bekennt und den Gott Abrahams, lsaaks und
 Jakobs anerkennt und auch in Gebeten anruft und als Teilhaber jener
 äter) in der Gottesverehrung erscheint — wenn also jemand eben
@@ -6315,10 +6319,10 @@ Lehrern zusammen redete, prophezeite er dem Ahnliches und redete in
 dieser Weise: „ Wenn ihr sehen werdet Abraham, Isaak und Jakob und
 <lb n="15"/> die Propheten, alle im Reiche Gottes, euch aber hinausgeworfen, dann
 werden sie kommen von Morgen <add>und Abend</add>, von Westen und üden
-und werden zu Tische sitzen im Reiche Gottes." Eben diese (Worte)
+und werden zu Tische sitzen im Reiche Gottes." Eben diese <supplied reason="undefined" resp="#editor">Worte</supplied>
 empfangen ihre ätigung offenbar durch die Bekehrung aller Völker
-zu dem über alles (waltenden) Gott. Dies also sagte er jenen über die
-<lb n="20"/> Bekehrung aller ölker zu dem über alles (waltenden) Gott.</p>
+zu dem über alles <supplied reason="undefined" resp="#editor">waltenden</supplied> Gott. Dies also sagte er jenen über die
+<lb n="20"/> Bekehrung aller ölker zu dem über alles <supplied reason="undefined" resp="#editor">waltenden</supplied> Gott.</p>
 </div>
    
 <div type="textpart" subtype="chapter" n="6">
@@ -6352,7 +6356,7 @@ Der aber sprach zu ihm: Die ganze Nacht haben wir gearbeitet, aber
 nichts gefunden; auf dein Wort jedoch will ich die Netze auswerfen.
 — und ührte den Auftrag aus. Als sie aber eine ße Menge Fische
 einfingen, zerrissen die Netze öllig, von der Menge beschwert. Da <lb n="10"/>
-riefen sie die (Leute) im Nachbarschiff zu Hilfe. Als sie dann die
+riefen sie die <supplied reason="undefined" resp="#editor">Leute</supplied> im Nachbarschiff zu Hilfe. Als sie dann die
 Fische in die öhe gezogen hatten, üllten sie beide Schiffe, sodaß Gefahr
 fahr vorhanden war unterzugehen. über wunderte sich Simon,
 staunte und bekannte, nicht wert zu sein, ß unser öser sich ihm
@@ -6362,10 +6366,10 @@ an sollst du Menschenfischer sein.“ äischen Männern, die nichts
 weiter kennen als die syrische Sprache und die auch dem niedrigen
 und armseligen Gewerbe der Fischerei nachgehen, versprach unser öser
 mit Recht, er werde sie zu Menschenfischern und Herolden seiner <lb n="20"/>
-Lehre machen, und hat sie (dazu) gemacht, ohne seine ßung
+Lehre machen, und hat sie <supplied reason="undefined" resp="#editor">dazu</supplied> gemacht, ohne seine ßung
 ügen zu strafen, und hat die Kraft Gottes wirksam gezeigt für eine
 Sache, die jede üchtigkeit der Menschen übertrifft. Denn wenn er die
-ünftigen und Weisen *oder die geehrten und reichen Leute unter
+ünftigen und Weisen <corr resp="#editor">oder</corr> die geehrten und reichen Leute unter
 den Juden zu sich ührt und sie als Lehrer seiner Worte benutzt <lb n="25"/>
 ätte, so äre es vielleicht ür ür jemanden natürlich zu meinen, daß die
 Sache menschlicher bereitet sei. Denn so pflegen die meisten der
@@ -6384,11 +6388,11 @@ indem er allein die öttliche Kraft verwandte, die er zeigte, indem
 
 <pb n="v.3.pt.2.p.172"/>
 er sie zuerst mit Einem Worte berief und zu seinen ängern machte
-und (indem) er ihnen dann ß, er werde sie zu Fischern und
+und <supplied reason="undefined" resp="#editor">indem</supplied> er ihnen dann ß, er werde sie zu Fischern und
 Herolden der Menschen machen, damit sie anstatt der Netze, die sie
 hatten, von ihm das Netz empfingen, das aus allerlei Worten der Gesetze
 <lb n="5"/> und Propheten und aus solchen seiner eigenen öttlichen
-Lehre gewebt war, und (damit) sie (es) in das Meer der Menschenwelt ürfen <milestone unit="altnumbering" n="129"/>
+Lehre gewebt war, und <supplied reason="undefined" resp="#editor">damit</supplied> sie <supplied reason="undefined" resp="#editor">es</supplied> in das Meer der Menschenwelt ürfen <milestone unit="altnumbering" n="129"/>
 und einfingen, soviele sie änden, indem sie ihre geistigen Netze mit
 jeder Art ünftiger Fische üllten. Aber dies waren, als man damals
 im Worte es örte, Phrasen und öne und nichts Das Work
@@ -6404,7 +6408,7 @@ und vorher sagte, sondern auch als äter so ßen Wissens erschienen
 ist. Er sprach durch das Wort und hat gewirkt durch die Tat; er
 <lb n="20"/> stellte die Zukunft durch Symbol und Bild dar und hat sie durch sein
 Wirken vollendet. Denn denen, die vor alters üher in der Finsternis
-(fern) vom Lichte der Wahrheit und in der Nacht der Gotteserlcenntnis
+<supplied reason="undefined" resp="#editor">fern</supplied> vom Lichte der Wahrheit und in der Nacht der Gotteserlcenntnis
 arbeiteten und keinen ür die ösung einfangen konnten, leuchtete er
 in seinem Glanze auf und befahl denen, die an den Tag und ans Licht
 <lb n="25"/> kamen, nicht auf die eigene Kunst, sondern auf sein Wort zu vertrauen
@@ -6413,7 +6417,7 @@ so ße Menge von Fischen zusammen, ß die Fanggeräte zerrissen
 und die Schiffe in Gefahr kameD, infolge der Belastung in die Tiefe zu
 sinken. Als dies aber so geschehen war, brachte er den Simon zum
 <lb n="30"/> Erstaunen und zu nicht geringer Furcht. Aber dies öge dich nicht
-erschrecken, sagte unser öser zu ihm; denn noch ist es (Kinder)spiel
+erschrecken, sagte unser öser zu ihm; denn noch ist es <supplied reason="undefined" resp="#editor">Kinder</supplied>spiel
 und ein Bild des ünftigen. Denn dies sind stumme und unver-
 <note type="footnote">6 εἰς τὴν τοῦ ἀνθρωπείου βίου θάλατταν] „in das menschliche Meer der Welt"
 Σ 12 ὡς ἐν βραχεῖ χρόνῳ τὴν σύμπασαν <add>ὁμοῦ</add> ἀνθρώπων οἰκουμένην μυρία
@@ -6436,9 +6440,9 @@ und aus den finstern Winkeln der Gottlosigkeit und Schlechtigkeit
 zum geistigen Licht und zur reinen Luft heraufziehen diejenigen, die
 von dir gefangen werden, das ßt vielmehr: du wirst sie zum Leben <lb n="10"/>
 fangen dadurch, ß du ihnen das Leben, aber nicht den Tod förderst.
-Denn die aus dem Meere (stammenden) Fische, die vorher in der
-Finsternis (und) in der Tiefe leben, gehen sofort zu grunde, sobald sie
-Licht und Luft erlangen, diejenigen (Fische) aber, die von dir unter den
+Denn die aus dem Meere <supplied reason="undefined" resp="#editor">stammenden</supplied> Fische, die vorher in der
+Finsternis <supplied reason="undefined" resp="#editor">und</supplied> in der Tiefe leben, gehen sofort zu grunde, sobald sie
+Licht und Luft erlangen, diejenigen <supplied reason="undefined" resp="#editor">Fische</supplied> aber, die von dir unter den
 Menschen gefangen werden aus der Finsternis der Unwissenheit, ändern <lb n="15"/>
 sich um und werden zum öttlichen Leben gefangen. Deswegen sprach
 er: „Von nun an wirst du Menschenfischer sein." Dies sagte unser
@@ -6467,14 +6471,14 @@ HSS) τὰ φαινόμενα 24 ἤνεγκέν] „ertrug" Σ 27 „verkünd
 
 
 <pb n="v.3.pt.2.p.174"/>
-in der Nachbarschaft ündete, und diejenigen in Agypten, *eben
-Alexandrien stellte er ferner selber, (freilich) nicht durch sich, sondern
+in der Nachbarschaft ündete, und diejenigen in Agypten, <corr resp="#editor">eben</corr>
+Alexandrien stellte er ferner selber, <supplied reason="undefined" resp="#editor">freilich</supplied> nicht durch sich, sondern
 durch den zum ünger gewonnenen Markus ür sich auf. Während er
 ämlich selber in Italien und unter den ölkern weilte, machte
 <lb n="5"/> er seinen ünger Markus zum Lehrer und Fischer ür die in Ägypten. die
 Richte aber deinen Sinn auch auf die übrigen ünger unsers Erlösers,
 denen er ß, er werde sie zu Menschenfiscbern machen, und <milestone unit="altnumbering" n="131"/>
-(denen) er sein Wort durch die Tat zeigte. Bis jetzt also schafft und
+<supplied reason="undefined" resp="#editor">denen</supplied> er sein Wort durch die Tat zeigte. Bis jetzt also schafft und
 wirkt derselbe, indem er überall auf Erden zugegen ist und die ganze
 <lb n="10"/> Menschenwelt mit seinen geistigen Netzen üllt und mit vernünftigen
 Fischen der Barbaren und Griechen aus jedem Geschlecht, aus der
@@ -6493,7 +6497,7 @@ nicht verborgen bleiben. Man ündet auch nicht ein Licht an setztes
 es unter einen Scheffel, sondern auf einen Leuchter, so leuchtet es allen,
 die in dem Hause sind. So soll euer Licht leuchten vor den Menschen,
 damit sie eure guten Werke sehen und euren Vater im Himmel
-<lb n="25"/> preisen." Hier (sagte er) wiederum zu jenen Fischern, die aus dem
+<lb n="25"/> preisen." Hier <supplied reason="undefined" resp="#editor">sagte er</supplied> wiederum zu jenen Fischern, die aus dem
 Lande äa kamen — es ist aber ein Winkel äas, der so genannt wird,
 am ücken gelegen, über den auch unter den Propheten Jesaja
 ündet ündet und ausruft, indem er zugleich auf die Verborgenheit des
@@ -6523,28 +6527,28 @@ Wie sollte dies nicht die Wahrheit dessen ätigen, was er seinen
 auch der Name des Johannes, des Sohnes äi, den er beim Fischfang <lb n="10"/>
 mit seinem Vater und Bruder die Netze flicken sah und den er
 derselben Berufung und ßung ürdigte, in der ganzen Welt, und
-seine Worte *erleuchten die Seelen der Menschen durch die von ihm
+seine Worte <corr resp="#editor">erleuchten</corr> die Seelen der Menschen durch die von ihm
 überlieferte Schrift des Evangeliums, die in mancherlei Sprachen, griechische
 chische und barbarische, verdolmetscht ist und allen ölkern alle Tage <lb n="15"/>
 ins Ohr ündigt wird. Und besonders auch ehrt man die ätte
-dieses (Apostels) zu Ephesus in (Klein)asien herrlich und beweist (damit),
+dieses <supplied reason="undefined" resp="#editor">Apostels</supplied> zu Ephesus in <supplied reason="undefined" resp="#editor">Klein</supplied>asien herrlich und beweist <supplied reason="undefined" resp="#editor">damit</supplied>,
 ß die Erinnerung an das Licht seiner üglichkeit in Ewigkeit
 nicht vergessen wird. So werden auch die Schriften des Apostels
 Paulus mit Recht in der ganzen Welt ündent und erleuchten die <lb n="20"/>
 Seelen der Menschen. Auch das ärtyrertum seines Todes und die
-über ihm (sich erhebende) ätte wird üglich und gewaltig in
+über ihm <supplied reason="undefined" resp="#editor">sich erhebende</supplied> ätte wird üglich und gewaltig in
 der Stadt Rom bis jetzt gepriesen. Was habe ich ötig zu sagen, ß
 auch die Lebensweise, die in der ganzen Welt durch eben die ünger
 unsers ösers ührt ist, dem Anblick eines Siegeszeichens gleich <lb n="25"/>
-eine ühmte Stadt ist, die nicht etwas im Verborgenen (Gelegenes) ist,
+eine ühmte Stadt ist, die nicht etwas im Verborgenen <supplied reason="undefined" resp="#editor">Gelegenes</supplied> ist,
 sondern die die Mitte aller ädte inne hat, entsprechend dem Wort
 unsers ösers: Einer Stadt gleich, die oben auf einem Berge gelegen
 ist. Das Wort, das sie über unsern Meister ündeten, war nicht wie
-(eins), das unter dem Scheffel verborgen und dem Irrtum und der <lb n="30"/>
-Finsternis überliefert ist, sondern wie (eins), das oben auf einen hohen
+<supplied reason="undefined" resp="#editor">eins</supplied>, das unter dem Scheffel verborgen und dem Irrtum und der <lb n="30"/>
+Finsternis überliefert ist, sondern wie <supplied reason="undefined" resp="#editor">eins</supplied>, das oben auf einen hohen
 Leuchter und in die öhe nach ärts gehoben ist und allen, die im
 Hause der ganzen Welt sind, leuchtet. Vorauswissen aber und Prophe-
-zeiung — und keineswegs nur (etwas) Befehlendes, sondern auch etwas
+zeiung — und keineswegs nur <supplied reason="undefined" resp="#editor">etwas</supplied> Befehlendes, sondern auch etwas
 <note type="footnote">5 vgl. Euseb. Hist. eccles. II 25 7 9 = Matth 5 14 9—16 = <lb n="7."/>
 der griech. Theoph. 10 vgl. Matth 421 17 vgl. Euseb. Hist. eccles. III 31 3
 22 vgl. Euseb. Hist. eccles. II 25 7 28 vgl. Matth 5 u 30 vgl. Matth 5 15</note>
@@ -6552,7 +6556,7 @@ der griech. Theoph. 10 vgl. Matth 421 17 vgl. Euseb. Hist. eccles. III 31 3
 Verborgenheit nichts ist" Σ</note>
 
 <pb n="v.3.pt.2.p.176"/>
-die Zukunft Vorauszeigendes — ist dies (Wort): „So wird euer Licht
+die Zukunft Vorauszeigendes — ist dies <supplied reason="undefined" resp="#editor">Wort</supplied>: „So wird euer Licht
 leuchten vor den Menschen." „Licht" aber nannte er durchaus alle,
 indem er sagte: „Ihr seid das Licht der Welt", und keineswegs viele
 Lichter, sondern zumal alle Ein Licht, sodaß infolge der Übereinstimmung
@@ -6566,10 +6570,10 @@ was ihr ins Ohr ört, sollt ihr auf den ächern und
 ürchtet euch nicht vor denen, die den Leib öten, aber die Seele nicht
 öten önnen; ürchtet euch vielmehr vor dem, der Seele und leib verderben
 kann in die ölle.“ Auch hierdurch versprach er eben in den
-<lb n="15"/> ängen (der Belehrung) seiner ünger, als sie die Dinge (noch) nicht
+<lb n="15"/> ängen <supplied reason="undefined" resp="#editor">der Belehrung</supplied> seiner ünger, als sie die Dinge <supplied reason="undefined" resp="#editor">noch</supplied> nicht
 kannten und waren wie der, der in Finsternis ist, die Kenntnis des
 Lichtes. Denen, die im Verborgenen und in der Finsternis seine Befehle
-örten, ohne ß (die üllung) sichtbar war, prophezeite er, daß
+örten, ohne ß <supplied reason="undefined" resp="#editor">die üllung</supplied> sichtbar war, prophezeite er, daß
 sie ihn offen bei jedermann predigen ürden, und ermahnte sie,
 <lb n="20"/> nicht zu scheuen, sondern die Gefahr mit ganzer Seele zu ertragen und
 ihn ins Ohr aller zu ündigen, ohne sich zu ürchten vor denen, die
@@ -6578,16 +6582,16 @@ nicht ötet werden, weil sie örperlich und unsterblich ist. Denn
 nur Gott kann Leib und Seele zumal öten und strafen. Es mag aber
 <lb n="25"/> beobachtet werden, ß er eben hierdurch die Unkörperlichkeit der
 Seele lehrte und ein Dogma der Philosophen in kurzen Worten darlegte.</p>
-<p>Daß er seinen üngern am Anfang (ihrer Berufung) sagte, er werde sie
+<p>Daß er seinen üngern am Anfang <supplied reason="undefined" resp="#editor">ihrer Berufung</supplied> sagte, er werde sie
 zu Menschenfischern machen, und am Ende offenkundig prophezeite, sie
-<lb n="30"/> ürden sofort alle ölker mit (Hilfe) seiner Kraft zu jüngern machen, (wird)
-nach dem Evangelium des äus (beschrieben).</p>
+<lb n="30"/> ürden sofort alle ölker mit <supplied reason="undefined" resp="#editor">Hilfe</supplied> seiner Kraft zu jüngern machen, <supplied reason="undefined" resp="#editor">wird</supplied>
+nach dem Evangelium des äus <supplied reason="undefined" resp="#editor">beschrieben</supplied>.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="8">
 <p>Nach seiner Auferstehung von den Toten gingen alle
 zumal, denen es aufgetragen war, nach äa, wohin er ihnen
-gesagt hatte (zu gehen). „Und da sie ihn sahen, fielen einige nieder,
+gesagt hatte <supplied reason="undefined" resp="#editor">zu gehen</supplied>. „Und da sie ihn sahen, fielen einige nieder,
 andere aber zweifelten. Er aber trat zu ihnen, redete mit ihnen und
 <note type="footnote">1 = Matth 5 16 3 = Matth 5 14 6 = Joh 8 12 7 = Joh 1 9
 10 = Matth 10 27. 28 32 vgl. Matth 28 16 33 = Matth 28 17—20</note>
@@ -6599,32 +6603,32 @@ sprach: mir ist gegeben von meinem Vater alle Gewalt im Himmel und
 auf Erden. Gehet hin, lehret alle ölker und taufet sie im Namen des
 Vaters, des Sohnes und des heiligen Geistes, und lehret sie halten alles,
 was ich euch befohlen habe, und siehe, ich bin bei euch alle Tage bis
-an das Ende der Welt." Beachte aber bei diesen (Dingen) die Überlegung <lb n="5"/>
+an das Ende der Welt." Beachte aber bei diesen <supplied reason="undefined" resp="#editor">Dingen</supplied> die Überlegung <lb n="5"/>
 der ünger und die Vorsicht ihres Denkens, ß nicht alle ihn
-anbeteten, als sie ihn sahen, sondern (nur) die einen taten dies äubig
+anbeteten, als sie ihn sahen, sondern <supplied reason="undefined" resp="#editor">nur</supplied> die einen taten dies äubig
 und gern, die andern aber hielten ür jetzt ück, ß sie nicht
-leicht(sinnig) und schnell diesem Wunder zustimmten, sondern mit
+leicht<supplied reason="undefined" resp="#editor">sinnig</supplied> und schnell diesem Wunder zustimmten, sondern mit
 <milestone unit="altnumbering" n="134"/> reiflicher üfung und aller Vorsicht. Dann am Ende ßen auch sie <lb n="10"/>
 sich überzeugen, zogen aus zu allen Menschen und wurden selbst Prediger
 seiner Auferstehung. Da aber in der Schrift der Propheten mit
 Bezug auf ihn prophetisch gesagt ist: „Bitte von mir, so will ich dir
-ölker zu deinem Erbe geben und deine Herrschaft (soll) bis an die Enden
-der Erde (reichen)," sagt er zu seinen üngern, als ob das prophetische <lb n="15"/>
+ölker zu deinem Erbe geben und deine Herrschaft <supplied reason="undefined" resp="#editor">soll</supplied> bis an die Enden
+der Erde <supplied reason="undefined" resp="#editor">reichen</supplied>," sagt er zu seinen üngern, als ob das prophetische <lb n="15"/>
 Zeugnis jetzt durch die Tat üllt ürde: „Mir ist jede Gewalt wie im
-Himmel (so) auch auf Erden gegeben.“ Denn die Herrschaft der
+Himmel <supplied reason="undefined" resp="#editor">so</supplied> auch auf Erden gegeben.“ Denn die Herrschaft der
 im Himmel hatte er von Ewigkeit an inne, die <add>Macht</add> der Dinge
 Erden aber, sagt er, sei ihm jetzt gegeben vom Vater, entsprechend dem
-(Worte): „Bitte von mir, so will ich dir Völker zu deinem Erbe
+<supplied reason="undefined" resp="#editor">Worte</supplied>: „Bitte von mir, so will ich dir Völker zu deinem Erbe
 geben.“ Denn einst, wie Mose bezeugt: „Als der öchste
 trennte, bestimmte er die Grenzen der ölker nach der Zahl der
 Engel,“ waren die Engel Gottes die Herrscher über alle üher auf
-Erden (Weilenden). Als sich die Menschheit aber zum polytheistischen
+Erden <supplied reason="undefined" resp="#editor">Weilenden</supplied>. Als sich die Menschheit aber zum polytheistischen
 Irrtum wandte und die herrschenden Engel nichts in betreff dieser <lb n="25"/>
-(Sache) helfen konnten, lehrte fortan der gemeinsame öser aller
+<supplied reason="undefined" resp="#editor">Sache</supplied> helfen konnten, lehrte fortan der gemeinsame öser aller
 selber durch seine Theophanie nach dem Siege über den Tod, ß nicht
 mehr den Engeln, sondern ihm von seinem Vater die Herrschaft
 über die ölker auf Erden gegeben sei. Deshalb befahl er seinen
-üngern nicht üher, sondern jetzt (erst), herumzuziehen und ölker <lb n="30"/>
+üngern nicht üher, sondern jetzt <supplied reason="undefined" resp="#editor">erst</supplied>, herumzuziehen und ölker <lb n="30"/>
 zu lehren. Notwendig aber ügt er auch das Geheimnis der Reinigung
 Denn er ßte diejenigen, die aus den ölkern sich bekehren, von jeder Befleckung
 und Besudelung durch seine Kraft reinigen, weil sie infolge des
@@ -6638,7 +6642,7 @@ Eusebius III*.</note>
 
 
 <pb n="v.3.pt.2.p.178"/>
-nach der Reinigung, die durch seine mystische Lehre (stattfindet), nicht
+nach der Reinigung, die durch seine mystische Lehre <supplied reason="undefined" resp="#editor">stattfindet</supplied>, nicht
 die üdischen Gesetze und nicht die Gebote des Mose, asondern alles
 das bewahren, was er selber ihnen auftrug. Dies war es, was alle
 äßig, bei allen ölkern herumgehend, allen üngern und allen
@@ -6648,10 +6652,10 @@ an und macht sie geneigt, zu fischen und herumzugehen bei allen
 die er ihnen gab, indem er sagte: „Siehe, ich bin bei each.“
 Denn diesem Worte der ßung ügte er die Tat hinzu, war mit <milestone unit="altnumbering" n="135"/>
 <lb n="10"/> öttlicher Kraft bei jedem einzelnen von ihnen, war allen zumal ärtig,
-schaffte und wirkte mit ihnen und äftigte das Sieges(werk),
+schaffte und wirkte mit ihnen und äftigte das Sieges<supplied reason="undefined" resp="#editor">werk</supplied>,
 indem er sie zu Lehrern aller ölker in der von ihm überlieferten
 Gottesfurcht machte. Auf diese ßung also vertrauend, üllten
-sie durch die Tat seine Worte. Sogleich und in nichts * ögernd
+sie durch die Tat seine Worte. Sogleich und in nichts <corr resp="#editor">ögernd</corr>
 <lb n="15"/> gingen sie in aller Bereitwilligkeit, alle ölker zu belehren, indem sie
 eben durch die Tat wahrnahmen und mit den Augen lebendig sahen den,
 der vor kurzem tot war, und den, den sie wegen des Vorgefallenen verleugnet
@@ -6659,10 +6663,10 @@ und abgeschworen hatten, eben ihn deutlich und in eigener
 Person nahe sahen und örten), wie er mit ihnen in gewohnter Weise
 <lb n="20"/> redete und ihnen das Vorhergesagte ß, ß) sie wegen des
 Anblicks, den sie üften, seinen Versprechungen nicht äubig sein
-konnten. Denn der Befehl (allein) ätte sie verdrossen, da sie ihr
+konnten. Denn der Befehl <supplied reason="undefined" resp="#editor">allein</supplied> ätte sie verdrossen, da sie ihr
 äurisches Wesen und ihre bescheidene Redegabe kannten, weswegen
-sie beinahe verzichtet ätten, *indem sie mit Recht bedachten, daß es
-<lb n="25"/> ür (Leute, die) der Sprache nach Syrer (waren) und nichts weiter als
+sie beinahe verzichtet ätten, <corr resp="#editor">indem</corr> sie mit Recht bedachten, daß es
+<lb n="25"/> ür <supplied reason="undefined" resp="#editor">Leute, die</supplied> der Sprache nach Syrer <supplied reason="undefined" resp="#editor">waren</supplied> und nichts weiter als
 Fischerei verstanden, öglich war, als Lehrer der Griechen zumal
 und ömer, der Ägypter, Perser und übrigen barbarischen ölker aufzutreten
 und Gesetze zu geben gegen alle Gesetzgeber und önige auf
@@ -6684,8 +6688,8 @@ sodaß sie daher die Gefahren mit ganzer Seele ertrugen, indem
 sie die ürgschaft des Lebens nach dem Tode vom Meister
 empfingen, und mutig daran gingen, bei allen ölkern umherzugehen,
 indem sie durch Werke die ßungen ihres Meisters bestätigten. <lb n="5"/>
-Er aber ügte zu seinen Versprechungen an sie (noch) ein übriges Wort
-hinzu, und (noch) wunderbarer: er ährt es bis jetzt. Indem er zu
+Er aber ügte zu seinen Versprechungen an sie <supplied reason="undefined" resp="#editor">noch</supplied> ein übriges Wort
+hinzu, und <supplied reason="undefined" resp="#editor">noch</supplied> wunderbarer: er ährt es bis jetzt. Indem er zu
 ihnen sagt: „Siehe ich bin bei euch alle Tage", ügt er hinzu: „bis
 <milestone unit="altnumbering" n="136"/> ans Ende der Welt." Dies üllt er keineswegs nur an ihnen,
 auch an allen denen, die ihnen folgten und eben von ihnen seine Lehre <lb n="10"/>
@@ -6710,9 +6714,9 @@ bei allen ölkern, anfangend von Jerusalem. Ihr aber seid Zeugen <lb n="25"/>
 ür.“ Nachdem er Einmal gesagt hat, auf seinen Namen solle Buße
 ündigt werden allen ölkern, darf man, falls die Tat nicht dem
 Wort folgte, auch seine Auferstehung von den Toten nicht glauben. Wenn
-aber auch bis jetzt die (Dinge) seiner Prophezeiung sich in die Tat umsetzen
-und (wenn) sein Wort lebendig und wirksam ist in der ganzen Welt <lb n="30"/>
-und mit Augen gesehen wird, so ziemt es sich, fortan nicht (mehr) zu
+aber auch bis jetzt die <supplied reason="undefined" resp="#editor">Dinge</supplied> seiner Prophezeiung sich in die Tat umsetzen
+und <supplied reason="undefined" resp="#editor">wenn</supplied> sein Wort lebendig und wirksam ist in der ganzen Welt <lb n="30"/>
+und mit Augen gesehen wird, so ziemt es sich, fortan nicht <supplied reason="undefined" resp="#editor">mehr</supplied> zu
 zweifeln an dem, der dies Wort sagte. Denn der, dessen Kraft lebendig
 und wirksam ist und mit Augen gesehen wird, wird, den ß man not-
 <note type="footnote">8 = Matth 2820 14 vgl. Didache 94 19 = Luk 2444—48 26—S. 180, 19
@@ -6723,7 +6727,7 @@ und wirksam ist und mit Augen gesehen wird, wird, den ß man not-
 <pb n="v.3.pt.2.p.180"/>
 wendig viel üher bekennen, daß er lebe und das Leben
 er dessen lebendige Werke übereinstimmend erscheinen mit seinen
-Worten. In alle Ohren also aller ölker *drangen seine Worte, übersetzt
+Worten. In alle Ohren also aller ölker <corr resp="#editor">drangen</corr> seine Worte, übersetzt
 und verdolmetscht in alle Sprachen der Griechen und Barbaren,
 <lb n="5"/> sodaß seine Lehre von allen ölkern ört wurde und zur Bekehrung
 und ße Myriaden Scharen derer brachte, die üher in polytheistischem
@@ -6742,7 +6746,7 @@ was ihnen aufgetragen war, indem sie allen die ße und Vergebung
 der üheren ünden der Seele ündeten und so große Tüchtigkeit
 <lb n="20"/> zeigten, daß bis jetzt in unserer Zeit die Lehre dieser armen und laienhaften
 änner in der ganzen Menschenwelt wirksam ist.</p>
-<p>Wie seine *Taten ört und ündet werden in der ganzen welt.
+<p>Wie seine <corr resp="#editor">Taten</corr> ört und ündet werden in der ganzen welt.
 Aus dem Evangelium des äus und aus Markus.</p>
 </div>
 
@@ -6786,16 +6790,16 @@ und wie er sagte, daß die Pforten des Todes sie niemals überwinden
 <div type="textpart" subtype="chapter" n="11">
 <p>Als er einst seine ünger fragte, was die Menschen über ihn
 sagten, und sie ihm die Meinung vieler antworteten, fragte er sie zum
-zweiten Male: „Ihr (aber), was sagt ihr?" Als Simon zu ihm sagte: <lb n="20"/>
+zweiten Male: „Ihr <supplied reason="undefined" resp="#editor">aber</supplied>, was sagt ihr?" Als Simon zu ihm sagte: <lb n="20"/>
 „Du bist Christus, der Sohn des lebendigen Gottes", antwortete er ihm
 und sprach: „Selig bist du, Simon bar Jonan. Fleisch und Blut hat
 es dir nicht geoffenbart, sondern mein Vater im Himmel. So sage auch
 ich dir: Du bist Petrus, und auf diesen Felsen will ich meine Kirche
 bauen, und die Riegel der Scheol sollen sie nicht überwältigen." Dies <lb n="25"/>
-Wissen (des Simon), daß er Christus sei, der Sohn des lebendigen
+Wissen <supplied reason="undefined" resp="#editor">des Simon</supplied>, daß er Christus sei, der Sohn des lebendigen
 Gottes, nahm er an und nannte dies ganze Begreifen mit Recht πέτρος,
 weil es weder zerrissen noch üttert wird. Deswegen nannte er
-auch jenen Mann, eben seinen ünger, den üher (so) genanten Simon:
+auch jenen Mann, eben seinen ünger, den üher <supplied reason="undefined" resp="#editor">so</supplied> genanten Simon:
 „Petrus“ wegen des Wissens, über das er hinterher prophezeite und <lb n="30"/>
 sagte: „Auf diesen Felsen will ich meine Kirche bauen und die Riegel
 der Scheol sollen sie nicht überwältigen." Er weissagte zugleich die
@@ -6808,7 +6812,7 @@ Wissen wie auf einen festen Grundstein ündet und gebaut <lb n="35"/>
 <pb n="v.3.pt.2.p.182"/>
 werde allein durch seine Macht in Ewigkeit und ß die Pforten des
 Todes sie niemals besiegen ürden. Die üllung zeigte er besser als
-alle Worte (es darstellen önnen). Denn Myriaden *Verfolgungen und
+alle Worte <supplied reason="undefined" resp="#editor">es darstellen önnen</supplied>. Denn Myriaden <corr resp="#editor">Verfolgungen</corr> und
 viele Arten des Todes ergingen über seine Kirche, vermochten aber
 <lb n="5"/> nichts wider sie. So zeigte die Prophezeiung eben in Taten offenkundig
 ihre Wahrheit durch die üllung. Dies war aber ein nicht geringes <milestone unit="altnumbering" n="139"/>
@@ -6858,26 +6862,26 @@ nicht einmal das dem Vorherwissen unseres ösers verborgen
 was in jedem einzelnen Hause in fernen, äteren Zeiten bis jetzt
 üllt? Denn als ob er den Dingen selber nahe sei und in den
 <milestone unit="altnumbering" n="140"/> Wohnungen aller Menschen umherwandle, sagte er seinen üngern die <lb n="10"/>
-(Dinge) voraus, die bis jetzt sich ereignen, Dinge, die bis dahin noch
-nicht existiert hatten und (noch) nicht waren zu der Zeit, wo er jene
+<supplied reason="undefined" resp="#editor">Dinge</supplied> voraus, die bis jetzt sich ereignen, Dinge, die bis dahin noch
+nicht existiert hatten und <supplied reason="undefined" resp="#editor">noch</supplied> nicht waren zu der Zeit, wo er jene
 Worte sprach. Denn damals waren sie noch nicht Taten geworden, als sie
 nur ins Ohr ört wurden. Jetzt aber ist die Prophezeiung durch Taten
 zur üllung gekommen und kann mit Augen gesehen werden. Wie <lb n="15"/>
 sollte da nicht jeder bekennen, der bereit ist, Geziemendes zu denken, ß es
 in Wahrheit Worte Gottes seien? Ferner aber sehen wir mit unsern eigenen
-Augen, wie er auch durch diese (Worte) : Ich bin gekommen zu spalten, das
+Augen, wie er auch durch diese <supplied reason="undefined" resp="#editor">Worte</supplied> : Ich bin gekommen zu spalten, das
 Schwert und Spaltungen unter die Menschen zu bringen, — was kein Wort
 der Menschen, weder der Philosophen noch der Propheten, weder der <lb n="20"/>
-Griechen noch der Barbaren jemals wie diese Kraft gezeigt hat — (wie
-er) auch hierdurch die ganze Welt beherrscht, alle äuser spaltet, alle
+Griechen noch der Barbaren jemals wie diese Kraft gezeigt hat — <supplied reason="undefined" resp="#editor">wie
+er</supplied> auch hierdurch die ganze Welt beherrscht, alle äuser spaltet, alle
 Geschlechter und alle Familien durchteilt und trennt, so ß die einen
 das Seine denken, die andern aber sich im Gegensatz dazu befinden.
 Er allein, unser öser und das Wort Gottes hat ßen, dieses zu <lb n="25"/>
 tun, und eben durch Taten die ßung ätigt. Er lehrte aber
 die Ursache der Seelenspaltung, die in den äusern geschenhen würde,
 wie wir irgendwo in dem Evangelium gefunden haben, das unter den
-Juden in äischer Sprache (verbreitet) ist, in dem es heißt: „Ich
-ähle *je die Besten mir aus, die mir mein Vater im Himmel gibt.“ <lb n="30"/>
+Juden in äischer Sprache <supplied reason="undefined" resp="#editor">verbreitet</supplied> ist, in dem es heißt: „Ich
+ähle <corr resp="#editor">je</corr> die Besten mir aus, die mir mein Vater im Himmel gibt.“ <lb n="30"/>
 Hieraus kann man lernen, wie sich in allen äusern, in denen das
 Wort Jesu siegt, die Besseren von den Schlechteren sondern. Wenn
 man also unter den üdern oder Sklaven und in allen Familien die
@@ -6893,12 +6897,12 @@ XXIV 66822.24 66938 Cramer I 81 zu Matth 10 34</note>
 und ß er nicht nur die Zukunft voraussagte, sondern ß er auch die
 Tat ügte zu seinem Worte, ächlich zu dem, was geschrieben steht:
 „Ich ähle mir je die Besten aus, die mir mein Vater im Himmel
-<lb n="5"/> gibt.“ Indessen aber (wenn es) jetzt (auch ßt): „Ich bin nicht gekommen,
+<lb n="5"/> gibt.“ Indessen aber <supplied reason="undefined" resp="#editor">wenn es</supplied> jetzt <supplied reason="undefined" resp="#editor">auch ßt</supplied>: „Ich bin nicht gekommen,
 Frieden auf die Erde zu bringen", so setzt er doch an einer
-andern (Stelle) seinen üngern auseinander und sagt: „Den Frieden lasse
+andern <supplied reason="undefined" resp="#editor">Stelle</supplied> seinen üngern auseinander und sagt: „Den Frieden lasse
 ich euch, meinen Frieden gebe ich euch. Nicht gebe auch ich ebenso <milestone unit="altnumbering" n="141"/>
 Heil, wie die Welt Heil gibt“, indem er in dieser Weise das Wissen
-<lb n="10"/> von Gott und die Liebe (zu ihm), die er bei seinen üngern förderte,
+<lb n="10"/> von Gott und die Liebe <supplied reason="undefined" resp="#editor">zu ihm</supplied>, die er bei seinen üngern förderte,
 und die Unerschrockenheit der Seele und die Klarheit und Festigkeit
 des Verstandes benennt. Dies also auch über dies. Was er aber auch
 über das Volk der Juden voraus ßte und voraus sagte, ist öglich,
@@ -6913,7 +6917,7 @@ Hohenpriester und Schriftgelehrten gemeinsam versammelt waren, sagte
 er, ährend er im Tempel selber verweilte, was sie in Zukunft gegen
 <lb n="20"/> ihn sich erdreisten ärden, und das Verderben, das sie wegen dieser
 Frechheit treffen ürde, versteckt auf diese Weise im Gleichnis
-„Es war (einmal) Ein Mann, ein Hausherr, (der) pflanzte einen Weinberg,
+„Es war <supplied reason="undefined" resp="#editor">einmal</supplied> Ein Mann, ein Hausherr, <supplied reason="undefined" resp="#editor">der</supplied> pflanzte einen Weinberg,
 setzte einen Zaun darum, grub eine Kelter darin und baute einen
 Turm darein, überließ ihn den Arbeitern und zog fort. Da aber die
 <lb n="25"/> Zeit der üchte nahte, sandte er seine Sklaven an die Arbeiter, ihm
@@ -6945,9 +6949,9 @@ und einem Volke gegeben werden, das üchte bringt.“ Dieses
 Gleichnis ist verwandt mit dem des Propheten Jesaja, bei dem es diese
 Form hat: „Einen Weinberg ß mein Geliebter auf dem Horn, an
 fettem Orte und er bearbeitete ihn, umgab ihn mit einem Zaun, pflanzte
-<milestone unit="altnumbering" n="142"/> *Reben darin und baute einen Turm in seine Mitte. Auch eine Kelter <lb n="15"/>
+<milestone unit="altnumbering" n="142"/> <corr resp="#editor">Reben</corr> darin und baute einen Turm in seine Mitte. Auch eine Kelter <lb n="15"/>
 machte er in ihm und hoffte, daß er Trauben bringe, aber er brachte
-Heerlinge." Aber das (Gleichnis) bei dem Propheten hat den Weinberg
+Heerlinge." Aber das <supplied reason="undefined" resp="#editor">Gleichnis</supplied> bei dem Propheten hat den Weinberg
 beschuldigt, den er auch seinem Wesen nach verdolmetscht, indem er
 sagt: „Denn der Weinberg des Herrn Zebaoth ist das Haus Israel und
 der Mann aus Juda ist die neue und geliebte Pflanze. Sie hoffte auf <lb n="20"/>
@@ -6961,16 +6965,16 @@ waren und örten, aber es ist keineswegs über den Weinberg
 gesagt, da der Prophet die Weissagung über diesen vorwegnehmend <lb n="25"/>
 ausgesprochen hatte. Das aber, was von dem Propheten verschwiegen
 wurde, das legte er in seinem Gleichnis nieder, ich meine aber das,
-was über die Arbeiter des Weinberges (geschrieben ist). Diese aber
+was über die Arbeiter des Weinberges <supplied reason="undefined" resp="#editor">geschrieben ist</supplied>. Diese aber
 waren die Altesten des Volkes, die Hohenpriester, Herrscher und Lehrer.
 Sie, die auch der ganzen Schar Ursache wurden ür das Sprossen <lb n="30"/>
 öser üchte, um derentwillen auch der Weinberg öde gelassen war —
 das ßt aber ihr ganzes Volk — und sein Zaun vernichtet ward, sie
-(sind es), die üher ämpfer des Volkes waren und das Volk mitsamt
-seinem Orte ützten, und der Turm in ihm (ist) der Tempel und
+<supplied reason="undefined" resp="#editor">sind es</supplied>, die üher ämpfer des Volkes waren und das Volk mitsamt
+seinem Orte ützten, und der Turm in ihm <supplied reason="undefined" resp="#editor">ist</supplied> der Tempel und
 die Kelter der Altar. Dies alles also wurde öllig von Grund aus zerstört, <lb n="35"/>
 weil vom Blute besudelt waren diejenigen Arbeiter, die die ersten
-und *letzten Sklaven, die zu ihnen geschickt wurden — offenbar die
+und <corr resp="#editor">letzten</corr> Sklaven, die zu ihnen geschickt wurden — offenbar die
 
 <note type="footnote">11—S. 186, 19 = 11. ück der griech. Theoph. S. 24 26—26 10 13 =
 Jes 51 f. 19 = Jes 57</note>
@@ -6979,8 +6983,8 @@ Jes 51 f. 19 = Jes 57</note>
 <pb n="v.3.pt.2.p.186"/>
 jeweiligen Propheten — öteten. Es legt aber Zeugnis ab über das
 Wort die alte Schrift und von den Propheten Elias, der im Gebet zu
-Gott sagt: „Herr, *deine Propheten haben sie ötet und *deine Altäre
-zerstört, ich aber blieb allein übrig und (selbst) meine Seele suchen sie
+Gott sagt: „Herr, <corr resp="#editor">deine</corr> Propheten haben sie ötet und <corr resp="#editor">deine</corr> Altäre
+zerstört, ich aber blieb allein übrig und <supplied reason="undefined" resp="#editor">selbst</supplied> meine Seele suchen sie
 <lb n="5"/> zu nehmen." Dies also klagt der Prophet in seinem Gebete wider die
 Herrscher des üdischen Volkes, denen aber ügte nicht die Besudelung
 mit dem Blute der Propheten, sondern sie öteten zuletzt auch den
@@ -7004,9 +7008,9 @@ und ist ein Wunder in unsern Augen?" öllig entsprechend zeigte er
 <lb n="25"/> nach der Voraussagung über seinen Tod seine Auferstehung von den
 Toten aus den prophetischen Zeugnissen. Denn er lehrte im voraus,
 ß der Sohn des Weinbergsbesitzers von ösen Arbeitern werde
-ötet werden. (Nachdem) er von ihnen den Urteilsspruch empfangen
-hatte, brachte er darauf folgendes (vor): „Der Stein, den die Erbauer
-<lb n="30"/> verwarfen, wurde zum Hauptgiebel des äudes“ und redete (so) prophetisch
+ötet werden. <supplied reason="undefined" resp="#editor">Nachdem</supplied> er von ihnen den Urteilsspruch empfangen
+hatte, brachte er darauf folgendes <supplied reason="undefined" resp="#editor">vor</supplied>: „Der Stein, den die Erbauer
+<lb n="30"/> verwarfen, wurde zum Hauptgiebel des äudes“ und redete <supplied reason="undefined" resp="#editor">so</supplied> prophetisch
 im ätsel über seine Auferstehung. Denn nachdem er von den
 Arbeitern, die auch Erbauer ßen), verworfen war, wurde er — der
 „kostbare Stein", von dem der Prophet Jesaja sagt: „Siehe, ich lege in
@@ -7024,8 +7028,8 @@ und sagte: „Das Reich Gottes wird von euch genommen und
 einem Volke gegeben werden, das üchte bringt", was mit dem von
 ihnen gesagten Worte übereinstimmt: „Er wird den Weinberg andern <lb n="5"/>
 Arbeitern geben, die ihm üchte liefern zu ihrer Zeit." Reich Gottes
-aber nannte er in diesen (Worten) die Sitte der Gottesverehrung, die
-von *jenen Arbeitern genommen wird, wie er sagte und sehr deutlich
+aber nannte er in diesen <supplied reason="undefined" resp="#editor">Worten</supplied> die Sitte der Gottesverehrung, die
+von <corr resp="#editor">jenen</corr> Arbeitern genommen wird, wie er sagte und sehr deutlich
 weissagte und zeigte. „Es wird aber einem anderen Volke gegeben
 werden, das üchte bringt": dies ist das Volk der Christen, das in der <lb n="10"/>
 ganzen örfung einer öttlichen ührung passende und würdige
@@ -7036,7 +7040,7 @@ und über das Ende eben dieser. Aus dem Evangelium des äus. <lb n="15"/></p>
 </div>
 
 <div type="textpart" subtype="chapter" n="15">
-<p>Nach dem (soeben) ähnten Gleichnis schreibt das Wort göttlicher
+<p>Nach dem <supplied reason="undefined" resp="#editor">soeben</supplied> ähnten Gleichnis schreibt das Wort göttlicher
 Schrift: „Da die Hohenpriester und die äqer siene Gleichnisse
 örten, erkannten sie, ß er über sie rede, und trachteten, ihn zu
 fassen, aber sie ürchteten sich vor dem Volke, weil sie ihn als einen
@@ -7052,7 +7056,7 @@ Acker, der andere in sein äft, die übrigen aber griffen seine knechte,
 ßhandelten und öteten sie. Der önig aber schickte
 sein Heer aus und ötete die örder, ihre Stadt aber verbrannte er. <lb n="30"/>
 Hierauf sagte er zu seinen Knechten: Meine Hochzeit ist fertig, die Geladenen
-aber waren es nicht wert. Geht *also hinaus auf Wege und
+aber waren es nicht wert. Geht <corr resp="#editor">also</corr> hinaus auf Wege und
 Stege und ruft zur Hochzeit, wen ihr findet. Und jene Knechte gingen
 hinaus auf die Wege und brachten zusammen alles, was sie fanden,
 Gute und Schlechte." Im ersten Gleichnis aber gab es einen Weinberg, <lb n="35"/>
@@ -7071,31 +7075,31 @@ Arbeiter, die an der Spitze des Volkes standen, öteten.</p>
 
 <div type="textpart" subtype="chapter" n="16">
 <p>Das
-(jetzige) vor unsern Augen liegende Gleichnis aber ührt eine Hochzeit
+<supplied reason="undefined" resp="#editor">jetzige</supplied> vor unsern Augen liegende Gleichnis aber ührt eine Hochzeit
 ein, eine Verbindung offenbar und Gemeinschaft des äutigams und
 der Braut und ein Hochzeitsmahl und wiederum auch hier Sklaven, die
 <lb n="10"/> geschlagen und ötet werden, und erste und letzte, de geladen
-Er zeigt aber durch diese (Worte) wiederum verborgen das, was nach
+Er zeigt aber durch diese <supplied reason="undefined" resp="#editor">Worte</supplied> wiederum verborgen das, was nach
 seiner Auferstehung von den Toten sich ereignen wird. Denn der äutigam
 ist der öttliche Logos und die Braut ist die ünftige Seele, <milestone unit="altnumbering" n="145"/>
 die sich mit ihm vereinigt und den öttlichen Samen von ihm empfängt,
-<lb n="15"/> und die öttliche und die ünftige Gemeinschaft (ist) die seiner
-Kirche, und darauf (folgt) das ünftige Gelage und Hochzeitsmahl
-öttlicher und himmlischer Speisen. Die Knechte aber (sind) hier Bitter.
+<lb n="15"/> und die öttliche und die ünftige Gemeinschaft <supplied reason="undefined" resp="#editor">ist</supplied> die seiner
+Kirche, und darauf <supplied reason="undefined" resp="#editor">folgt</supplied> das ünftige Gelage und Hochzeitsmahl
+öttlicher und himmlischer Speisen. Die Knechte aber <supplied reason="undefined" resp="#editor">sind</supplied> hier Bitter.
 Er redet keineswegs von denen, die üher zum Weinberg seschickt
 wurden, sondern von andern. Denn jenes waren die Propheten, dies
-<lb n="20"/> aber (sind) seine ünger, die geschickt wurden zuerst zu berufen diejenigen,
-die aus der Beschneidung (sind). Denn indem er sie ausschickt,
+<lb n="20"/> aber <supplied reason="undefined" resp="#editor">sind</supplied> seine ünger, die geschickt wurden zuerst zu berufen diejenigen,
+die aus der Beschneidung <supplied reason="undefined" resp="#editor">sind</supplied>. Denn indem er sie ausschickt,
 ermahnt er sie am Anfang und sagt: „Auf der ße der Heiden sollt
 ihr nicht ziehen und eine Stadt der Samariter nicht betreten, sondern
 geht vielmehr zu den verlorenen Schafen vom Hause Israel." Eben
 <lb n="25"/> diese also luden die Knechte zuvor ein. Da man aber auf die Berufung
 nicht örte, sandte er auch zum zweiten Male viele Verkündiger und
 Herolde des Evangeliums, die er nach den ölf Aposteln auserwáhlte,
-andere siebzig ünger, damit eben auch sie dem Volk der Juden suerst (die
-frohe Botschaft) ündigten und es beriefen zum Gelage der neuen
+andere siebzig ünger, damit eben auch sie dem Volk der Juden suerst <supplied reason="undefined" resp="#editor">die
+frohe Botschaft</supplied> ündigten und es beriefen zum Gelage der neuen
 <lb n="30"/> διαθήκη. Aber sie richteten nichts aus, weil diejenigen, die geladen
-waren, sich ümmerten um äfte, (weil) diese, nachdem man die
+waren, sich ümmerten um äfte, <supplied reason="undefined" resp="#editor">weil</supplied> diese, nachdem man die
 Berufung der Knechte nicht ört hatte, die einen mißhandelten und
 die andern öteten. In der Schrift kann man finden, wieviele von den
 üngern unseres ösers man in Jerusalem selbst und im übrigen
@@ -7119,20 +7123,20 @@ durch folgende Worte: „Der önig aber ward zornig über die
 ötete die örder, und ihre Stadt verbrannte er." Was ist offenbarer
 <milestone unit="altnumbering" n="146"/> als dies Vorher wissen und die Εrfüllung dieser Dinge? Denn das Heer
 der ömer kam nach kurzer Zeit, belagerte die Stadt und vernichtete
-den Tempel im Feuer. Und wessen war (dies Werk), wenn nicht des
-über allem (stehenden) önigs Gott? Deswegen ßt es: „Der König <lb n="15"/>
+den Tempel im Feuer. Und wessen war <supplied reason="undefined" resp="#editor">dies Werk</supplied>, wenn nicht des
+über allem <supplied reason="undefined" resp="#editor">stehenden</supplied> önigs Gott? Deswegen ßt es: „Der König <lb n="15"/>
 aber schickte sein Heer, ötete die örder und verbrannte die Stadt.“
 Bis jetzt also ist es öglich, mit eigenen Augen die Brandtrümmer der
 ätze <del>mit Augen</del> zu sehen, ür diejenigen, die nach dem orte
 reisen. Wie aber die örder der Apostel bei der Eroberung ergriffen
 wurden und die ührende Strafe erlitten, ist nicht ürdig zu sagen. <lb n="20"/>
-Man kann in der Schrift des *Juden Flavius Josephus das finden, was
+Man kann in der Schrift des <corr resp="#editor">Juden</corr> Flavius Josephus das finden, was
 ihnen geschah. Nach dem Morde dieser aber und nach der Eroberung
-der öniglichen Hauptstadt *taten diejenigen, die übrig geblieben waren
+der öniglichen Hauptstadt <corr resp="#editor">taten</corr> diejenigen, die übrig geblieben waren
 von den Knechten, — die zuvor von ihrem Herrn ört hatten, daß
 die ersten, die berufen waren, „es nicht wert waren: Geht vielmehr <lb n="25"/>
 hinaus auf die Wege und Stege und ruft jeden, den ihr findet, zur
-Hochzeit" — (taten) das, was ihnen aufgetragen war. Es sagte also zu
+Hochzeit" — <supplied reason="undefined" resp="#editor">taten</supplied> das, was ihnen aufgetragen war. Es sagte also zu
 ihnen unser öser nach seiner Auferstehung: „Gehet hin und lehret alle
 ölker in meinem Namen", und das sagte er, der üher befohlen hatte:
 „Auf der ße der Heiden sollt ihr nicht ziehen", sondern nur den <lb n="30"/>
@@ -7151,9 +7155,9 @@ in die ganze öpfung und ündeten allen Völkern die göttliche
 und himmlische Berufung und brachten zusammen, soviele sie fanden,
 öse und Gute. Niemand also darf sich wundern, wenn nicht alle diejenigen,
 die in der Kirche Christi versammelt sind, gut sind, sondern
-<lb n="5"/> auch öse durch Vermischung mit den Guten *vereinigt sind. Denn
+<lb n="5"/> auch öse durch Vermischung mit den Guten <corr resp="#editor">vereinigt</corr> sind. Denn
 auch dies war dem Vorauswissen unseres ösers nicht verborgen. Entsprechend
-aber (und) gemäß dem Vorauswissen erscheint auch dies,
+aber <supplied reason="undefined" resp="#editor">und</supplied> gemäß dem Vorauswissen erscheint auch dies,
 nachdem es in die Tat übergegangen ist. Er zeigt also, welches das
 Ende derer sein wird, die, obwohl ürdig, in seiner Kirche versammelt
 <lb n="10"/> sind; denn er lehrt hinterher im Gleichnis dies und sagt: „Und
@@ -7164,14 +7168,14 @@ hereingekommen, obwohl du kein Hochzeitskleid anhast? Er aber <milestone unit="a
 <lb n="15"/> schwieg. Darauf sprach der Κönig zu den Dienern: Fesselt ihm Ηände
 und Füße und bringt ihn hinaus in die äußerste Finsternis, dort wird
 sein Weinen und ähneknirschen. Denn viele sind berufen, wenige
-aber ählt.“ Eben mit (diesen) voraussagenden Worten unterwiew
+aber ählt.“ Eben mit <supplied reason="undefined" resp="#editor">diesen</supplied> voraussagenden Worten unterwiew
 er auch vorher diejenigen, die nicht recht in seiner Kirche leben.</p>
 <lb n="20"/> <p>Wiederum über die Verwerfung des üdischen Volkes.
 Aus dem äusevangelium.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="17">
-<p> „Ihr Schlangen (und) Otternbrut, wie wollt ihr der ölle
+<p> „Ihr Schlangen <supplied reason="undefined" resp="#editor">und</supplied> Otternbrut, wie wollt ihr der ölle
 entfliehen? Darum siehe, ich sende zu euch Propheten und Weise und
 Schriftgelehrte, und ihr werdet die einen öten und kreuzigen, die andern
 <lb n="25"/> in euren Synagogen ßeln und sie verfolgen von Stadt zu Stadt,
@@ -7195,20 +7199,20 @@ gesteinigt. Simon aber, der nach Jakobus den Bischofsthron von Jerusalem
 empfing, wurde, wie die Geschichte berichtet, dem Kreuz üdergeben,
 und ferner viele andere, die von den Juden ötet wurden, <lb n="5"/>
 versiegelten das Vorauswissen unsers ösers. Wegen aller dieser
-(Dinge) wurde das Geschlecht, das sich so sehr erfrechte, mit dem von
-Gott (stammenden) Gerichte bestraft, und (so) brachte es über sich selbst
-die äußersten (Folgen) all seiner Taten. Denn aus jenem Geschlecht wurde
+<supplied reason="undefined" resp="#editor">Dinge</supplied> wurde das Geschlecht, das sich so sehr erfrechte, mit dem von
+Gott <supplied reason="undefined" resp="#editor">stammenden</supplied> Gerichte bestraft, und <supplied reason="undefined" resp="#editor">so</supplied> brachte es über sich selbst
+die äußersten <supplied reason="undefined" resp="#editor">Folgen</supplied> all seiner Taten. Denn aus jenem Geschlecht wurde
 ausgerottet Tempel und Altar und wurde öst das Reich, das, von <lb n="10"/>
 den ätern her überliefert, bis zu jener Zeit bewahrt worden war, und
-die Freiheit von ihnen genommen. Eben durch Taten ward (jetzt) ersichtlich,
-sichtlich, ß die Strafe all des von jenem Geschlechte (vergossenen)
+die Freiheit von ihnen genommen. Eben durch Taten ward <supplied reason="undefined" resp="#editor">jetzt</supplied> ersichtlich,
+sichtlich, ß die Strafe all des von jenem Geschlechte <supplied reason="undefined" resp="#editor">vergossenen</supplied>
 Blutes der Gerechten den voraussagenden Worten unsers ösers Erlösers ent-
 <milestone unit="altnumbering" n="148"/> sprechend war. Es ist aber notwendig, zu sehen, mit wie ßer Vollmacht <lb n="15"/>
 und aus wie ßer Kraft gesagt ward: „Siehe ich sende zu euch
 Propheten und Weise". Denn das „Siehe ich sende" zeigt, ß es in
-Vollmacht Gottes (gesagt ward), und ß er den Herrschern der Juden
-ins Angesicht rief: „Ihr Schlangen (und) Otternbrut", war kein geringerer
-Beweis. Nach all diesen (Dingen) aber zeigte das voraussagende Wort <lb n="20"/>
+Vollmacht Gottes <supplied reason="undefined" resp="#editor">gesagt ward</supplied>, und ß er den Herrschern der Juden
+ins Angesicht rief: „Ihr Schlangen <supplied reason="undefined" resp="#editor">und</supplied> Otternbrut", war kein geringerer
+Beweis. Nach all diesen <supplied reason="undefined" resp="#editor">Dingen</supplied> aber zeigte das voraussagende Wort <lb n="20"/>
 über das Verderben, das sie erreichen sollte, die ätigung dieser
 Worte durch die üllung. Dies also genügend.</p>
 <p>Wohlan aber, entsprechend wollen wir üfen, wie er über das
@@ -7224,7 +7228,7 @@ gegen ihn, über die er sogar weinte in seiner Liebe.</p>
 <p>Wie das, was über das Volk der Juden vorausgesagt war, <lb n="30"/>
 üllung fand, ist im Vorhergehenden gezeigt worden. Da aber der
 Logos Gottes auch über ihre Orte weissagte, so üssen wir auch seine
-Worte über sehen (und üfen). Da sie seine reine Lehre nicht ertrugen
+Worte über sehen <supplied reason="undefined" resp="#editor">und üfen</supplied>. Da sie seine reine Lehre nicht ertrugen
 noch seinen Freimut noch seine Widerlegung, so bewirkten die
 <note type="footnote">1 vgl. Act 7 59 12 2 vgl. Euseb. Hist. eccles. II 1 5 23 16 4 vgl. Euseb
 Hist. eccles. II 25 5 16 ff. = Matth 23 33 f. 28 vgl. Luk 19 41 31—S. 194, 17
@@ -7238,7 +7242,7 @@ die, die zu dir gesandt sind, wie oft habe ich deine Kinder
 <lb n="5"/> sammeln wollen, wie eine Henne ihre üchlein sammelt unter ihre
 ügel, und ihr habt nicht gewollt! Siehe euer Haus wird öde gelassen.
 Ich sage euch aber: nimmermehr sollt ihr mich sehen von jetzt an, bis
-ß ihr sagt: Gesegnet, der da kommt im Namen des Herrn.“ (Da)
+ß ihr sagt: Gesegnet, der da kommt im Namen des Herrn.“ <supplied reason="undefined" resp="#editor">Da</supplied>
 eine schmutzige Besudelung in äterer Zeit von ihnen geschah — es
 <lb n="10"/> war dies aber der Frevel, den sie gegen unsern öser wagten — so
 war es ötig, ß nicht nur die Bewohner der Stadt, sondern auch das
@@ -7247,11 +7251,11 @@ was seine Bewohner taten; was sie auch bald darauf gelitten haben, als
 die ömer öber über die Stadt kamen und von den Bewohnern die einen
 <lb n="15"/> Kriegsrecht öteten, die andern durch Hunger vernichteten, andere in <milestone unit="altnumbering" n="149"/>
 die Gefangenschaft ührten, andere verfolgten <add>und an jeden Ort zerstreuten</add>
-ihr *Haus aber und ihren Tempel verbrannten und in die
+ihr <corr resp="#editor">Haus</corr> aber und ihren Tempel verbrannten und in die
 äußerste üstung warfen. Aber obwohl dies in äterer Zeit geschah,
 nahm unser öser die Zukunft durch Vorauswissen vorweg als Logos
-<lb n="20"/> Gottes (und) sagte das, was sich ereignen werde, durch die vorliegenden
-(Worte) voraus. Kinder der Stadt aber nennt er das ganze Volk der
+<lb n="20"/> Gottes <supplied reason="undefined" resp="#editor">und</supplied> sagte das, was sich ereignen werde, durch die vorliegenden
+<supplied reason="undefined" resp="#editor">Worte</supplied> voraus. Kinder der Stadt aber nennt er das ganze Volk der
 Juden und als ihr Haus bezeichnet er den Tempel. Dann bezeugt er,
 ß das Unheil ihnen nachfolgen werde durch ihre Veranlassung, das er
 oftmals ihre Kinder unter das Joch der ömmigkeit habe ssammeln
@@ -7276,7 +7280,7 @@ noch Gottes Haus ßen will, sondern das ihre. Er weissagte, daß es
 wird öde gelassen werden." Man ß sich wundern üher die Erfüllung
 des Wortes, weil zu keiner anderen Zeit jemals der Ort eine solche
 üstung erlitt, nicht einmal zu der Zeit, als er wegen der Vielheit
-ihrer Bosheit und ötzenverehrung und (wegen) der Besudelung mit
+ihrer Bosheit und ötzenverehrung und <supplied reason="undefined" resp="#editor">wegen</supplied> der Besudelung mit
 Prophetenblut von den Babyloniern ausgerottet wurde. Denn ährig
 ward die ganze Zeit der üstung des Ortes in jenen Jahren.
 Deswegen äre ihnen in jener Zeit nicht passend gesagt worden: „Siehe,
@@ -7291,14 +7295,14 @@ durch den Urteilsspruch Gottes in die äußerste üstung geriet, zeigt <lb n="15
 Wort, die üllung. Und die Zeit ist ährig und lang geworden,
 ß sie nicht nur das Doppelte ägt der siebzigjährigen verwüstung,
 die zur Zeit der Babylonier stattfand, sondern sogar das Vierfache
-überschreitet, und (so) ätigt sie den Urteilsspruch unsers <lb n="20"/>
+überschreitet, und <supplied reason="undefined" resp="#editor">so</supplied> ätigt sie den Urteilsspruch unsers <lb n="20"/>
 ösers. Wiederum aber auch zu anderer Zeit wandelte unser Erlöser
 um den besagten Tempel und, als seine ünger die Gebäude bewunderten,
 die ihn umgeben, und die öße und önheit des Tempels selbst,
-zeigten sie (es) ihm. „Der aber antwortete ihnen und sprach: Seht
+zeigten sie <supplied reason="undefined" resp="#editor">es</supplied> ihm. „Der aber antwortete ihnen und sprach: Seht
 ihr nicht dies alles? Ich sage euch, es soll hier nicht ein Stein auf <lb n="25"/>
 dem anderen gelassen werden, der nicht öst ürde.“ Daß aber
-wahrlich bewundernswert war das ganze äude und der ganze *andere
+wahrlich bewundernswert war das ganze äude und der ganze <corr resp="#editor">andere</corr>
 Schmuck des dortigen Tempels, zeigen die Schriften. Des Beweises
 halber aber ist bis jetzt ein Uberrest aufbewahrt, durch den die Spuren
 der alten ände wahrgenommen werden. Das allergrößte <lb n="30"/>
@@ -7306,7 +7310,7 @@ Wunder aber ist die öttliche Stimme des des Vorherwissebns unsers Erlösers,
 die den Urteilsspruch ällte entsprechend denen, die das Gebäude
 bewunderten, daß an dem Orte, den sie bewunderten, kein Stein auf
 dem anderen ört gelassen ürde. Denn der Ort müsse um der
-Frechheit *seiner Bewohner willen ändige Vernichtung und Ver- <lb n="35"/>
+Frechheit <corr resp="#editor">seiner</corr> Bewohner willen ändige Vernichtung und Ver- <lb n="35"/>
 <note type="footnote">12 = Hag 29 21 vgl. Matth 24 1 24 = Matth 24 2</note>
 <note type="footnote">16 ἡ ὄψις αὐτὴ τοῦ λόγου μᾶλλον δείκνυσι τὸ ἀποτέλεσμα Th. gr. „die üllung
 des Wortes" Σ 27 τά τε τῆς ἄλλης κατασκευῆς Th. gr.] 1. <foreign xml:lang="abbr">ABBREV</foreign>
@@ -7315,11 +7319,11 @@ Eusebiua III*.</note>
 
 <pb n="v.3.pt.2.p.194"/>
 wüstung erdulden, da er eine Wohnung gottloser änner sei. Wie aber
-*die (Worte) der Prophezeiung in die Tat übergingen und (wie) der
-ganze Tempel und seine Mauer und *die schmuckvollen und önen
+<corr resp="#editor">die</corr> <supplied reason="undefined" resp="#editor">Worte</supplied> der Prophezeiung in die Tat übergingen und <supplied reason="undefined" resp="#editor">wie</supplied> der
+ganze Tempel und seine Mauer und <corr resp="#editor">die</corr> schmuckvollen und önen
 äude in ihm, die jedes Wort in den Schatten stellen, eine Verwüstung
-<lb n="5"/> von jener Zeit bis heute ertrugen und (wie) mit den Zeiten die Kraft
-des Logos immer mehr vernichtet, ß nicht einmal (mehr) Spuren
+<lb n="5"/> von jener Zeit bis heute ertrugen und <supplied reason="undefined" resp="#editor">wie</supplied> mit den Zeiten die Kraft
+des Logos immer mehr vernichtet, ß nicht einmal <supplied reason="undefined" resp="#editor">mehr</supplied> Spuren
 der Fundamente an einigen Orten gesehen werden, kann, wer will, mit
 Augen sehen. Wenn aber jemand sagt, ß noch einige Orte bestehen,
 so ist es dennoch notwendig, auch ihre Vernichtung zu erwarten, da
@@ -7337,18 +7341,18 @@ Folgendes über die örer des Ortes.</p></div>
 <div type="textpart" subtype="chapter" n="19">
 <p><milestone unit="altnumbering" n="151"/> „Als er die Stadt sah, weinte er über sie und sagte: Wenn
 <lb n="20"/> du erkannt ättest, wenn auch nur an diesem Tage, was zu deinem
-Frieden (dient); jetzt aber ward es vor deinen Augen verborgen. Es
+Frieden <supplied reason="undefined" resp="#editor">dient</supplied>; jetzt aber ward es vor deinen Augen verborgen. Es
 werden Tage über dich kommen, wo deine Feinde dich umgeben, dich
 umzingeln und von allen Seiten ängen werden. <add>Und</add> sie werden
-dich ausrotten und deine Kinder in dir." Das Vorher(gehende) wurde
+dich ausrotten und deine Kinder in dir." Das Vorher<supplied reason="undefined" resp="#editor">gehende</supplied> wurde
 <lb n="25"/> über den Tempel geweissagt, das Vorliegende aber über die Stadt selbst,
 welche die Juden eine „Stadt Gottes“ nannten wegen des in ihr erbauten
 Tempels Gottes. Er weinte aber über die ganze <add>Stadt</add>, der
-Mitleidige, indem er nicht so (sehr) mit ihren äuden noch mit dem
-Erdboden als (vielmehr) mit den Seelen ihrer einstigen Bewohner und
+Mitleidige, indem er nicht so <supplied reason="undefined" resp="#editor">sehr</supplied> mit ihren äuden noch mit dem
+Erdboden als <supplied reason="undefined" resp="#editor">vielmehr</supplied> mit den Seelen ihrer einstigen Bewohner und
 <lb n="30"/> mit ihrem Untergang Mitleid hatte. Er legt aber auch die Ursache
 ihrer üstung dar, indem er sagt: „Wenn du üßtest, wenn auch
-nur an diesem Tage, das, was zu deinem Frieden (dient)". Er zeigt
+nur an diesem Tage, das, was zu deinem Frieden <supplied reason="undefined" resp="#editor">dient</supplied>". Er zeigt
 aber, ß sein Kommen zum Frieden der ganzen Welt geschah. Denn
 <note type="footnote">19—24 = Luk 19 41—44 24—S. 195, 12 = 12. Bruchstück der griech.
 Theoph. S. 29 6—3010 26 vgl. Ps 46 (LXX: 45)5 31 = Luk 19 42</note>
@@ -7363,25 +7367,25 @@ und sagte denen, die ihn aufnahmen: „Den Frieden lasse ich euch,
 meinen Frieden gebe ich euch", den Frieden, den alle ölker in der <lb n="5"/>
 ganzen öpfung, die an ihn glaubten, angenommen haben. Das Volk
 aus der Beschneidung aber, das nicht an ihn glaubte, erkannte nicht
-die (Dinge) seines Friedens. Deswegen sagt er hinterher: „Jetzt ist es
+die <supplied reason="undefined" resp="#editor">Dinge</supplied> seines Friedens. Deswegen sagt er hinterher: „Jetzt ist es
 verborgen vor deinen Augen, ß Tage über dich kommen und deine
 Feinde dich umgeben werden." Das also, was sie in kurzer Zeit erreichen <lb n="10"/>
 sollte in der Belagerung, weil sie nicht <del>vorher</del> merkten auf den Frieden.
 der ihnen vorher ündigt war. war vor ihren Augen verborgen. Sie
 also sahen voraus, was ihnen nachher geschah, er aber weissagte dies
-deutlich durch (sein) Vorauswissen und zeigte die Eroberung, die sie
+deutlich durch <supplied reason="undefined" resp="#editor">sein</supplied> Vorauswissen und zeigte die Eroberung, die sie
 von selten der ömer treffen ürde, deutlich vorher: „Denn es werden <lb n="15"/>
 Tage über dich kommen," weil du nicht erkannt hast, das „was zu
-deinem Frieden (dient)". Denn um dieser Ursache willen „werden Tage
+deinem Frieden <supplied reason="undefined" resp="#editor">dient</supplied>". Denn um dieser Ursache willen „werden Tage
 über dich kommen und deine Feinde werden dich umgeben, dich umzingeln
 und dich von allen Seiten ängen, und sie werden dich ausroten
 und deine Kinder in dir." Er beschreibt aber hierdurch die Ar
 <milestone unit="altnumbering" n="152"/> des Krieges, der gegen sie ührt) werden sollte. Wie dies zur Erfüllung
 kam, kann man aus der Schrift des Josephus Stsehen, der ein
 Jude war und in einer Familie eben der Juden geboren war von bekannten
-und ühmten ännern im Volk (und) der um die Zeit der
+und ühmten ännern im Volk <supplied reason="undefined" resp="#editor">und</supplied> der um die Zeit der
 Belagerung alles das, was bei ihnen geschah, niederschrieb und zeigte. <lb n="25"/>
-ß es in der Tat den uns vor (liegenden) voraussagenden Worten
+ß es in der Tat den uns vor <supplied reason="undefined" resp="#editor">liegenden</supplied> voraussagenden Worten
 entspreche.</p>
 <p>Wiederum über die Eroberung der Stadt. Aus dem Evangelium des Lukas.</p>
 </div>
@@ -7390,7 +7394,7 @@ entspreche.</p>
 <p> „ Wenn ihr", sagt er, „Jerusalem umgeben seht von einem
 Heer, so wisset, ß seine üstung nahe ist. Hierauf sollen diejenigen, <lb n="30"/>
 die in Juda sind, entrinnen auf den Berg, und diejenigen, die
-drinnen sind, fliehen, und diejenigen, die *auf dem Lande sind, nicht
+drinnen sind, fliehen, und diejenigen, die <corr resp="#editor">auf</corr> dem Lande sind, nicht
 hineingehen nach innen, weil es die Tage der Vergeltung sind zu er-
 <note type="footnote">1 = Ps 72 (LXX: 71)7 3 = Jes 57 19 4 = Joh 14 27 8 = Luk 19 42 f.
 15. 17 = Luk 19 43 f. 29—S. 196, 6 = Luk 21 20—24</note>
@@ -7403,7 +7407,7 @@ Säugenden in jenen Tagen; den es wird große Not sein auf der Erde
 Und großer Zorn über dieses Volk. Und sie warden fallen durch die
 Schneide des Schwertes und warden gefangen geführt warden unter alle
 <lb n="5"/> Völker, und Jerusalem wird zertreten warden von den Völkern, bis daß
-Die Zeiten der Völker erfüllt warden“, so gibt er durch das uns (jetzt)
+Die Zeiten der Völker erfüllt warden“, so gibt er durch das uns <supplied reason="undefined" resp="#editor">jetzt</supplied>
 Vorliegende die Zeichen der Zeit der äußersten Verwüstung des Ortes, was
 Er zeight, indem er sagt: „Wenn ihr Jerusalem umgeben seht von einem
 <lb n="10"/> Heer, dann wisest, daß seine Verwüstung nahe ist.“ Denn niemand, sagt
@@ -7411,23 +7415,23 @@ Er, möge hoffen, daß nach der eintretenden Eroberung und der dabei eintretende
 Verwüstung des Ortes eine andere Erneuerung ihm werde zu teil
 Warden unter Antionchus Epiphanes und wiederum unter Pompejus. Denn
 <lb n="15"/> oftmals erlitt der Ort eine Eroberung und wurde späterhin einer besseren
-Erneuerung gewürdigt. Aber erkennt, daß (jetzt) die äußerste Verwüstung
+Erneuerung gewürdigt. Aber erkennt, daß <supplied reason="undefined" resp="#editor">jetzt</supplied> die äußerste Verwüstung
 Und vollständige Vernichtung über ihn kommen werde, „wenn
 Ihr ihn von Heeren belagert seht.“ Eine Verwüstung Jerusalem saber
 Nennt er die Vernichtung des Tempels und die Aufhebung dessen, was
 <lb n="20"/> früher in ihm nach dem Gesetz des Mose gottesdienstlich vollzogen
 Wurde. Denn nicht mögest du glauben, daß eine Verwüstung der Stadt
-Selbst durch diese (Worte) ausgedrückt sei, als ob niemand mehr in ihr
+Selbst durch diese <supplied reason="undefined" resp="#editor">Worte</supplied> ausgedrückt sei, als ob niemand mehr in ihr
 Wohnen werde. Denn er sagt hinterher, daß die Stadt bewohnt warden
 Wird, nicht von den Juden, sondern von den Völkern, indem er so sagt:
-<lb n="25"/> „Jerusalem wird zertreten warden von den Völkern“, und *deher weiß
+<lb n="25"/> „Jerusalem wird zertreten warden von den Völkern“, und <corr resp="#editor">deher</corr> weiß
 Er, daß sie bewohnt sein wird von den Völkern. Ihre Verwüstung aber
-Nennt er (die Tatsache), daß sie nicht mehr von ihren Kindern (bewohnt
-Wird) und daß kein gesetzlicher Gottesdienst in ihr besteht. Wie aber <milestone unit="altnumbering" n="153"/>
+Nennt er <supplied reason="undefined" resp="#editor">die Tatsache</supplied>, daß sie nicht mehr von ihren Kindern <supplied reason="undefined" resp="#editor">bewohnt
+Wird</supplied> und daß kein gesetzlicher Gottesdienst in ihr besteht. Wie aber <milestone unit="altnumbering" n="153"/>
 Auch dies erfüllt wurde, bedarf nicht vieler Worte, da man mit Augen
 <lb n="30"/> sehen kann, daß die Juden unter alle Völker zerstreut sind, und daß
-Fremde und Andersgeschlechtige Bewohner der  (Stadt) sind, die einst
-Jerusalem (hieß), jetzt aber von dem *Eroberer Aelius Hadrianus: Aelia
+Fremde und Andersgeschlechtige Bewohner der  <supplied reason="undefined" resp="#editor">Stadt</supplied> sind, die einst
+Jerusalem <supplied reason="undefined" resp="#editor">hieß</supplied>, jetzt aber von dem <corr resp="#editor">Eroberer</corr> Aelius Hadrianus: Aelia
 Genannt ist. Das Wunderbare also an seiner Prophezeiung ist, daß er
 <note type="footnote">6 = Luk 13 35 7–S. 198, 2 = 12. Bruchstück der griech. Theoph.
 S. 30 12–32 6 9. 17 =  Luk 21 20 25 = Luk 21 24 32 vgl. Euseb. Hist.
@@ -7462,14 +7466,14 @@ Wortes unsere Erlössers: „ Wehe aber den Schwangeren
 den Säugenden in jenen Tagen“ deutlich zeigt und berichtet,
 ihre Kinder im Feuer brieten und aßen wegen der Stärke
 der die Stadt erfaßt hatte. Eben ihn also, den Hunger, der über
-Stadt kommen werde, sah unser Erlöser *voraus und riet (daher) seinen <note type="marginal">25</note>
+Stadt kommen werde, sah unser Erlöser <corr resp="#editor">voraus</corr> und riet <supplied reason="undefined" resp="#editor">daher</supplied> seinen <note type="marginal">25</note>
 Jüngern, bei der Belagerung, die über die Juden kommen sollte,
 Zuflucht nicht zur Stadt zu nehmen als zu einem festen und von Gott
 beschützten Orte, was den meisten widerfahren ist, sondern sich von
 <milestone unit="altnumbering" n="154"/> wegzuwenden und auf die Berge zu fliehen, und diejenigen inmitten
 Judäas sollen zu den Völkern entweichen und diejenigen in seinen <note type="marginal">30</note>
-Land(gebieten) sollen nicht ihre Zuflucht nehmen zu ihm (zu Jerusalem)
-wie zu einem festen Ort. Deswegen sagt er: „Die *auf dem Lande (sind),
+Land<supplied reason="undefined" resp="#editor">gebieten</supplied> sollen nicht ihre Zuflucht nehmen zu ihm <supplied reason="undefined" resp="#editor">zu Jerusalem</supplied>
+wie zu einem festen Ort. Deswegen sagt er: „Die <corr resp="#editor">auf</corr> dem Lande <supplied reason="undefined" resp="#editor">sind</supplied>,
 <note type="footnote">1 2. 12 = Luk 21 24 16 = Luk 21 23 f. 20 vgl. Jos. bell. Jud. VT 3
 21 = Luk 2123 32 = Luk 21 21 f.</note>
 <note type="footnote">6 καὶ τῷ πάλαι θρησκευομένῳ παρ’ αὐτοῖς τόπῳ Th. gr. „und den Ort der
@@ -7481,37 +7485,37 @@ haben" Σ 32 „auf dem Lande"] <foreign xml:lang="abbr">ABBREV</foreign> Bernst
 <pb n="v.3.pt.2.p.198"/>
 sollen nicht hineingehen nach innen, weil es Tage der Vergeltung sind.
 zu erfüllen alles, was geschrieben ist."</p>
-<p>Wer Lust hat, kann also die Erfüllung dieser (Dinge) aus der Schrift
+<p>Wer Lust hat, kann also die Erfüllung dieser <supplied reason="undefined" resp="#editor">Dinge</supplied> aus der Schrift
 des Josephus lernen. Wenn es aber recht ist, daß wir, sei es auch nur
 <lb n="5"/> in Kürze, auch in dieser Schrift um des Zeugnisses willen von ihm
-(etwas) hersetzen, so hindert nichts, den Schriftsteller selbst zu hören,
+<supplied reason="undefined" resp="#editor">etwas</supplied> hersetzen, so hindert nichts, den Schriftsteller selbst zu hören,
 der in dieser Weise schreibt:</p>
-<p>Aus dem sechsten (Buch) der Schrift des Josephus.</p>
+<p>Aus dem sechsten <supplied reason="undefined" resp="#editor">Buch</supplied> der Schrift des Josephus.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="21">
 <p> „Was habe ich nötig, die Schamlosigkeit des Hungers gegen
-<lb n="10"/> die seelenlosen (Dinge) auszusagen. Denn ich gehe daran, ein Werk
-(von ihm) zu Künden, wie es weder bei Griechen noch bei Barbaren
+<lb n="10"/> die seelenlosen <supplied reason="undefined" resp="#editor">Dinge</supplied> auszusagen. Denn ich gehe daran, ein Werk
+<supplied reason="undefined" resp="#editor">von ihm</supplied> zu Künden, wie es weder bei Griechen noch bei Barbaren
 beschrieben ist. Denn es ist furchtbar zu sagen und unglaublich zu hören.
 Ich würde, damit es nicht scheine, als ob ich den späteren Menschen
 Lügen erzählte, die leidvolle Sache vielleicht gern übergehen, wenn ich
 <lb n="15"/> nicht viele zeitgenössische Zeugen hätte. Hauptsächlich aber würde ich
 meinem Vaterlande eine laue Gnade erweisen, wenn ich zu erwähnen unterließe
 was es in der Tat litt. Ein Weib von denen, die jenseits des Jordans
-wohnen, mit Namen Maria, bekannt wegen ihrer (vornehmen) Familie
+wohnen, mit Namen Maria, bekannt wegen ihrer <supplied reason="undefined" resp="#editor">vornehmen</supplied> Familie
 und ihres Reichtums, nahm mit vielen ihre Zuflucht zu Jerusalem und
-<lb n="20"/> wurde mit ihnen belagert. Die einen Besitztümer dieser (Frau), soviel
+<lb n="20"/> wurde mit ihnen belagert. Die einen Besitztümer dieser <supplied reason="undefined" resp="#editor">Frau</supplied>, soviel
 sie von Peräa fortgeschafft und in die Stadt gebracht hatte, raubten die
-Tyrannen, den Rest ihres Schatzes aber, selbst wenn (etwas) Nahrung
+Tyrannen, den Rest ihres Schatzes aber, selbst wenn <supplied reason="undefined" resp="#editor">etwas</supplied> Nahrung
 rung ausfindig gemacht war, raubten die Soldaten, indem sie täglich
 hineinsprangen. Gewaltiger Grimm aber kam über das Weib und oftmals
 <lb n="25"/> reizte sie die Räuber wider sich, wenn sie schmähte und fluchte.
 Da aber niemand weder im Grimm noch aus Mitleid sie tötete, und
-(da) sie müde ward, für andere etwas Nahrung zu finden, (und) von
-allen Seiten *außer stande war, überhaupt zu finden, und da der Hunger
+<supplied reason="undefined" resp="#editor">da</supplied> sie müde ward, für andere etwas Nahrung zu finden, <supplied reason="undefined" resp="#editor">und</supplied> von
+allen Seiten <corr resp="#editor">außer</corr> stande war, überhaupt zu finden, und da der Hunger
 durch ihr Inneres und ihre Eingeweide zog und ihr Grimm mehr als
-<lb n="30"/> der Hunger entbrannte, *so nahm sie den Drang mitsamt dem Zwang
+<lb n="30"/> der Hunger entbrannte, <corr resp="#editor">so</corr> nahm sie den Drang mitsamt dem Zwang
 zum Berater, ging gegen die Natur an, ergriff ihren Sohn — sie hatte
 <note type="footnote">9–S. 199, 8 Jos. Jos. bell. Jud. VI 3 3; Euseb. Hist. eccles. III 6 20—25</note>
 <note type="footnote">15 ἄλλως τε καὶ] „anders aber auch" Σ 21 ὅσην ἐκ τῆς Περαίας ἀνασκευασαμένη
@@ -7535,10 +7539,10 @@ den Schwangeren und den Säugenden in jenen Tagen“. Da aber auch
 dies den voratissagenden Worten unsers Erlösers hinzugefügt ist: „Es
 wird eine große Not sein auf Erden und ein großer Zorn über dies
 Volk“ oder wie Matthäus sagt: „Denn es wird in jener Zeit eine große
-Xot sein, dergleichen es nicht gegeben hat seit Anfang der Welt *bis <lb n="15"/>
+Xot sein, dergleichen es nicht gegeben hat seit Anfang der Welt <corr resp="#editor">bis</corr> <lb n="15"/>
 jetzt und nicht sein wird“, so ist es recht, von dem Schriftsteller zu
 hören, wie er die Erfüllung eben dieser Dinge so beschreibt:</p>
-<p>Aus dem fünften (Buch) der Schrift des Josephus.</p>
+<p>Aus dem fünften <supplied reason="undefined" resp="#editor">Buch</supplied> der Schrift des Josephus.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="22">
@@ -7546,10 +7550,10 @@ hören, wie er die Erfüllung eben dieser Dinge so beschreibt:</p>
 Um es aber zusammenfassend zu sagen: keine andere Stadt hat so viel <lb n="20"/>
 gelitten und kein Geschlecht ist jemals zeugungskräftiger gewesen an
 Bosheit als dies. Denn die Stadt zerstörten sie selbst und erzwangen,
-daß den Römern eine traurige Sieg(estat) wider Willen zugeschrieben
+daß den Römern eine traurige Sieg<supplied reason="undefined" resp="#editor">estat</supplied> wider Willen zugeschrieben
 wurde, und schleppten das fast zögernde Feuer zum Tempel. In der Tat
 sahen sie ihn von der oberen Stadt aus brennen, ohne zu klagen und <lb n="25"/>
-zu weinen.“ Dies (geschah) wegen des (Wortes): „Es wird in jener Zeit
+zu weinen.“ Dies <supplied reason="undefined" resp="#editor">geschah</supplied> wegen des <supplied reason="undefined" resp="#editor">Wortes</supplied>: „Es wird in jener Zeit
 eine große Not sein, dergleichen es nicht gegeben hat seit Anfang der
 <note type="footnote">9— S. 200, 7 = 13. Bruchstück der griech. Theoph. 10. 12 = Luk 21 23
 14 = Matth 24 21 19—26 = Jos. bell. Jud. V 10 5 26 = Matth 24 21</note>
@@ -7564,7 +7568,7 @@ sahen sie von der oberen Stadt“ Σ</note>
 
 <pb n="v.3.pt.2.p.200"/>
 Welt“, was. ebenfalls von unserm Erlöser vorausgesagt, der Schriftsteller
-bestätigt hat als *ganze vierzig Jahre später in der Zeit des
+bestätigt hat als <corr resp="#editor">ganze</corr> vierzig Jahre später in der Zeit des
 römischen Königs Vespasian erfüllt. Es fügt aber unser Erlöser seinen
 voraussagenden Worten hinzu und bestimmt die Zeit, bis wann Jerusalem
 <lb n="5"/> niedergetreten sein soll von den Völkern. Denn er sagt, „bis
@@ -7579,23 +7583,23 @@ des Johannes.</note>
 <div type="textpart" subtype="chapter" n="23">
 <p>In der Nähe der uns benachbarten Stadt, in dem palästinischen
 Neapel — einer keineswegs kleinen, sondern sogar berühmten
-Stadt — traf ihn ein samaritisches Weib und sagte nach (einigen) anderen
+Stadt — traf ihn ein samaritisches Weib und sagte nach <supplied reason="undefined" resp="#editor">einigen</supplied> anderen
 <lb n="15"/> Worten zu ihm: „Herr, ich sehe, daß du ein Prophet bist. Unsere
 Väter haben auf diesem Berge angebetet, und ihr sagt, daß in Jerusalem
 der Ort sei, wo man anbeten müsse.“ Darauf antwortete unser Erlöser
 und sagte zu ihr: „Glaube mir, Weib, es kommt die Stunde, wo ihr
 weder auf diesem Berge noch in Jerusalem werdet den Vater anbeten.“
-<lb n="20"/> Kurz darauf sagt er: „Es kommt die Stunde und ist (schon) jetzt, wo
+<lb n="20"/> Kurz darauf sagt er: „Es kommt die Stunde und ist <supplied reason="undefined" resp="#editor">schon</supplied> jetzt, wo
 die wahrhaftigen Anbeter den Vater anbeten werden im Geist und in
 der Wahrheit. Denn auch der Vater verlangt solche Anbeter. Gott ist
 Geist, und die ihn anbeten, müssen ihn im Geist und in der Wahrheit
 anbeten.“ Auch hierin zeigte er ein durchaus nicht gewöhnliches Vorauswissen.
 <lb n="25"/> Denn früher, in den Tagen des römischen Königs Tiberius, zu
-dessen Zeit dies gesagt wurde, waren die Juden (für sich) gesondert in
+dessen Zeit dies gesagt wurde, waren die Juden <supplied reason="undefined" resp="#editor">für sich</supplied> gesondert in
 Jerusalem vereinigt, um das Gebot ihres Gesetzes zu erfüllen, während
-die Samariter auf dem (so)genannten Berge Garizim, in der Nähe von
-Neapel, (Gott) ehrten und behaupteten, man müsse das Gesetz des
-<lb n="30"/> Mose dort erfüllen. Diese Berge wurden als die geweihten (Stätten)
+die Samariter auf dem <supplied reason="undefined" resp="#editor">so</supplied>genannten Berge Garizim, in der Nähe von
+Neapel, <supplied reason="undefined" resp="#editor">Gott</supplied> ehrten und behaupteten, man müsse das Gesetz des
+<lb n="30"/> Mose dort erfüllen. Diese Berge wurden als die geweihten <supplied reason="undefined" resp="#editor">Stätten</supplied>
 Gottes auf beiden Seiten verherrlicht und über beide legt die Schrift
 Zeugnis ab, bei ihnen: Mose über den Garizim, bei den Hebräern aber:
 die Propheten über Jerusalem. Ein Urteilsspruch aber der göttlichen
@@ -7607,35 +7611,35 @@ Stimme unsers Erlösers ging aus, daß fortan nicht mehr anbeten würden
 
 <pb n="v.3.pt.2.p.201"/>
 hielten. Dies fand nicht lange darauf in der folgenden Zeit statt. Diese
-beiden Berge wurden (nämlich) durch die Belagerung in den Tagen des
+beiden Berge wurden <supplied reason="undefined" resp="#editor">nämlich</supplied> durch die Belagerung in den Tagen des
 Titus Vespasianus und in den Tagen Hadrians entsprechend seinen
 Worten verwüstet. Denn der Tempel in der Nähe der Stadt Neapel
 ward durch unziemliche Bilder, Götzen, Opfer und blutvergießen be <lb n="5"/>
 fleckt und beschmutzt, derjenige aber in Jerusalem bestand so lange Zeit,
-wie (eben) gesagt ist, und wurde (dann) von Grund aus durch äußerste Verwüstung
-<milestone unit="altnumbering" n="157"/> und Brand zerstört. Durch die Tat (also) wurde von jener Zeit
+wie <supplied reason="undefined" resp="#editor">eben</supplied> gesagt ist, und wurde <supplied reason="undefined" resp="#editor">dann</supplied> von Grund aus durch äußerste Verwüstung
+<milestone unit="altnumbering" n="157"/> und Brand zerstört. Durch die Tat <supplied reason="undefined" resp="#editor">also</supplied> wurde von jener Zeit
 an bis jetzt die Prophezeiung unsers Erlösers erfüllt, die lautete: „Es
 kommt die Stunde, wo ihr weder auf diesem Berge noch in Jerusalem <lb n="10"/>
 werdet anbeten.“ „Stunde“ aber nannte er die Zeit, die noch nicht nahe
-war, sondern (erst) kommen sollte. Über den vernünftigen Gottesdienst
-aber, der von ihm seinen Jüngern *überliefert wurde, fügte er hinzu
-und sagte: „Es kommt die Stunde und ist (schon) jetzt, wo die wahrhaftigen
+war, sondern <supplied reason="undefined" resp="#editor">erst</supplied> kommen sollte. Über den vernünftigen Gottesdienst
+aber, der von ihm seinen Jüngern <corr resp="#editor">überliefert</corr> wurde, fügte er hinzu
+und sagte: „Es kommt die Stunde und ist <supplied reason="undefined" resp="#editor">schon</supplied> jetzt, wo die wahrhaftigen
 Anbeter den Vater anbeten werden im Geist und in der Wahrheit.“ <lb n="15"/>
-Notwendig aber fügte er hier hinzu: „und ist (schon) jetzt.“
+Notwendig aber fügte er hier hinzu: „und ist <supplied reason="undefined" resp="#editor">schon</supplied> jetzt.“
 Denn auf der Stelle von der Stunde an, wo er die Worte sagte, überlieferten
 die wahrhaften Anbeter eben jenes Meisters und Lehrers und
 seine Jünger, die von ihm den vernünftigen Gottesdienst empfingen,
-einen Gottesdienst im Geist und in der Wahrheit. Der über alles (waltende) <lb n="20"/>
+einen Gottesdienst im Geist und in der Wahrheit. Der über alles <supplied reason="undefined" resp="#editor">waltende</supplied> <lb n="20"/>
 Logos wies jirophczeiend darauf hin, daß fortan die wahrhaften
-Verehrer den über alles (waltenden) Gott nicht auf einem Berge noch
-in einem Winkel der Erde (für sich) gesondert, sondern in der ganzen
+Verehrer den über alles <supplied reason="undefined" resp="#editor">waltenden</supplied> Gott nicht auf einem Berge noch
+in einem Winkel der Erde <supplied reason="undefined" resp="#editor">für sich</supplied> gesondert, sondern in der ganzen
 Welt anbeten und ihm die göttlichen, unblutigen Gottesdienste leisten
 sollten, die im Geist und in der Wahrheit vollendet werden, weder durch <lb n="25"/>
-Bilder noch durch irgend welche (äußere) Zeichen, wie es die (Gottesdienste)
+Bilder noch durch irgend welche <supplied reason="undefined" resp="#editor">äußere</supplied> Zeichen, wie es die <supplied reason="undefined" resp="#editor">Gottesdienste</supplied>
 des Mose waren, die von den Juden und Samaritern gehalten
 wurden: durch Schlachtungen, Opfer, Weihrauch, Feuer und viele andere
 leibliche Mittel. Daß sie eben dies abschaffen würden, prophezeite
-der Logos Gottes in den vorliegenden (Aussprüchen) und sagte, daß die <lb n="30"/>
+der Logos Gottes in den vorliegenden <supplied reason="undefined" resp="#editor">Aussprüchen</supplied> und sagte, daß die <lb n="30"/>
 wahrhaftigen Verehrer fortan in der Wahrheit und im Geiste, das heißt
 aber nach göttlicher Art, in der Seele und im Gedanken den gottgeziemenden
 Gottesdienst leisten würden.</p>
@@ -7657,12 +7661,12 @@ Meinen kennen mich, wie mich mein Vater kennt und ich meinn Vater
 <lb n="5"/> kenne, und ich lasse mein Leben für meine Schafe. Und andere Schafe
 habe ich, die nicht aus diesem Hofe sind. Ich muß sie führen, und sie
 hören auf meine Stimme, und es wird sein Eine Herde und Ein Hirt.“
-An einer andern (Stelle) lehrte er und sprach: „Ich bin nur gekommen
+An einer andern <supplied reason="undefined" resp="#editor">Stelle</supplied> lehrte er und sprach: „Ich bin nur gekommen
 zu den irrenden Schafen aus dem Hause Israel.“ Er nannte aber das
 <lb n="10"/> Volk der Juden in dieser Weise und prophezeite durch die vorliegenden
-(Aussprüche), daß keineswegs nur diejenigen, die aus den Juden ihm
+<supplied reason="undefined" resp="#editor">Aussprüche</supplied>, daß keineswegs nur diejenigen, die aus den Juden ihm
 zu Jüngern gewonnen wurden, in seine Herde gerechnet werden sollten,
-sondern auch (die) außerhalb dieses „Hofes“. So aber pflegt der Logos bisweilen <milestone unit="altnumbering" n="158"/>
+sondern auch <supplied reason="undefined" resp="#editor">die</supplied> außerhalb dieses „Hofes“. So aber pflegt der Logos bisweilen <milestone unit="altnumbering" n="158"/>
  das ganze Volk der Juden, bisweilen Jerusalem und den dortigen
 <lb n="15"/> Gottesdienst zu nennen, der nach dem Gesetz des Mose erfüllt wurde.
 Daß er „andere Schafe“ sammeln will, „die nicht aus diesem Hofe sind“. —
@@ -7671,7 +7675,7 @@ voraus, daß ihm aus ihnen vernünftige Herden gesammelt werden sollen,
 sodaß zu Einer und derselben Gottesverehrung alle diejenigen kommen,
 <lb n="20"/> die aus den Juden und aus den Heiden an ihn gläubig werden. „Und
 es wird sein Eine Herde und Ein Hirt“ — seine Kirche, die aus Juden
-zumal und Heiden besteht, wie dies ία (der Fall) war am Anfang der
+zumal und Heiden besteht, wie dies ία <supplied reason="undefined" resp="#editor">der Fall</supplied> war am Anfang der
 Verkündigung des Evangeliums. Denn viele Scharen der Juden zumal
 ließeb sich überzeugen, daß er der Christus Gottes sei, der von den
 <lb n="25"/> Propheten verkündet wurde, und wurden mit denen, die aus den Heiden
@@ -7700,16 +7704,16 @@ und lenkt, so ist noch viel mehr der Hirte, der Logos Gottes, eine bei
 weitem bessere Natur als die der Menschen. Wir aber sind seine Schafe
 und im Vergleich zu seiner Kraft gleichsam unvernünftiger als alle
 Herden. Ein guter und treuer Hirte aber ist in Wahrheit derjenige, der
-seine Schafe nicht vernachlässigt (und zuläßt), daß sie von den Wölfen <lb n="10"/>
+seine Schafe nicht vernachlässigt <supplied reason="undefined" resp="#editor">und zuläßt</supplied>, daß sie von den Wölfen <lb n="10"/>
 gefressen w erden, das heiß aber: von den bösen, seelenverderbenden
 <milestone unit="altnumbering" n="159"/>Dämonen. Dies zwingt uns, auf das Wort dessen zu achten, der mit
 vieler Vollmacht“ und Kraft sagt: „Ich bin der gute Hirte“. Wenn er
-aber sagt: „Ich lasse mein Leben für meine Herden“, so weist er (damit)
+aber sagt: „Ich lasse mein Leben für meine Herden“, so weist er <supplied reason="undefined" resp="#editor">damit</supplied>
 geheimnisvoll auf seinen Tod hin und lehrt zugleich auch die Ursache: <lb n="15"/>
 daß er für die Erlösung der Seelen der vernünftigen Herden sein Leben
-ließ. Das (Wort): „Ich habe andere Schafe“ deutet darauf, daß zu
+ließ. Das <supplied reason="undefined" resp="#editor">Wort</supplied>: „Ich habe andere Schafe“ deutet darauf, daß zu
 seinem Besitztum nicht nur Juden, sondern auch alle Völker gehören,
-die ihm von seinem Vater gegeben sind, entsprechend jener (Verheißung):
+die ihm von seinem Vater gegeben sind, entsprechend jener <supplied reason="undefined" resp="#editor">Verheißung</supplied>:
 „Bitte von mir, so will ich dir Völker zu deinem Erbe geben.“ <lb n="20"/></p>
 <p>Wie sein Tod die Ursache der Erlösung vieler ist. Aus dem Evangelium
 des Johannes.</p>
@@ -7722,7 +7726,7 @@ aber einmal auch Griechen sich seinen Jüngern näherten und baten, ihn <lb n="2
 zu sehen, so steht seine Antwort geschrieben, als man ihm dies sagte:
 „Die Stunde ist gekommen, daß der Menschensohn verherrlicht werde.
 Ich sage euch, wenn das Weizenkorn nicht in die Erde fällt und stirbt,
-so bleibt es eben nur (wie es ist). Wenn es aber stirbt, so bringt es
+so bleibt es eben nur <supplied reason="undefined" resp="#editor">wie es ist</supplied>. Wenn es aber stirbt, so bringt es
 viele Früchte“. Offenbar verkündigt er auch hiermit geheimnisvoll, daß <lb n="30"/>
 unter den Griechen, unter den fremden und andersgescblechtigen Völkern
 die Verherrlichung seiner Gottheit stark werden solle. Denn
@@ -7737,11 +7741,11 @@ mit den Juden zusammen war und redete, sondern als die Griechen zu
 ihm kamen. Er fügt aber notwendig hinzu und weist hin auf seinen
 Tod, seine Auferstehung und die dadurch geschehende Berufung der
 Völker. Denn wie das Weizenkorn, ehe es in die Erde fällt, eben dasselbe
-<lb n="5"/> allein ist, die lebenzeugende Kraft (in sich) besitzt und die Triebe
-in sich birgt für die Ahrensaat, die aus ihm hervorsprossen soll, (wie)
+<lb n="5"/> allein ist, die lebenzeugende Kraft <supplied reason="undefined" resp="#editor">in sich</supplied> besitzt und die Triebe
+in sich birgt für die Ahrensaat, die aus ihm hervorsprossen soll, <supplied reason="undefined" resp="#editor">wie</supplied>
 es aber dann, nachdem es in die Erde gefallen ist, gleichsam lebt nach
 dem Tode, sich mehrt und viele Ähren aus eigener Kraft hervorsprießen
-läßt, demgemäß, sagt er, werde es auch in betreff seiner (selbst) geschehen.
+läßt, demgemäß, sagt er, werde es auch in betreff seiner <supplied reason="undefined" resp="#editor">selbst</supplied> geschehen.
 <lb n="10"/> Das hat offenkundig der Ausgang der ’ bewiesen, indem
 nach seinem Tode nicht nur Griechen, sondern auch viele Völker aus
 seiner Kraft und seiner göttlichen Fürsorge geschöpft haben. Er ist
@@ -7752,7 +7756,7 @@ unaussprechlicher Kraft füllte. Deswegen sagt er: „Die Ernte ist reich,
 aber der Arbeiter sind weige.“ Und wiederum: „Hebt eure Augen auf <milestone unit="altnumbering" n="160"/>
 und seht die Felder an, die weiß sind zur Ernte.“ Auch dies deutet hin
 auf diejenigen, die nach seinem Tode ihm vereinigt sind durch echten
-<lb n="20"/> Glauben an ihn, (durch) deren Menge in der ganzen Welt der Griechen
+<lb n="20"/> Glauben an ihn, <supplied reason="undefined" resp="#editor">durch</supplied> deren Menge in der ganzen Welt der Griechen
 und Barbaren Kirchen von Myriaden Scharen gegründet wurden, indem
 die Seelen der Menschen nach Art vernünftiger Felder an Einen Ort:
 auf die Tennen seiner Kirchen gesammelt werden. Deswegen heißt es:
@@ -7766,7 +7770,7 @@ mit unverlöschlichem Feuer.“</p>
 Johannes.</note>
 
 <div type="textpart" subtype="chapter" n="26">
-<p><lb n="30"/> „Kinder, (nur noch) eine kleine Weile bin ich bei euch. Dann
+<p><lb n="30"/> „Kinder, <supplied reason="undefined" resp="#editor">nur noch</supplied> eine kleine Weile bin ich bei euch. Dann
 werdet ihr mich suchen. Wie ich den Juden sagte: Wohin ich gehe,
 könnt ihr nicht kommen, so wiederum sage ich auch euch.“ „Sagt zu
 ihm Simon Petrus: Wohin gehst du? Antwortete ihm Jesus: Wohin
@@ -7775,7 +7779,7 @@ ihm Simon Petrus: Wohin gehst du? Antwortete ihm Jesus: Wohin
 <note type="footnote">5 „die Triebe“] wörtlich λόγοι</note>
 
 <pb n="v.3.pt.2.p.205"/>
-ich gehe, kannst du jetzt nicht kommen. Du wirst aber später (dorthin)
+ich gehe, kannst du jetzt nicht kommen. Du wirst aber später <supplied reason="undefined" resp="#editor">dorthin</supplied>
 kommen.“ Wiederum aber sagte Jesus am Ende der Schrift nach seiner
 Auferstehung von den Toten zu Petrus: „Ich sage dir, als du jung warst,
 gürtetest du deine Lenden und gingst, wohin du wolltest. Wenn du
@@ -7786,7 +7790,7 @@ Und als er dies gesagt hatte, sagt er zu ihm: Folge mir nach.“ Wer
 sollte sich nicht wundern, dabß seine Jünger, als er dies zu ihnen sagte,
 bereit und geneigt waren, ihm bis zum Tode anzuhangen? Denn nicht <lb n="10"/>
 indem er sie irre führt und ihnen Hoffnung auf Glück verheißt und das
-verspricht, was in diesem Leben für Glück gehalten wird, — *(nicht)
+verspricht, was in diesem Leben für Glück gehalten wird, — <corr resp="#editor">(nicht)</corr>
 auf diese Weise ködert er sie, ihm anzuhangen, sondern indem er nackt
 und unverhüllt die Martern voraussagt, die um seinetwillen über sie
 kommen sollten. Dem Simon selbst aber zeigte er sogar die Art der <lb n="15"/>
@@ -7794,9 +7798,9 @@ Kreuzigung voraus, durch die er später bei seinem Aufenthalt in Rom
 sein Leben vollendete, durch das Wort: „Wenn du alt wirst, wirst du
 deine Hände ausstrecken, aber andere werden dir die Lenden gürten.“
 Demgemäß aber zeigte er auch geheimnisvoll durch das Wort: „Wohin
-<milestone unit="altnumbering" n="161"/> ich gehe, kannst du jetzt nicht kommen. Du wirst aber später (dorthin) <lb n="20"/>
+<milestone unit="altnumbering" n="161"/> ich gehe, kannst du jetzt nicht kommen. Du wirst aber später <supplied reason="undefined" resp="#editor">dorthin</supplied> <lb n="20"/>
 kommen.“ Denn dies wurde keineswegs allen gesagt, sondern nur dem
-Simon, weil er allein in der Schrift (genannt) ist. der nach Art des
+Simon, weil er allein in der Schrift <supplied reason="undefined" resp="#editor">genannt</supplied> ist. der nach Art des
 Leidens unsers Erlösers sein Leben vollenden werde.</p></div>
    
 <note>Wie er seinen übrigen Jüngern die Verfolgungen voraussagte, die von Zeit
@@ -7807,7 +7811,7 @@ zu Zeit über sie ergehen sollten. Aus dem Evangelium des Matthäus.</note> <lb 
 Obrigkeit ausliefern und euch in ihren Synagogen geißeln; und vor
 Statthalter und Könige werden sie euch führen um meinetwillen zum
 Zeugnis für sie und die Völker.“ Und wiederum: „Selig seid ihr, wenn
-ihr verfolgt und geschmäht werdet, und (wenn) man euch alles Schlechte <lb n="30"/>
+ihr verfolgt und geschmäht werdet, und <supplied reason="undefined" resp="#editor">wenn</supplied> man euch alles Schlechte <lb n="30"/>
 andichtet um meinetwillen. Freut euch und frohlocket; denn euer Lohn
 ist groß im Himmel. Denn so hat man die Propheten vor euch verfolgt.“
 Ein Wunder aber ist der Zusatz des Wortes, das da heißt: „um
@@ -7831,8 +7835,8 @@ aber gewinnt er sie und macht sie sich geneigt dadurch, daß er sie mit
 den früheren gottgeliebten Propheten vergleicht. Denn wie sie die Propheten
 vor euch verfolgt haben, so werden sie auch euch in Zukunft
 <lb n="15"/> ohne Grund verjagen und auch nach Art der Propheten bestrafen, weil
-ihr den über alles (waltenden) Gott verehrt, weswegen sie auch die Propheten
-verfolgt haben. Die (Tatsache) aber, daß er voraussagte, selbst
+ihr den über alles <supplied reason="undefined" resp="#editor">waltenden</supplied> Gott verehrt, weswegen sie auch die Propheten
+verfolgt haben. Die <supplied reason="undefined" resp="#editor">Tatsache</supplied> aber, daß er voraussagte, selbst
 ἡγεμόνες und Könige würden darüber bewegt werden, zu einer Zeit,
 wo er zugegen war und mit seinen Jüngern redete, und daß seine Worte
 <lb n="20"/> sich so ereigneten und in die Tat übergingen, wie sollte das nicht größer
@@ -7841,8 +7845,8 @@ sich für Lehrer der Weisheit ausgaben, haben vieles mit ihren Jüngern geredet,
 indem die einen Gottloses verkündeten, die anderen das Wort der <milestone unit="altnumbering" n="162"/>
 Vorsehung und andere selbst die bei vielen als Götter Geltenden aufhoben,
 <lb n="25"/> während andere als Anfänger böser Dogmen auftraten und andere
-sagten, daß das (höchste) Ziel die Lust sei und noch andere, daß die
-Lust gleichgültig sei, *wie es sich gerade traf. Niemals aber hat einer
+sagten, daß das <supplied reason="undefined" resp="#editor">höchste</supplied> Ziel die Lust sei und noch andere, daß die
+Lust gleichgültig sei, <corr resp="#editor">wie</corr> es sich gerade traf. Niemals aber hat einer
 von ihnen derartiges für seine Jünger vorher entschieden, noch kennen
 wir Verfolgungen, die über sie kamen, wie diejenigen, die über die Lehre
 <lb n="30"/> unsers Erlösers kamen. Wie also sollten wir uns nicht wundern und
@@ -7858,7 +7862,7 @@ vorher zeigte durch das Wort: um seinetwillen solle ihnen das
 schied“ = ἀδιάφορος | „und wie“ Σ str. <foreign xml:lang="abbr">ABBREV</foreign></note>
 
 <pb n="v.3.pt.2.p.207"/>
-<note>Wie auch diejenigen, die verwandt *sind, wider einander aufstehen werden
+<note>Wie auch diejenigen, die verwandt <corr resp="#editor">sind</corr>, wider einander aufstehen werden
 in der Zeit der Verfolgung. Aus dem Evangelium des Matthäus.</note>
 <div type="textpart" subtype="chapter" n="28">
 <p> „Es wird ein Bruder den andern ausliefern zum Tode und
@@ -7869,7 +7873,7 @@ leben.“ Was habe ich nötig, vieles zu reden, wie dies bis jetzt durch
 die Tat erfüllt wurde, da die Werke besser sind als alles Hören. Denn
 mit eigenen Augen sehen wir, wie oft derartiges in den Zeiten der Verfolgung
 und zu unserer eigenen Zeit geschah. Du mögest dies aber <lb n="10"/>
-nicht einfach hören (und verstehen), daß „ein Bruder den andern ausliefern
+nicht einfach hören <supplied reason="undefined" resp="#editor">und verstehen</supplied>, daß „ein Bruder den andern ausliefern
 wird zum Tode“, — denn auch dies wäre gleichsam ein einfacher Gedanke
 — sondern wir können auch daran prüfen und erkennen, wie
 ein Bruder den andern ausliefert zum Tode, wenn er sich der Bruderliebe
@@ -7879,15 +7883,15 @@ Götzen zu verehren, den er aufwiegelt und anfleht und dem er brüderliche
 Liebe vorhält, abbringt von dem Gedächtnis an den Befehl unsers
 Erlösers; denn dann in Wahrheit „wird ein Bruder den andern zum
 eigenen Tode ausliefern“. So verführt auch der Vater seinen Sohn mit <lb n="20"/>
-Worten, überredet ihn, Götzen zu verehren, und bringt ihn (dadurch)
+Worten, überredet ihn, Götzen zu verehren, und bringt ihn <supplied reason="undefined" resp="#editor">dadurch</supplied>
 zum Tode. So bringen auch de Söhne ihre Väter in der Liebe zu ihnen
-dahin, *daß sie das zeitliche, sterbliche Leben dem bei Gott vorziehen,
-und werden (so) die Ursache des Todes und der Seelenverderbnis für ihre
+dahin, <corr resp="#editor">daß</corr> sie das zeitliche, sterbliche Leben dem bei Gott vorziehen,
+und werden <supplied reason="undefined" resp="#editor">so</supplied> die Ursache des Todes und der Seelenverderbnis für ihre
 <milestone unit="altnumbering" n="163"/> Väter. Denn oftmals sehen wir solches zur Verfolgungszeit mit eigenen <lb n="25"/>
-Augen, sodaß *dadurch erfüllt wird das (Wort): „Ihr werdet gehaßt sein
+Augen, sodaß <corr resp="#editor">dadurch</corr> erfüllt wird das <supplied reason="undefined" resp="#editor">Wort</supplied>: „Ihr werdet gehaßt sein
 von jedermann um meines Namens willen.“ Indessen aber ist auch hier
 sorgfältig der Zusatz gemacht worden, der lehrt, daß seine Jünger um
-keiner andern schimpflichen Tatsache als (allein) um seines Namens
+keiner andern schimpflichen Tatsache als <supplied reason="undefined" resp="#editor">allein</supplied> um seines Namens
 willen gehaßt werden sollen.</p>
 </div> <lb n="30"/>
 <note>Über diejenigen, die unrein in seine Kirche aufgenommen werden sollen, und
@@ -7906,15 +7910,15 @@ aber warfen sie weg. So wird es sein am Ende der Welt: die Engel
 warden ausziehen und die Bösen ausscheiden von den Gerechten und
 werden sie in den Feuerofen werfen, dort wird sein Heulen und Zähneklappern.“
 <lb n="5"/> Netz nennt er hier sinngemäß seine Lehre, die aus mannigfachen
-Gedanken der Schriften alten und neuen (Testamentes) gewebt
+Gedanken der Schriften alten und neuen <supplied reason="undefined" resp="#editor">Testamentes</supplied> gewebt
 ist, Meer aber das wogende Leben des Menschen, das gefahrvoll ist wegen
-des Bösen, welches in seinen Taten (liegt). Aus (diesem) Leben rafft
+des Bösen, welches in seinen Taten <supplied reason="undefined" resp="#editor">liegt</supplied>. Aus <supplied reason="undefined" resp="#editor">diesem</supplied> Leben rafft
 das genannte Netz wie aus dem Meere Myriaden empor, und seinen
-<lb n="10"/> untern Teil (nehmen) verschiedene, ihrer Art nach entgegengesetzte
-Scharen (ein): *I)ie Guten und Bösen in ihren Gedanken. Über diejenigen,
+<lb n="10"/> untern Teil <supplied reason="undefined" resp="#editor">nehmen</supplied> verschiedene, ihrer Art nach entgegengesetzte
+Scharen <supplied reason="undefined" resp="#editor">ein</supplied>: <corr resp="#editor">I</corr>)ie Guten und Bösen in ihren Gedanken. Über diejenigen,
 die gleichsam aus dem Meere nach Art der Fische gefangen
 werden, redet er Ἴ’ bei der ersten Berufung seiner Jünger mystisch
-(so): „Folgt mir nach, so will ich euch zu Menschenfischern machen."
+<supplied reason="undefined" resp="#editor">so</supplied>: „Folgt mir nach, so will ich euch zu Menschenfischern machen."
 <lb n="15"/> Nicht einmal also die Gemeinschaft der bösen Menschen war ihm verborgen,
 die mit den Guten in seine Kirche bis heute aufgenommen
 werden, da er lehrt, daß eben sie in der Zeit des Endes durch die damit
@@ -7930,7 +7934,7 @@ Früchten sollt ihr sie erkennen. Denn nicht sammelt man von den
 Α· Dornbüschen Trauben -ι Feigen von den Disteln. So bringt jeder
 gute Baum gute Früchte, der schlechte Baum aber bringt schlechte
 Früchte." Durch Vorauswissen Ἡ er vorher, sich vor gottlosen, andersgläubigen <milestone unit="altnumbering" n="164"/>
-(Ketzern) zu hüten; die in späterer Zeit seine göttlichen
+<supplied reason="undefined" resp="#editor">Ketzern</supplied> zu hüten; die in späterer Zeit seine göttlichen
 Schriftworte zum Vorwand nehmen und den christlichen Namen sich aneignen
 <lb n="30"/> eignen würden, und zeigte die Zeichen und Zeugnisse des in ihnen verborgenen
 Bösen, das viele verführen werde, indem er sagt: „An ihren
@@ -7945,22 +7949,22 @@ sondern verkehrt ist. Während dies aber in jener Zeit geredet wurde
 stätigung durch den Anblick denen gewährten, die es damals hörten,
 so sind dennoch in späterer Zeit die Werke seiner Worte jedermann
 offenkundig sichtbar geworden. Die Markioniten aber, die Anhänger
-des Valentinus und des Basilides und (alle) die andern, die in späterer
+des Valentinus und des Basilides und <supplied reason="undefined" resp="#editor">alle</supplied> die andern, die in späterer
 Zeit als Seelenverderber aufsproßten: Bardesanes und der jüngst zu <lb n="5"/>
-unserer Zeit (aufgetretene) Verstandes wahnsinnige, dessen Name der Beiname
-für die Partei der Manichäer ward, (waren Leute), die trügerische,
+unserer Zeit <supplied reason="undefined" resp="#editor">aufgetretene</supplied> Verstandes wahnsinnige, dessen Name der Beiname
+für die Partei der Manichäer ward, <supplied reason="undefined" resp="#editor">waren Leute</supplied>, die trügerische,
 gottlose Lehren hervorsprudeln ließen. Und nicht anders kamen
 sie ans Licht als äußerlich bekleidet mit dem Schafsfell unsers Erlösers.
 Schafe aber nennt er offenbar seine Jünger, indem er sagt: „Meine <lb n="10"/>
 Schafe hören auf meine Stimme“ und ferner: „Siehe ich sende euch wie
-Schafe mitten unter die Wölfe.“ In die Art dieser (Schafe) kleideten
+Schafe mitten unter die Wölfe.“ In die Art dieser <supplied reason="undefined" resp="#editor">Schafe</supplied> kleideten
 sie sich äußerlich, während sie in ihren Seelen reißende Wölfe sind.
 Wieviel Myriaden haben diese Verführer von der Herde unsers Erlösers
 geraubt, indem sie sich Christo heuchlerisch anähnelten und der <lb n="15"/>
 Lehre Christi anhingen und sich heuchlerisch stellten, als ob sie Worte
-der göttlichen Lehre sagten, (in Wirklichkeit) aber das hinterlistige,
+der göttlichen Lehre sagten, <supplied reason="undefined" resp="#editor">in Wirklichkeit</supplied> aber das hinterlistige,
 gottlose Gift in ihnen insgeheim denen zuführten, die von ihnen eingefangen
-waren. *Diejenigen also, die jetzt wegen ihrer Heuchelei für
+waren. <corr resp="#editor">Diejenigen</corr> also, die jetzt wegen ihrer Heuchelei für
 Schafe gehalten wurden, wurden nach kurzer Zeit als reißende Wölfe <lb n="20"/>
 offenbar. Deswegen lehrt uns unser Erlöser, uns vorher vor ihnen in
 Acht nehmen, indem er mahnt und sagt: „An ihren Früchten sollt ihr
@@ -7970,8 +7974,8 @@ sie erkennen.“</p>
 und durch Gemeinschaft mit den Dämonen die Menschen überwältigt haben.</note> <lb n="25"/>
 <div type="textpart" subtype="chapter" n="31">
 <p> „Nicht ist ein Jünger größer als sein Meister noch ein Sklave
-(größer) als sein Herr. Genug für den Jünger, zu sein wie sein Meister,
-und für den Skaven. (zu sein) wie sein Herr. Wenn sie den Hausherrn
+<supplied reason="undefined" resp="#editor">größer</supplied> als sein Herr. Genug für den Jünger, zu sein wie sein Meister,
+und für den Skaven. <supplied reason="undefined" resp="#editor">zu sein</supplied> wie sein Herr. Wenn sie den Hausherrn
 Beelzebub genannt haben, wieviel mehr seine Hausgenossen? Fürchtet euch
 also nicht vor ihnen. Denn nichts ist verhüllt, das nicht enthüllt würde, <lb n="30"/>
 und nichts verborgen, das nicht bekannt würde.“ Die Juden glaubten,
@@ -7989,18 +7993,18 @@ alter sagte er vorher, daß ma auch von ihnen glauben werde, sie besiegten
 die Menschen in Gemeinschaft mit Dämonen und Zauberei. Indem
 eben dies von vielen geredet ward, versiegelte und bestätigte das
 <lb n="5"/> die Voraussagung unsers Erlösers. Er bezeugt aber, daß die über sie
-(verhängte) Strafe aufgehoben werden sollte infolge ihres reinen Lebens
-und Charakters und ihrer (reinen) Lehre und Frömmigkeit. Deswegen
+<supplied reason="undefined" resp="#editor">verhängte</supplied> Strafe aufgehoben werden sollte infolge ihres reinen Lebens
+und Charakters und ihrer <supplied reason="undefined" resp="#editor">reinen</supplied> Lehre und Frömmigkeit. Deswegen
 sagt er: „Fürchtet euch nicht vor ihnen. Denn nichts ist verhüllt, das
 nicht enthüllt würde, und nichts verborgen, das nicht bekannt würde.“
 <lb n="10"/> Die lange Zeit also bringt an den Tag das, was früher den meisten verborgen
 war. Deswegen wurde verkündet, daß offenbart und ans Licht
-kommen würden die (Worte) der gottesfürchtigen Lehre. Und seine
+kommen würden die <supplied reason="undefined" resp="#editor">Worte</supplied> der gottesfürchtigen Lehre. Und seine
 Dogmen und Satzungen sind fernerhin jedermann bekannt geworden
 und haben die Meinung ausgelöscht, die früher bei vielen über sie
 <lb n="15"/> herrschte.</p>
 <p>Über diejenigen, die in seiner Kirche in vollkommener Heiligkeit und in
-einem der (ehelichen) Gemeinschaft nicht teilhaftig gewordenen Leben
+einem der <supplied reason="undefined" resp="#editor">ehelichen</supplied> Gemeinschaft nicht teilhaftig gewordenen Leben
 existieren werden. Aus dem Evangelium des Matthäus.</p>
 </div>
 
@@ -8009,7 +8013,7 @@ existieren werden. Aus dem Evangelium des Matthäus.</p>
 <lb n="20"/> sein Weib zu entlassen außer aus dem Grunde der Unzucht, und sie zu
 ihm sagten, „wenn die Ursache des Mannes mit dem Weibe derart ist,
 so nützt es nichts zu heiraten,“ heißt es, daß er darüber sagte: „Nicht
-jedermann ist genügend (stark) für dies Wort, sondern (nur) diejenigen,
+jedermann ist genügend <supplied reason="undefined" resp="#editor">stark</supplied> für dies Wort, sondern <supplied reason="undefined" resp="#editor">nur</supplied> diejenigen,
 denen es gegeben ist. Es gibt Verschnittene, die von Mutterleib an so
 <lb n="25"/> waren, und gibt Verschnittene, die von den Menschen verschnitten wurden.
 und gibt Verschnittene, die sich selbst zu Verschnittenen gemacht haben <milestone unit="altnumbering" n="166"/>
@@ -8021,7 +8025,7 @@ ist. In der ganzen Welt aber und unter allen Völkern in Städten und
 Dörfern haben Myriaden nicht nur von Männern, sondern auch von
 Weibern vollkommene Heiligkeit und Jungfräulichkeit bewahrt um der
 Hoffnung und der Erwartung des himmlischen Reiches willen, auf
-<lb n="35"/> welches sie eilends von hier (von dr Erde) sich vorzubereiten gelernt
+<lb n="35"/> welches sie eilends von hier <supplied reason="undefined" resp="#editor">von dr Erde</supplied> sich vorzubereiten gelernt
 <note type="footnote">19 vgl. Matth 19 9 21 = Matth 19 10 22 — 27 = Matth
 19 11—12</note>
 
@@ -8033,7 +8037,7 @@ Eisen benutzten und ihre Leiber zu verschnittenen gemacht haben um
 keiner anderen Ursache als um der Hoffnung auf das himmlische Reich <lb n="5"/>
 willen, die nicht lange in der Lehre unsers Erlösers erstarkt waren,
 sondern schlicht und schnell sich an die Sache heranmachten, sodaß
-auch in betreff dieser (Männer) das Vorauswissen unsers Erlösers, in
+auch in betreff dieser <supplied reason="undefined" resp="#editor">Männer</supplied> das Vorauswissen unsers Erlösers, in
 Wahrheit des Logos Gottes, versiegelt wurde.
 Über die Unterschiede derer, die nicht würdig den Samen seiner Lehre <lb n="10"/>
 aufnehmen sollten. Aus dem Evangelium des Matthäus.</p>
@@ -8052,7 +8056,7 @@ gab Früchte, das eine hundertfältig, das andere sechzigfältig und anderes
 dreißigfältig.“ Darnach rief er aus und sagte: „Wer Ohren hat zu
 hören, höre!“ Darauf wurde er von seinen Jüngern gefragt, was die
 Erklärung des Gleichnisses sei, und er lehrte und sprach: „So hört ihr
-also das Gleichnis des *Säemanns! Jeder, der das Wort vom Reiche <lb n="25"/>
+also das Gleichnis des <corr resp="#editor">Säemanns</corr>! Jeder, der das Wort vom Reiche <lb n="25"/>
 hört und es nicht versteht, da kommt der Böse und raubt den Samen
 aus seinem Herzea. Das ist der, der an den Rand des Weges gesät
 <milestone unit="altnumbering" n="167"/> wurde. Was aber auf den Felsen gesät wurde, das ist der, welcher das
@@ -8071,7 +8075,7 @@ und der Trug des Reichtums erstickt das Wort, und er bleibt ohne
 Frucht. Was aber auf das gute Land gesät ist, das ist der, der das
 Wort hört und es versteht, und er bringt Früchte, der eine hundertfältig,
 der andere sechzigfältig, ein anderer dreißigfältig.“ Woher war es einer
-<lb n="5"/> menschlichen Natur (möglich), nicht nur durch Vorauswissen die Zukunft
+<lb n="5"/> menschlichen Natur <supplied reason="undefined" resp="#editor">möglich</supplied>, nicht nur durch Vorauswissen die Zukunft
 vorauszusagen, sondern auch die verschiedenen Arten der Seelen
 zu unterscheiden, wenn sie nicht in Wahrheit der göttliche Logow war,
 er, der damals zugleich weissagte und lehrte, über den es heißt: „Denn
@@ -8090,8 +8094,8 @@ in ihre Seelen fallen, drei Ursachen sind für diejenigen, die zu Grunde
 Lebens und der Sorge um das Nichtnotwendige und infolge des Reichtums
 und der Üppigkeit den Samen in sich und gleichen denen, die
 von den Dornen erstickt werden, oder da sie ihn nicht in die Tiefe ihres
-Geistes aufgenommen haben, *verlöschen sie bald, sowie eine Drangsal
-<lb n="25"/> sie erreicht, oder die dritte Ursache (ist) die, daß sie die Ursache für den
+Geistes aufgenommen haben, <corr resp="#editor">verlöschen</corr> sie bald, sowie eine Drangsal
+<lb n="25"/> sie erreicht, oder die dritte Ursache <supplied reason="undefined" resp="#editor">ist</supplied> die, daß sie die Ursache für den
 Untergang des Samens in sich werden, indem sie schlaff ihre Ohren darbieten
 denen, die die in ihre Seele gefallenen Samen verführen und fortraffen
 wollen. Eben sie aber sind nicht anders beraubt des Fruchttragens
@@ -8100,7 +8104,7 @@ in Gott als in einer der genannten Weisen. Die aber, welche jenen entgegengesetz
 aufgenommen haben, vervielfältigen wiederum ihre Früchte nach der
 Kraft ihrer Seele. Aber auch ihre Unterschiede vergleicht er den guten
 und schönen Ländern, die dreißigfach, und hundertfach <milestone unit="altnumbering" n="168"/>
-(tragen). Denn *derartige Kräfte werden bisweilen in den Seelen der
+<supplied reason="undefined" resp="#editor">tragen</supplied>. Denn <corr resp="#editor">derartige</corr> Kräfte werden bisweilen in den Seelen der
 <lb n="35"/> Menschen gefunden. Dies also prophezeite er darüber.</p>
 <note type="footnote">8 = Hebr. 4 12 f. 13—32 = 14. Bruchstück der griech. Theoph.</note>
 <note type="footnote">19 „für diejenigen, die zu Grunde gehen“ ist unlogiscb. Man erwartet „für
@@ -8117,11 +8121,11 @@ so kommt die Ernte? Hebt eure Augen auf und seht die Felder an,
 die fortan weiß sind zur Ernte.“ Und wer sollte sich nicht wundern,
 daß er sogar die geringe Zahl derer zeigte, die in Reinheit Führer
 seines Wortes sein sollten, indem er sagte: „der Arbeiter aber sind
-wenige“, und daß ein Gebet erforderlich sei, um *sie zu finden (zu <lb n="10"/>
-gewinnen). Deswegen sagt er: „Bittet den Herrn der Ernte, daß er
+wenige“, und daß ein Gebet erforderlich sei, um <corr resp="#editor">sie</corr> zu finden <supplied reason="undefined" resp="#editor">zu <lb n="10"/>
+gewinnen</supplied>. Deswegen sagt er: „Bittet den Herrn der Ernte, daß er
 Arbeiter hergebe zu seiner Ernte.“ Wenn er aber sagt, daß „ein Säemann
 ausging zu säen“, so zeigte er hierdurch, daß ein anderer der
-Säemann und ein anderer der Same (sei). Woher und wohin er ausging,
+Säemann und ein anderer der Same <supplied reason="undefined" resp="#editor">sei</supplied>. Woher und wohin er ausging,
 sagte und lehrte er durch das sich daran schließende Gleichnis in <lb n="15"/>
 folgender Weise.</p></div>
 <note>Über heterodoxe Lehren, die mit seinem Worte in die Seelen der Menschen
@@ -8131,9 +8135,9 @@ gesät werden. Aus dem Evangelium des Matthäus.</note>
 Himmelreich gleicht einem Manne, der guten Samen auf sein Landgut <lb n="20"/>
 säte. Während aber die Menschen schliefen, kam ein Feind und
 säte Unkraut unter den Weizen und ging davon. Als aber Weizen
-aufging und Frucht brachte, dann zeigte sich (auch) Unkraut. Es
+aufging und Frucht brachte, dann zeigte sich <supplied reason="undefined" resp="#editor">auch</supplied> Unkraut. Es
 kamen aber seine Knechte und sagten zu ihm: Herr, hast du nicht
-guten Samen auf dein Landgut gesät? Woher (denn) das Unkraut in <lb n="25"/>
+guten Samen auf dein Landgut gesät? Woher <supplied reason="undefined" resp="#editor">denn</supplied> das Unkraut in <lb n="25"/>
 ihm? Er aber sagte zu ihnen: Ein feindlicher Mann hat das getan.
 Sagen sie zu ihm: Willst du also, daß wir hingehen und es sammeln?
 Er aber sagt: Nein, damit ihr nicht, wenn ihr das Unkraut sammelt,
@@ -8157,11 +8161,11 @@ also das Unkraut gesammelt wird und ins Feuer fällt, so wird es am
 Ende dieser Welt sein. Der Menschensohn wird seine Engel schicken
 und sie werden auslesen aus seinem Reiche alle Anstöße und diejenigen,
 <lb n="10"/> die Frevel üben, und werden sie in die Gehenna des Feuers werfen.
-Dort wird sein *Heulen und Zähneklappern. Dann aber werden
+Dort wird sein <corr resp="#editor">Heulen</corr> und Zähneklappern. Dann aber werden
 Gerechten leuchten im Reich ihres Vaters. Wer Ohren hat zu hören,
-höre!“ Dies also (sprach) er, unser Erlöser. Wer aber der Säemann ist,
+höre!“ Dies also <supplied reason="undefined" resp="#editor">sprach</supplied> er, unser Erlöser. Wer aber der Säemann ist,
 der ausging zu säen, und welches der Same ist, den er auswarf, zeigte
-<lb n="15"/> die Deutung des *Gleichnisses, in der es heißt: „Der den guten Samen
+<lb n="15"/> die Deutung des <corr resp="#editor">Gleichnisses</corr>, in der es heißt: „Der den guten Samen
 sät, ist der Menschensohn, und das Landgut ist die Welt.“ Menschensohn
 aber pflegt er sich selbst zu nennen wegen seines Durchgangs
 unter den Menschen. Er ging also aus von innen und kam nach
@@ -8173,13 +8177,13 @@ wie in verschiedene Ländereien säte. Das vorliegende Wort aber belehrt
 auch über die Beschaffenheit des Landgutes, auf das er den Samen
 <lb n="25"/> warf. Er sagt aber: „Das Landgut ist die Welt“, und zeigt, wem dies
 Landgut gehört: keinem andern als ihm selbst, der aus dem Innern
-seines Reiches zu *denen außerhalb hinausging, indem er stagt, daß
+seines Reiches zu <corr resp="#editor">denen</corr> außerhalb hinausging, indem er stagt, daß
 „die Knechte herzutraten und zu ihm sprachen: Herr, hast du nicht
 guten Samen auf dein Landgut gesät?“ Offenbar lehrt er also, daß dies
 <lb n="30"/> Landgut auch ihm selbst gehöre, und verdolmetscht es und zeigt, daß es
 die Welt sei. In jenem ersten Gleichnis also wußte er voraus, wie die
 Unterschiede derer sein würden, die den Samen in ihre Seele aufnahmen,
-in dem uns (jetzt) vorliegenden aber die verdrehten, trügerischen Lehren
+in dem uns <supplied reason="undefined" resp="#editor">jetzt</supplied> vorliegenden aber die verdrehten, trügerischen Lehren
 gottloser Häretiker, obwohl noch kein derartiger von ihnen unter den
 <note type="footnote">1—13 = Matth 13 36—43</note>
 <note type="footnote">11 l. <foreign xml:lang="abbr">ABBREV</foreign> Bernstein mit HS 12 Ob + <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="abbr">ABBREV</foreign> „wie die Sonne“
@@ -8191,28 +8195,28 @@ Menschen existierte. Indessen aber war es ihm nicht verborgen, daß
 dies kommen werde. Denn da in späteren Zeiten auf der ganzen Erde
 Schriftstücke und Worte betrügerischer Schriften seiner Lehre angeähnelt
 wurden von entgegengesetzter Natur, so wurden sie nach Art
-<milestone unit="altnumbering" n="170"/> des Unkrauts mit dem reinen und belebenden Worte seiner *ausgesät. <lb n="5"/>
+<milestone unit="altnumbering" n="170"/> des Unkrauts mit dem reinen und belebenden Worte seiner <corr resp="#editor">ausgesät</corr>. <lb n="5"/>
 Myriaden aber, die bald des Mani sich rühmen, bald des Markion,
-bald anderer unter den gottlosen Heterodoxen, *bringen bis jetzt Unkraut
+bald anderer unter den gottlosen Heterodoxen, <corr resp="#editor">bringen</corr> bis jetzt Unkraut
 hervor, indem sie sich der Lehre unsers Erlösers anähneln und
 seinen Namen gebrauchen, die Schriften der Evangelien aber für Gefasel
-halten. Ihr Vater aber, der sie (die Trugworte) zuerst in die Seelen <lb n="10"/>
-derer säte, die ihn aufnahmen, ist der Verleumder. Indem er (Jesus)
+halten. Ihr Vater aber, der sie <supplied reason="undefined" resp="#editor">die Trugworte</supplied> zuerst in die Seelen <lb n="10"/>
+derer säte, die ihn aufnahmen, ist der Verleumder. Indem er <supplied reason="undefined" resp="#editor">Jesus</supplied>
 mit Recht vorwegnahm, was eintreten werde, wußte er mit göttlicher
 Kraft im voraus und bezeugte im voraus, was auf diese Weise durch
 die Tat erfüllt wurde und seinen Worten entsprechend Erfüllung
-ging. Wie er also dies in Wahrheit zeigte und (wie) wir die Erfüllung <lb n="15"/>
+ging. Wie er also dies in Wahrheit zeigte und <supplied reason="undefined" resp="#editor">wie</supplied> wir die Erfüllung <lb n="15"/>
 der voraussagenden Worte unsers Erlösers eben in Taten sehen, so ge
 es sich auch von dem Übrigen zu glauben, daß es eintreten werde.
-Was aber ist das? (Daß) die Ernte *das Ende und die Schnitter die
-Engel (sind), und daß das Unkraut gesammelt wird und ins Feuer fällt,
-daß aber das Ende der guten (Dinge) denjenigen (zu teil werde), die <lb n="20"/>
+Was aber ist das? <supplied reason="undefined" resp="#editor">Daß</supplied> die Ernte <corr resp="#editor">das</corr> Ende und die Schnitter die
+Engel <supplied reason="undefined" resp="#editor">sind</supplied>, und daß das Unkraut gesammelt wird und ins Feuer fällt,
+daß aber das Ende der guten <supplied reason="undefined" resp="#editor">Dinge</supplied> denjenigen <supplied reason="undefined" resp="#editor">zu teil werde</supplied>, die <lb n="20"/>
 den lebendigen, reinen und lebenbringenden Samen bewahrt und vermehrt
 haben, von denen gesagt ist: „Dann werden die Gerechten leuchten
 wie die Sonne im Reiche ihres Vaters.“</p>
 </div>
    
-<note>Über diejenigen, die in Zukunft sich selbst fälschlich *Christusse nennen.
+<note>Über diejenigen, die in Zukunft sich selbst fälschlich <corr resp="#editor">Christusse</corr> nennen.
 Aus dem Evangelium des Matthäus.</note> <lb n="25"/>
 
 <div type="textpart" subtype="chapter" n="35">
@@ -8243,24 +8247,24 @@ gekommen, aber ihr habt mich nicht aufgenommen. Wenn aber ein
 anderer in seinem eigenen Namen kommt, den werdet ihr aufnehmen.“
 Dies sagte er über den lügnerischen Antichristen voraus, den sie erwarten
 sollten, indem er seine Jünger warnte. Ein anderer aber zeigte
-<lb n="15"/> im Thessalonikerbrief, daß er am Ende (der Welt kommen werde).
+<lb n="15"/> im Thessalonikerbrief, daß er am Ende <supplied reason="undefined" resp="#editor">der Welt kommen werde</supplied>.
 Daß aber auch andere vor ihm einzeln kommen würden, sagte unser
 Erlöser voraus: „Denn viele, sagte er, werden kommen in meinem
 Namen und werden sagen: Ich bin der Christus und werden viele verführen.“
-Es traten aber (in der Tat) nach seinen Worten viele auf derart. Denn
+Es traten aber <supplied reason="undefined" resp="#editor">in der Tat</supplied> nach seinen Worten viele auf derart. Denn
 <lb n="20"/> sogleich waren die Samariter überzeugt, daß Dositheus. der nach der
 Zeit UDsers Erlösers auftrat, der Prophet sei, über den Mose geweissagt
 habe. Er aber führte sie irre, sodaß sie sagten, er sei der Christus. Andere
 aber wiederum in der Zeit der Apostel nannten den Zauberer Simon
 die große Kraft Gottes und glaubten, er sei der Christus, und andere
 <lb n="25"/> in Phrygien von Montanus, und andere wiederum anderswo glaubten
-(dasselbe) von andern, und nicht werden aufhören die Betrüger. Denn
+<supplied reason="undefined" resp="#editor">dasselbe</supplied> von andern, und nicht werden aufhören die Betrüger. Denn
 man muß erwarten, daß sogar mehr derartige auftreten werden, von
 denen eben die Wahrheit der Prophezeiungen unsers Erlösers ebenfalls
 Bestätigung empfangen hat. Er aber, unser Erlöser, lehrte daß fernerhin
 <lb n="30"/> nicht an Einem Orte seine gelobte zweite Ankunft stattfinden werde
-wie die erste, damit niemand meine, (sie geschehe) in einem Winkel
-der sichtbaren Erde. Damit aber niemand (dies) meine, lehrt er so und
+wie die erste, damit niemand meine, <supplied reason="undefined" resp="#editor">sie geschehe</supplied> in einem Winkel
+der sichtbaren Erde. Damit aber niemand <supplied reason="undefined" resp="#editor">dies</supplied> meine, lehrt er so und
 <note type="footnote">1—9 = Matth 2423—27 10 = Joh 5 43 15 vgl. II Thess 23 19—29 =
 15 Bruchstück der griech. Theoph. 21 vgl. Dtn 1815 23 vgl. Act 8 10</note>
 <note type="footnote">27 πλείους τοιούτους ἔσεσθαι, ἐξ ὧν δὴ καὶ αὐτῶν ἡ ἀλήθεια τῶν σωτηρίων
@@ -8271,7 +8275,7 @@ die Wahrheit des Vorauswissens unsers Erlösers empfangen hat“ Σ. Lies viell.
 <pb n="v.3.pt.2.p.217"/>
 sagt: „Wenn jemand zu euch spricht: Siehe hier ist der Christus oder
 dort, so glaubt es nicht.“ Die Meinungen nämlich, welche derart sind,
-treffen auf ihn nicht zu, sondern (nur) auf die betrügerischen Christusse
+treffen auf ihn nicht zu, sondern <supplied reason="undefined" resp="#editor">nur</supplied> auf die betrügerischen Christusse
 und die lügnerischen Propheten. Er ist vielmehr Ein Mal in der Gestalt
 eines Menschen und in Einem Winkel erschienen. Wie aber seine
 zweite gelobte Ankunft vom Himmel her stattfinden werde, lehrt er,
@@ -8286,7 +8290,7 @@ Aus dem Evangelium des Matthäus.</note> <lb n="10"/>
 Kriegsgerüchten; üchten; seht zu, damit ihr nicht erschreckt. Denn es
 muß kommen, aber das ist noch nicht das Ende. Denn es wird sich
 erheben ein Volk wider das andere und ein Reich wider das andere,
-und es werden sein Hungersnöte, Seuchen und (Erd)beben an jedem <lb n="15"/>
+und es werden sein Hungersnöte, Seuchen und <supplied reason="undefined" resp="#editor">Erd</supplied>beben an jedem <lb n="15"/>
 Ort. Dies alles aber ist der Anfang der Wehen. Hierauf werden sie
 <milestone unit="altnumbering" n="172"/> euch ausliefern zur Drangsal und euch töten, und ihr werdet gehaßt
 sein von allen Völkern um meines Namens willen.“ Er fügt aber
@@ -8301,7 +8305,7 @@ zuvor sein Evangelium in aller Welt zum Zeugnis für alle Völker verkúndet
 werden müsse und dann erst das Ende kommen werde. Denn
 nicht früher wird das verkündigte Ende der Welt kommen, als bis sein
 Wort von allen Völkern ergriffen ist. Soviel Völker also fehlen, unter
-denen sein Evangelium (noch) nicht Verkündigt worden ist, soviel Zeit <lb n="30"/>
+denen sein Evangelium <supplied reason="undefined" resp="#editor">noch</supplied> nicht Verkündigt worden ist, soviel Zeit <lb n="30"/>
 fehlt auch am Ende. Er lehrt aber und sagt: „Es wird dazu kommen,
 daß ihr hört von Kriegen und Kriegsgerüchten; seht zu, damit ihr
 nicht erschreckt. Denn es muß kommen, aber das ist noch nicht das
@@ -8311,24 +8315,24 @@ Zeugnis für alle Völker, und dann wird das Ende kommen“, wenn auch
 <note type="footnote">11—18 = Matth 246—9 19—25 = Matth 24 10—14</note>
 
 <pb n="v.3.pt.2.p.218"/>
-Hungersnöte und Seuchen und (Erd)beben an jedem Ort (eintreten) und
+Hungersnöte und Seuchen und <supplied reason="undefined" resp="#editor">Erd</supplied>beben an jedem Ort <supplied reason="undefined" resp="#editor">eintreten</supplied> und
 ein Volk sich wider das andere und ein Reich wider das andere andere erheben
 und schwere Verfolgungen und gewaltige Drangsale sein werden.
 Darauf aber sagt er: „Und ihr werdet gehaßt sein von allen Völkern,“
-<lb n="5"/> nicht wegen anderer verhaßter Taten, sondern (nur) um seines Namens
+<lb n="5"/> nicht wegen anderer verhaßter Taten, sondern <supplied reason="undefined" resp="#editor">nur</supplied> um seines Namens
 willen.</p>
 </div>
       
 <div type="textpart" subtype="chapter" n="37">
 <p>Diese Beweise der göttlichen Offenbarung unsers Erlösers,
 die bis jetzt mit Augen gesehen werden, zeigen, zeigen, Worte zumal
-und Taten göttlich (sind). Denn früher wurden einfach die Stimmen
+und Taten göttlich <supplied reason="undefined" resp="#editor">sind</supplied>. Denn früher wurden einfach die Stimmen
 <lb n="10"/> gehört, jetzt aber in unsern Zeiten sind die Erfüllungen seiner Worte
 offenbar in der Tat sichtbar und die Kräfte, die jede sterbliche Natur
 in den Schatten stellen. Wenn aber einige sich dadurch nicht überzeugen
 lassen, so darf man sich nicht wundern, da der Mensch selbst
 gegen das Offenbare sich aufzulehnen pflegt, sodaß er auch gegen die
-<lb n="15"/> über alles (waltende) Vorsehung mit feindlichen Worten zu reden
+<lb n="15"/> über alles <supplied reason="undefined" resp="#editor">waltende</supplied> Vorsehung mit feindlichen Worten zu reden
 wagt, und so auch Gott selbst leugnet und so auch über vieles andere
 schamlos streitet, über das die Wahrheit Zeugnis ablegt. Aber wie
 ihre Verleumdung dem wahren Worte der Natur nichts schadet, so <milestone unit="altnumbering" n="173"/>
@@ -8351,15 +8355,15 @@ geprüft haben, das wollen wir auch jetzt solchen erzählen, die sich
 <div type="textpart" subtype="chapter" n="1">
 <p>Derartig sind die Beweise der Theophanie des gemeisamen Erlösers
 aller, Jesu Christi, die bis jetzt mit den Augen wahrgenommen
-werden (und die) zeigen, daß Worte zumal und Taten göttlich sind. Denn
+werden <supplied reason="undefined" resp="#editor">und die</supplied> zeigen, daß Worte zumal und Taten göttlich sind. Denn
 früher wurden einfach die Stimmen gehört, die die kommenden Dinge <lb n="5"/>
-voraussagten, welche er seinen Jüngern prophezeite, als er (noch) bei
+voraussagten, welche er seinen Jüngern prophezeite, als er <supplied reason="undefined" resp="#editor">noch</supplied> bei
 ihnen war, jetzt aber in unsern Zeiten ist die Erfüllung seiner Worte
 offenkundig in der Tat sichtbar und die Karäfte, die jede sterbliche Natur
 in den Schatten stellen. Wenn aber einige sich dadurch nicht überzeugen
 lassen, so darf man sich nicht wundern, da der Mensch selbst <lb n="10"/>
 gegen das Offenbare sich aufzulehnen pflegt, sodaß er auch gegen die
-über alles (waltende) Vorsehung mit feindlichen Worten zu reden wagt,
+über alles <supplied reason="undefined" resp="#editor">waltende</supplied> Vorsehung mit feindlichen Worten zu reden wagt,
 und so auch Gott selbst leugnet und so auch über vieles andere schamlos
 streitet, über das die Wahrheit Zeugnis ablegt. Aber wie ihre Verleumdung
 dem wahren Worte der Natur nichts schadet, so schadet auch <lb n="15"/>
@@ -8371,7 +8375,7 @@ Wort sie überzeugte. Indessen aber wollen wir zum Überfluß das gegen <lb n="2
 sie wieder aufnehmen, was wir auch früher in den Evangelienbeweisen
 mit Fragen geprüft haben. Wenn also irgend jemand nach alledem der
 Wahrheit hartnächkig widerstrebt und schamlos zu sagen sich erfrecht,
-<milestone unit="altnumbering" n="174"/> daß er (Jesus) keineswegs der Christus Gottes sei, wie wir meinen, sondern
+<milestone unit="altnumbering" n="174"/> daß er <supplied reason="undefined" resp="#editor">Jesus</supplied> keineswegs der Christus Gottes sei, wie wir meinen, sondern
 ein Zauberer, Betrüger und Verführer, so wollen wir ihm, als einem <lb n="25"/>
 Unmündigen im Geiste, eben das vorlegen, was wir schon früher geprüft
 haben.</p>
@@ -8390,29 +8394,29 @@ und ob es recht sei, daß mit solchen Namen derjenige benannt werde,
 der nicht einmal mit lüsterner Begierde Weiber anzublicken erlaubt
 hat, und ob ein Zauberer derjenige sei, der die höchste Philosophie überliefert
 <lb n="5"/> hat dadurch, daß er seine Jünger unterwies, denen, die arm an
-Gütern sind, mitzuteilen und (Menschen)freundlichkeit und Freigebigkeit
-im Überfluß zu besitzen, und ob ein Zauberer derjenige sei, der (sie)
+Gütern sind, mitzuteilen und <supplied reason="undefined" resp="#editor">Menschen</supplied>freundlichkeit und Freigebigkeit
+im Überfluß zu besitzen, und ob ein Zauberer derjenige sei, der <supplied reason="undefined" resp="#editor">sie</supplied>
 von der Versammlung wilder und aufrührerischer Massen fernhielt und
-(sie) lehrte, nur die Muße bei den göttlichen Worten zu lieben? Er
+<supplied reason="undefined" resp="#editor">sie</supplied> lehrte, nur die Muße bei den göttlichen Worten zu lieben? Er
 <lb n="10"/> aber, der von jeder Lüge zurücktrieb und die Wahrheit vor allem zu
 ehren ermahnte, sodaß nicht einmal ein Treueid, geschweige denn ein
 nötig ötig war, wie sollte der mit Recht ein Zauberer genannt
 werden? Was habe ich nötig, jetzt noch mehr zu sagen, da es möglich
 ist, aus seinen Worten, die bis jetzt auf der ganzen Erde verkündigt
 <lb n="15"/> werden, zu erkennen, welches die Art der von ihm in die Welt gesäten
-(Lebens) führung sei, infolge deren jeder, der die Wahrheit liebt, bekennt,
+<supplied reason="undefined" resp="#editor">Lebens</supplied> führung sei, infolge deren jeder, der die Wahrheit liebt, bekennt,
 daß er nicht nur kein Zauberer und Betrüger, sondern in Wahrheit das
 Wort Gottes und ein Lehrer der göttlichen und frommen Philosophie,
-aber nicht der weltlichen (und) gemeinen Philosophie sei.</p>
+aber nicht der weltlichen <supplied reason="undefined" resp="#editor">und</supplied> gemeinen Philosophie sei.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="3">
 <p>Aber das
-<lb n="20"/> Ethische seiner Lehre (ist) derart.</p>
+<lb n="20"/> Ethische seiner Lehre <supplied reason="undefined" resp="#editor">ist</supplied> derart.</p>
 <p>Wohlan aber, prüfen wir, ob nicht seine Verirrung in denn Hauptpunkten
 seiner Dogmatik bestand. Steht denn nicht von ihm geschrieben,
 daß er selbst den Allkönig Gott, die einzige Ursache alles Guten, lehrte
-und seine Jünger (eben dahin) brachte, und führen nicht bis jetzt die
+und seine Jünger <supplied reason="undefined" resp="#editor">eben dahin</supplied> brachte, und führen nicht bis jetzt die
 <lb n="25"/> Worte seiner Lehre jeden Griechen und Barbaren nach oben in ihrem
 Geist zu dem höchsten Gott, dem Schöpfer Himmels und der Erden
 und der ganzen Welt, der jede sichtbare und gewordene Natur übertrifft? <milestone unit="altnumbering" n="175"/>
@@ -8428,15 +8432,15 @@ doch vgl. 8111 | „lehrte“] ἀνακείμενος D 1. <foreign xml:lang="a
 . . . . Natur hervor“ Σ</note>
 
 <pb n="v.3.pt.2.p.221"/>
-Das ist doch wohl nicht seine Verirrung? Oder (soll man eine solche
-annehmen), weil er nicht gestattete, viele Götter zu verehren, denen, die
-von der Verehrung des allein *höchsten, untrügerischen Gottes in diesen
+Das ist doch wohl nicht seine Verirrung? Oder <supplied reason="undefined" resp="#editor">soll man eine solche
+annehmen</supplied>, weil er nicht gestattete, viele Götter zu verehren, denen, die
+von der Verehrung des allein <corr resp="#editor">höchsten</corr>, untrügerischen Gottes in diesen
 wahrhaftigen Irrtum kopfüber gefallen waren? Aber dies Wort war
-weder neu noch ihm gigentümlich, sondern war (Sache) der einst aufleuchtenden <lb n="5"/>
+weder neu noch ihm gigentümlich, sondern war <supplied reason="undefined" resp="#editor">Sache</supplied> der einst aufleuchtenden <lb n="5"/>
 gottliebenden Hebräer gewesen, von denen auch die neueren
 Philosophen mächtig gefördert wurden und mit deren Lehre sie übereinstimmten.
 Es rühmen sich aber auch die Weisesten der Griechen
-wegen der Orakel ihrer Götter, da sie (die Orakel) die Hebräer so erwähnen:
+wegen der Orakel ihrer Götter, da sie <supplied reason="undefined" resp="#editor">die Orakel</supplied> die Hebräer so erwähnen:
 „Allein die Chaldäer erlangten Weisheit und die Hebräer, die <lb n="10"/>
 Gott, den König des Alls, den ans sich selbst Erzeugten, fromm verehrten.“</p>
 </div>
@@ -8444,11 +8448,11 @@ Gott, den König des Alls, den ans sich selbst Erzeugten, fromm verehrten.“</p
 <div type="textpart" subtype="chapter" n="4">
 <p>Wenn also auch einst die Gottliebenden, über die besonders
 auch die Orakel Zeugnis ablegen, zu dem allerhöchsten Gott die
-Verehrung erhoben, warum bekennen wir (dann), daß er ein Verführer
+Verehrung erhoben, warum bekennen wir <supplied reason="undefined" resp="#editor">dann</supplied>, daß er ein Verführer
 sei, und nicht vielmehr ein bewundernswerter Lehrer der Frömmigkeit, <lb n="15"/>
 er, der das, was einst von den Kindern der hebräischen Patriarchen
 allein erkannt wurde, zu allen Menschen ausbreitete, sodaß fortan
-nicht (mehr) wie früher wenige Menschen, gering an Zahl, die rechte
+nicht <supplied reason="undefined" resp="#editor">mehr</supplied> wie früher wenige Menschen, gering an Zahl, die rechte
 Meinung über Gott besaßen, sondern Myriaden Scharen der Barbaren
 zumal, die einst die wildesten waren, und der weisen und hellenischen <lb n="20"/>
 Männer, die nach Art der früheren Propheten und frommen Männer
@@ -8461,7 +8465,7 @@ Lehre?</p>
 um dessentwillen sie ihn einen Verführer heißen: daß er lehrte, nicht <lb n="25"/>
 mehr durch Stieropfer, noch durch Schlachtungen unvernünftiger Tiere,
 noch durch Blut und Feuer, noch durch Räucherwerk, das von der Erde
-(aufsteigt), Gott verehren, deswegen, weil er *zeigte, daß dies minderwertig
+<supplied reason="undefined" resp="#editor">aufsteigt</supplied>, Gott verehren, deswegen, weil er <corr resp="#editor">zeigte</corr>, daß dies minderwertig
 und irdisch sei <add>und</add> niemals entspreche der unsterblichen
 unkörperlichen Natur, vielmehr urteilte, daß von allen Opfern dies das <lb n="30"/>
 angenehmste und Gott wohlgefälligste sei, die göttlichen Gebote zu halten,
@@ -8480,30 +8484,30 @@ mit Gott anzuähneln. Wenn aber jemand von den Griechen dies tadelt, <milestone 
 so wisse er, daß er keineswegs das sinnt, was seinen Lehrern angenehm
 ist, die vieles darüber anordneten, daß man nicht glauben dürfe, Gott
 <lb n="5"/> durch Blut und Opfer unvernünftiger Tiere und durch Feuer, Rauch
-und (Fett)geruch zu ehren.</p>
+und <supplied reason="undefined" resp="#editor">Fett</supplied>geruch zu ehren.</p>
 </div>
 <div type="textpart" subtype="chapter" n="6">
-<p>Außerdem aber wissen wir, die wir von ihm (Christus) gelernt
-haben, daß die Welt geworden ist und (daß) der Himmel selbst, die
+<p>Außerdem aber wissen wir, die wir von ihm <supplied reason="undefined" resp="#editor">Christus</supplied> gelernt
+haben, daß die Welt geworden ist und <supplied reason="undefined" resp="#editor">daß</supplied> der Himmel selbst, die
 Sonne, der Mond und die Sterne Werke Gottes sind, und daß ma nicht
-<lb n="10"/> diese (Dinge), sondern (nur) den Werkmeister und Schöpfer aller verehren
-dürfe. Recht also ist es, zu betrachten, ob er *uns verführt hat, die
+<lb n="10"/> diese <supplied reason="undefined" resp="#editor">Dinge</supplied>, sondern <supplied reason="undefined" resp="#editor">nur</supplied> den Werkmeister und Schöpfer aller verehren
+dürfe. Recht also ist es, zu betrachten, ob er <corr resp="#editor">uns</corr> verführt hat, die
 wir diese Art der Gesinnung von ihm gelernt haben, obgleich auch diese
-Rede keineswegs neu, sondern (schon Lehre) der einst gottliebenden
-Hebräer war, und (obgleich) auch von den Philosophen die namhaftesten
-<lb n="15"/> in ebendenselben (Dingen) übereinstimmten, daß geworden sei sowohl
+Rede keineswegs neu, sondern <supplied reason="undefined" resp="#editor">schon Lehre</supplied> der einst gottliebenden
+Hebräer war, und <supplied reason="undefined" resp="#editor">obgleich</supplied> auch von den Philosophen die namhaftesten
+<lb n="15"/> in ebendenselben <supplied reason="undefined" resp="#editor">Dingen</supplied> übereinstimmten, daß geworden sei sowohl
 Himmel selbst wie die Sonne, der Mond und die Gestirne, und
 sagten, daß die ganze Welt von dem Schöpfer des Alls gemacht sei.</p>
 <p>Ferner aber hat er uns glauben gelehrt, daß die Seele in uns unsterblich
 und in nichts den unvernünftigen Tieren ähnlich sei, sondern
 <lb n="20"/> die Bilder der Kräfte Gottes in sich trage, und hat jeden Barbaren und
-Laien unterrichtet, sich so zu verhalten, (so) zu sein und (solche) Gesinnung
-zu hegen. Hat er uns nicht (dadurch) weiser gemacht als die
-weisesten unter den Ägyptern und als die Griechen, die (vornehm) ihre
+Laien unterrichtet, sich so zu verhalten, <supplied reason="undefined" resp="#editor">so</supplied> zu sein und <supplied reason="undefined" resp="#editor">solche</supplied> Gesinnung
+zu hegen. Hat er uns nicht <supplied reason="undefined" resp="#editor">dadurch</supplied> weiser gemacht als die
+weisesten unter den Ägyptern und als die Griechen, die <supplied reason="undefined" resp="#editor">vornehm</supplied> ihre
 Augenbrauen in die Höhe ziehen, die gesagt haben, daß die Seele im
 <lb n="25"/> Menschen ihrer οὐσία nach nichts besser sei als Schnaken, Flöhe, Würmer
-und Fliegen, aber (daß) auch nicht einmal von der Seele der Schlange,
-der Natter, des *Bären, des Panthers und des Schweines sich ihre eigene
+und Fliegen, aber <supplied reason="undefined" resp="#editor">daß</supplied> auch nicht einmal von der Seele der Schlange,
+der Natter, des <corr resp="#editor">Bären</corr>, des Panthers und des Schweines sich ihre eigene
 Stele ihrem Wesen nach in irgend etwas unterscheide?</p>
 </div>
 
@@ -8521,7 +8525,7 @@ zu sein und zu wissen“ Σ (1. <foreign xml:lang="abbr">ABBREV</foreign> ?) 25 
 ἀρετὴν D „zur Tugend zu eilen“ Σ</note>
 
 <pb n="v.3.pt.2.p.223"/>
-um der Kampf(preise) willen, die den Frommen aufbewahrt werden, dagegen
+um der Kampf<supplied reason="undefined" resp="#editor">preise</supplied> willen, die den Frommen aufbewahrt werden, dagegen
 jede Boshaftigkeit zu fliehen und von sich zu stoßen wegen der
 Strafen, die den Gottlosen auferlegt werden? Denn derart waren die
 <milestone unit="altnumbering" n="177"/> Unterweisungen, die in den Dogmen der Lehre unsers Erlösers eingeschlossen
@@ -8531,14 +8535,14 @@ wir auch dies.</p>
 </div>
 <div type="textpart" subtype="chapter" n="8">
 <p>Zu was für Leuten macht der Zauberer seine Genossen, wenn
-er ihnen Anteil gibt an den (Dingen) der Bosheit? (Macht er sie) nicht
+er ihnen Anteil gibt an den <supplied reason="undefined" resp="#editor">Dingen</supplied> der Bosheit? <supplied reason="undefined" resp="#editor">Macht er sie</supplied> nicht
 zu Zauberern und Betrügern und Giftmischern, die in allem ihm gleichen? <lb n="10"/>
 Ist denn jemals jemand im ganzen Geschlecht der Christen gefunden
 worden, der infolge der Lehre unsers Erlösers Zauberei trieb oder Gift
-(mischte)? Aber man kann keinen nennen, im Gegensatz dazu ist vielmehr
+<supplied reason="undefined" resp="#editor">mischte</supplied>? Aber man kann keinen nennen, im Gegensatz dazu ist vielmehr
 ersichtlich, daß sie den Worten göttlicher Philosophie nachgehen.
 Er also, der in der ganzen Menschenwelt für alle Völker die Ursache <lb n="15"/>
-eines reinen und keuschen Lebens und des Wissens (und) der Verehrung
+eines reinen und keuschen Lebens und des Wissens <supplied reason="undefined" resp="#editor">und</supplied> der Verehrung
 des Schöpfers aller war — was darf mit Recht geglaubt werden als dies,
 daß er in Wahrheit der gemeinsame Erlöser aller ist und der Lehrer
 eines gottesfürchtigen Lebens?</p>
@@ -8547,17 +8551,17 @@ eines gottesfürchtigen Lebens?</p>
 <div type="textpart" subtype="chapter" n="9">
 <p>Diejenigen aber, die von Anfang
 an ihm anhingen, und diejenigen, die später die Überlieferung der Gewohnheit <note type="marginal">20</note>
-jener (Apostel) übernahmen, waren so weit entfernt von bösen
+jener <supplied reason="undefined" resp="#editor">Apostel</supplied> übernahmen, waren so weit entfernt von bösen
 und bitteren Gedanken, daß sie nicht einmal den Kranken erlaubten,
 das zu tun, was viele in vielen Fällen versuchen: entweder Schalen zu
 beschreiben oder Amulette zu gebrauchen oder den Sinn hinzuwenden
 zu denen, die zu besprechen vorgeben, oder durch Räucherwerk von <lb n="25"/>
-Wurzeln und Gemüse und (durch) andere (Dinge), die diesen gleichen,
+Wurzeln und Gemüse und <supplied reason="undefined" resp="#editor">durch</supplied> andere <supplied reason="undefined" resp="#editor">Dinge</supplied>, die diesen gleichen,
 Heilungen der Schmerzen für sich zu beschaffen. Alles dies also ist
 infolge der Lehre unsers Erlösers vertrieben und niemals ist es möglich,
 einen Christen zu finden, der Amulette gebraucht, noch Besprechungen,
 noch den Vorwitz, auf Schalen zu schreiben, noch andere derartige Dinge <lb n="30"/>
-(anwendet), deren Gebrauch bei den meisten für gleichgültig gehalten
+<supplied reason="undefined" resp="#editor">anwendet</supplied>, deren Gebrauch bei den meisten für gleichgültig gehalten
 <note type="footnote">3—5 vgl. Dem. III 319 5 —19 = Dem. III 67—8 19—S. 224, 17=
 Dem. III 6 9—14</note>
 <note type="footnote">8 ἑταίροις Σ ἑτέροις D 17 τίς ἂν ἐνδίκως νομισθείη D „genannt werden“
@@ -8573,20 +8577,20 @@ zu Jüngern gemacht wordeu, da doch für jeden, der sich als Meister
 einer Lehre ausgibt, ein großer Beweis die Gemeinschaft seiner Jünger
 <lb n="5"/> ist? Künstler und Gelehrte also sagen durchaus von dem, der die Ursache
 ihrer Lehre für sie war, daß er besser sei als sie. Denn wie auch
-Ärzte Zeugen sind für die Richtigkeit *der Lehre ihres Meisters, die
+Ärzte Zeugen sind für die Richtigkeit <corr resp="#editor">der</corr> Lehre ihres Meisters, die
 Geometer aber — wen anders erkennen sie als Führer für sich an, wenn
 nicht einen Geometer, und die Arithmetiker einen Arithmetiker? Demgemäß <milestone unit="altnumbering" n="178"/>
 <lb n="10"/> sind aber auch die besten Zeugen für einen Zauberer seine
-Jünger, die ebenfalls ihrem Meister durchaus ähnliche (Dinge) tun.
+Jünger, die ebenfalls ihrem Meister durchaus ähnliche <supplied reason="undefined" resp="#editor">Dinge</supplied> tun.
 Aber auch nicht ein Jünger unsers Erlösers ist jemals in allen diesen
 Jahren als Zauberer erfunden worden, obwohl zu allen Zeiten Könige
-und ἡγεμόνες sorgfältig durch böse (Folter)qualen eine Untersuchung
+und ἡγεμόνες sorgfältig durch böse <supplied reason="undefined" resp="#editor">Folter</supplied>qualen eine Untersuchung
 <lb n="15"/> der Dinge veranstaltet haben.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="10">
 <p>So wenig war aber irgend ein Zauberer
-sein Jünger, daß freigelassen wurde und jedes (gefährlichen) Prozesses
+sein Jünger, daß freigelassen wurde und jedes <supplied reason="undefined" resp="#editor">gefährlichen</supplied> Prozesses
 ledig war, wer nur zu opfern von ihnen gezwungen war.</p>
 </div>
 
@@ -8595,7 +8599,7 @@ ledig war, wer nur zu opfern von ihnen gezwungen war.</p>
 su empfange den Beweis dafür auch aus der Schrift: Die ersten Vertrauten
 <lb n="20"/> und Jünger unsers Erlösers machten nach der Schrift ihrer
 Πραξεῖς diejenigen, die aus den Heiden zu ihrer Lehre kamen, derart,
-daß viele von ihnen, die früher der Zauberei *beschuldigt waren, ihre
+daß viele von ihnen, die früher der Zauberei <corr resp="#editor">beschuldigt</corr> waren, ihre
 Art so sehr veränderten, daß sie mitten in die Menge die verworfenen
 Bücher zu bringen wagten, die einst bei ihnen verborgen waren, und
 <lb n="25"/> eben sie vor jedermann dem Feuer übergaben. Höred aber, wie die
@@ -8610,8 +8614,8 @@ wert waren.“</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="13">
-<p>*Derart also waren die Jünger unsers Erlösers,
-<lb n="30"/> und sie brachten eine so große Kraft *der Worte
+<p><corr resp="#editor">Derart</corr> also waren die Jünger unsers Erlösers,
+<lb n="30"/> und sie brachten eine so große Kraft <corr resp="#editor">der</corr> Worte
 mit den den Hörern hervor, daß sie in die Tiefe ihrer Seele trafen
 <note type="footnote">17—225,8 = Dem. III 614—18 26 = Act 19 19</note>
 <note type="footnote">1 „Welches Wort also gibt es, das gesagt werden kann“ Σ τίς οὐν ἐρεῖ
@@ -8627,7 +8631,7 @@ und das Gewissen eines jeden schlugen und verwundeten, sodaß sie
 es nicht mehr aushielten, das zu verstecken, wodurch früher viele in
 die Irre geführt wurden, sondern das Verborgene ans Licht brachten
 und Zeugen wurden wider sich selbst und wider ihre frühere Bosheit.
-*Derartig waren aber auch die, welche von ihnen zu Jüngern gemacht <lb n="5"/>
+<corr resp="#editor">Derartig</corr> waren aber auch die, welche von ihnen zu Jüngern gemacht <lb n="5"/>
 wurden: rein und lauter in ihrer Seele und echt in ihrer Liebe, sodaß
 <milestone unit="altnumbering" n="179"/> sie nichts Tadelnswertes in sich versteckt ließen, sondern sich rühmten
 und frohlockten wegen der Wandlung vom Schlechteren zum Besseren.
@@ -8639,21 +8643,21 @@ Menge Scharen von Männern sind, die sich wappnen wider die natürlichen
 Lüste des Leibes und ihren Geist unverwundet von allen schändlichen
 Leidenschaften zu bewahren sich bemühen, die ihr ganzes Leben <lb n="15"/>
 hindurch in Reinheit alt geworden sind und glänzende Zeugnisse infolge
-der aus seinen Worten (geschörften) Nahrung aufwiesen.</p>
+der aus seinen Worten <supplied reason="undefined" resp="#editor">geschörften</supplied> Nahrung aufwiesen.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="14">
 <p>Aber
 nicht nur Männer wurden bei ihm in dieser Weise Philoaophen, sondern
 auch Myriaden von Weibern in der ganzen Welt, die nach Art von
-Priesterinnen des über alles (waltenden) Gottes den höchsten (Gottes)dienst <lb n="20"/>
+Priesterinnen des über alles <supplied reason="undefined" resp="#editor">waltenden</supplied> Gottes den höchsten <supplied reason="undefined" resp="#editor">Gottes</supplied>dienst <lb n="20"/>
 geliebt haben, von der Liebe zur himmlischen Weisheit erfaßt
 sind, die Geburt des Leibes verachtet, sich alle Mühe um ihre Seele
-gegeben, sich vor jedem Schmutz und *Unrat rein bewahrt und gänzliche
+gegeben, sich vor jedem Schmutz und <corr resp="#editor">Unrat</corr> rein bewahrt und gänzliche
 Heiligkeit und Jungfräulichkeit geliebt haben.</p>
-<p>Von Einem (Philosophen) aber singen die Griechen, der sein Land <lb n="25"/>
-als (Schaf)weide überließ unter dem Vorwande der Philosophie, und bringen
-ihn (im Liede) herum , hierhin und dorthin. Es war dies aber Demokrit.
+<p>Von Einem <supplied reason="undefined" resp="#editor">Philosophen</supplied> aber singen die Griechen, der sein Land <lb n="25"/>
+als <supplied reason="undefined" resp="#editor">Schaf</supplied>weide überließ unter dem Vorwande der Philosophie, und bringen
+ihn <supplied reason="undefined" resp="#editor">im Liede</supplied> herum , hierhin und dorthin. Es war dies aber Demokrit.
 Und man bewundert einen gewissen Krates, der sein Besitztum
 seinen Bürgern gab, sich selbst bezwang und mit der freien Selbst-
 <note type="footnote">9—S. S. 226, 13 = Dem. III 619—24 25 vgl. Menag. ad Diogen. Laert. II 6
@@ -8667,7 +8671,7 @@ Einen Hirten (= μηλοβότην) aber, der seinen Platz aus dem Grunde der Ph
 (ver-?)ließ, singen (= ᾄδουσιν) die Griechen“ Σ 29 „sich selbst bezwang —
 prahlte“] αὐτὸς ἑαυτὸν Κράτης Κράτητα ἠλευθέρου κομπάζων D | „Selbstbeherrschung“]
 <foreign xml:lang="abbr">ABBREV</foreign> PSm = „Meinung“
-Eusebins III*.</note>
+Eusebius III*.</note>
 
 <pb n="v.3.pt.2.p.226"/>
 beherrschung prahlte. Die Eiferer für die Worte unsers Erlösers aber
@@ -8675,9 +8679,9 @@ sind Myriaden an Zahl, keineswegs einer noch zweie, die ihren Besitz
 verkauften und den Armen und Bedürftigen gaben, deren Zeugen
 wir geworden sind, die wir mit derartigen Männern zusammen waren
 <lb n="5"/> und eben in Taten die richtige Ausführung der Lehre unsers Erlösers
-(mit) ansahen.</p>
+<supplied reason="undefined" resp="#editor">mit</supplied> ansahen.</p>
 <p>Was habe ich nötig zu sagen, wieviele Myriaden selbst von den
-Barbaren *nicht nur, sondern auch von den Griechen durch die Lehre
+Barbaren <corr resp="#editor">nicht</corr> nur, sondern auch von den Griechen durch die Lehre
 der Worte unsers Erlösers emporgehoben wurden über jede polytheistische
 <lb n="10"/> Verirrung und den Einen Gott allein, den Vater und Schörfer
 dieser ganzen Welt erkannten und bekannten? Ihn, den einst Einer:
@@ -8702,10 +8706,10 @@ Meister war.</p>
 <p>Wohlan aber, ferner wollen wir das Wort auch so prüfen!
 Einen Zauberer nennst du ihn, du da!, aber auch einen geschickten
 Quacksalber und Verführer heißt du ihn. Ist er denn jetwa als der
-<lb n="30"/> alleinige (und) erste Erfinder dieser Sache aufgetreten, oder dúrfen wir
-mit Recht die Ursache gemäß der (auch sonst üblichen) Gewohnheit
+<lb n="30"/> alleinige <supplied reason="undefined" resp="#editor">und</supplied> erste Erfinder dieser Sache aufgetreten, oder dúrfen wir
+mit Recht die Ursache gemäß der <supplied reason="undefined" resp="#editor">auch sonst üblichen</supplied> Gewohnheit
 auf die Lehrer zurückführen? Wenn er also, ohne daß ihn jemand belehrte
-zum ersten (und) alleinigen Erfinder dieser Sache ward, ohne
+zum ersten <supplied reason="undefined" resp="#editor">und</supplied> alleinigen Erfinder dieser Sache ward, ohne
 <note type="footnote">12 vgl. Piaton Timaios 28 C — S. 227,34 = Dem. III 6 25—29</note>
 <note type="footnote">8 „und nicht nur“ Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 9 „emporgehoben wurden“] ὑπερεκκῦψαι D
 20 ὥστε . . . μυρία πλήθη . . . . τοσοῦτον τοῦ Πλάτωνος μὴ πείθεσθαι D τοῦ
@@ -8715,36 +8719,36 @@ der Gewohnheit“] <foreign xml:lang="abbr">ABBREV</foreign> <foreign xml:lang="
 
 <pb n="v.3.pt.2.p.227"/>
 je etwas von anderen gelernt, noch von den Vorgängern entlehnt zu
-haben, wie sollten wir (dann) nicht von ihm bekennen, daß seine Natur
+haben, wie sollten wir <supplied reason="undefined" resp="#editor">dann</supplied> nicht von ihm bekennen, daß seine Natur
 göttlich sei, er. der ohne Bücher, Worte und Lehrer, ein Selbstgelehrter
 und Selbstgebildeter, als Schöpfer dieser Dinge erschienen ist, obwohl
 es nicht möglich ist, die Lehre einer Handwerkskunst oder der logischen <lb n="5"/>
-Wissenschaft und nicht (einmal) der ersten Elemente ohne irgend einen
-Unterweiser und Lehrer (in sich) aufzunehmen, es sei denn, daß jemand
-außerhalb der <add>gemeinsamen</add> (Menschen)natur stehe. Niemals also trat
+Wissenschaft und nicht <supplied reason="undefined" resp="#editor">einmal</supplied> der ersten Elemente ohne irgend einen
+Unterweiser und Lehrer <supplied reason="undefined" resp="#editor">in sich</supplied> aufzunehmen, es sei denn, daß jemand
+außerhalb der <add>gemeinsamen</add> <supplied reason="undefined" resp="#editor">Menschen</supplied>natur stehe. Niemals also trat
 ein Selbstgelehrter hervor als Lehrer der Grammatik, noch ein Rhetor.
 ohne gelernt zu haben, noch wurde ein Arzt <add>aus sich</add> selbst, noch ein <lb n="10"/>
 Zimmermanu, noch der Schöpfer einer andern Kunst, obwohl dies gering
-ring und menschlich ist. Die (Tatsache) aber, daß jemand von dem
+ring und menschlich ist. Die <supplied reason="undefined" resp="#editor">Tatsache</supplied> aber, daß jemand von dem
 Lehrer der ganzen Menschenwelt, der die Wunder getan hat, die in der
 <milestone unit="altnumbering" n="181"/> Schrift seiner Jünger geschrieben sind, sagt, er sei aus sich selbst so
 geworden, ohne von den Vorgängern empfangen zu haben noch von <lb n="15"/>
-neueren Lehrern unterstützt zu sein, die ihm gleich (auch) vor ihm handelten,
+neueren Lehrern unterstützt zu sein, die ihm gleich <supplied reason="undefined" resp="#editor">auch</supplied> vor ihm handelten,
 — was bedeutet das anderes als das Zeugnis und Bekenntnis,
-daß (hier) etwas Göttliches war und (einer, der) besser (war) als jede
+daß <supplied reason="undefined" resp="#editor">hier</supplied> etwas Göttliches war und <supplied reason="undefined" resp="#editor">einer, der</supplied> besser <supplied reason="undefined" resp="#editor">war</supplied> als jede
 menschliche Natur?</p>
 </div>
 <div type="textpart" subtype="chapter" n="16">
 <p>Aber du sagst, daß er verführende Lehrer besaß und daß <lb n="20"/>
-ihm nicht verborgen waren die weisen (Theorien) der Ägypter und die
-geheimen (Mysterien), die einst bei ihnen verkündet wurden, von denen
-er sammelte und als derartiger Mann erschien, wie das Wort (der
-Schrift) sagt. Was also? Sind andere etwa besser als er erschienen
+ihm nicht verborgen waren die weisen <supplied reason="undefined" resp="#editor">Theorien</supplied> der Ägypter und die
+geheimen <supplied reason="undefined" resp="#editor">Mysterien</supplied>, die einst bei ihnen verkündet wurden, von denen
+er sammelte und als derartiger Mann erschien, wie das Wort <supplied reason="undefined" resp="#editor">der
+Schrift</supplied> sagt. Was also? Sind andere etwa besser als er erschienen
 und früher der Zeit nach und seine Lehrer, sei es in Agypten, sei es <lb n="25"/>
 wo sonst? Warum lief nicht auch die Kunde von jenen, bevor dieser
 sich einen Namen machte, zu allen Menschen diesem gleich, und warum
 wird nicht auch der Ruhm jener diesem gleich bis jetzt verkündet? Welcher
-Zauberer aber von denen, die von Ewigkeit her (lebten), Barbare oder
+Zauberer aber von denen, die von Ewigkeit her <supplied reason="undefined" resp="#editor">lebten</supplied>, Barbare oder
 Grieche, trat auf als Lehrer solcher Jünger und ward zum Herrscher <lb n="30"/>
 so vieler Gesetze und Worte wie die sind, welche die Kraft des gemeinsamen
 Erlösers aller zeigten? Von wem aber ist jemals geschrieben,
@@ -8758,9 +8762,9 @@ gemäß dem, was vor ihm war, handelten“ Σ 24 τί δῆτα οὐν, ἤ τ
 κατηγορίας D</note>
 
 <pb n="v.3.pt.2.p.228"/>
-von aller Ewigkeit her, *der vor ihm oder nach ihm war, wird berichtet,
+von aller Ewigkeit her, <corr resp="#editor">der</corr> vor ihm oder nach ihm war, wird berichtet,
 daß er das Wissen der Zukunft und soviele und derartige Prophezeiungen
-überlieferte, die kürzlich durch die früheren (Ausführungen)
+überlieferte, die kürzlich durch die früheren <supplied reason="undefined" resp="#editor">Ausführungen</supplied>
 vorgelegt sind? Wer aber hat verheißen, undefined daß er das tun werde in der
 <lb n="5"/> ganzen Menschenwelt, was er durch das Wort voraussagte, und hat
 durch die Tat seine Worte bestätigt, sodaß die Erfüllungen seiner
@@ -8771,21 +8775,21 @@ der Dinge haben jemals in der Bewährung durch Feuer und Eisen die
 die Jünger unsers Erlösers, die alle Mißhandlungen ertrugen für das,
 was sie sahen und von ihm bezeugten, und alle Arten von Qualen
 erduldeten und schließlich die Zeugnisse, die sie von ihm als dem Sohne
-Gottes, geschweige denn (als von) einem Zauberer ablegten, durch ihr
+Gottes, geschweige denn <supplied reason="undefined" resp="#editor">als von</supplied> einem Zauberer ablegten, durch ihr
 <lb n="15"/> eigenes Blut versiegelten? Wem aber von den Zauberern kam es jemals
 in den Sinn, die Sammlung eines neuen Volkes auf seinen Namen <milestone unit="altnumbering" n="182"/>
-zu veranstalten? Die (Tatsache) aber, daß er es nicht nur überlegte,
+zu veranstalten? Die <supplied reason="undefined" resp="#editor">Tatsache</supplied> aber, daß er es nicht nur überlegte,
 sondern auch die Überlegung ausführte, wie sollte das nicht jede
-Natur der Menschen in den Schatten stellen? Und die (Tatsache),
+Natur der Menschen in den Schatten stellen? Und die <supplied reason="undefined" resp="#editor">Tatsache</supplied>,
 <lb n="20"/> daß er Gesetze auferlegte, die der polytheistischen Verirrung entgegengesetzt
-(waren), wider die Satzungen der Könige, der früheren Gesetzgeber,
-der Philosophen, Poeten und Theologen, und diese (Gesetze) *bestätigte
+<supplied reason="undefined" resp="#editor">waren</supplied>, wider die Satzungen der Könige, der früheren Gesetzgeber,
+der Philosophen, Poeten und Theologen, und diese <supplied reason="undefined" resp="#editor">Gesetze</supplied> <corr resp="#editor">bestätigte</corr>
 und für die lange Ewigkeit als unbesiegbar und unüberwindlich
 zeigte —</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="17">
-<p>wer jemals von den Zauberern ersann (das)? Unser
+<p>wer jemals von den Zauberern ersann <supplied reason="undefined" resp="#editor">das</supplied>? Unser
 <lb n="25"/> Erlöser aber ersann es nicht ohne daß er wagte, hand anzulegen, sondern
 er legte nicht einmal Hand an, ohne es auszuführen. Mit Einem Worte
 und mit Einer Stimme sagte er zu seinen Jüngern: „Gehet hin und
@@ -8808,23 +8812,23 @@ seinen Befehl in Völker gesät, entgegengesetzt der alten polytheistischen
 Verehrung, Gesetze: Feinde der Dämonen und Gegner der polytheistischen
 Verirrung, Gesetze: Zügler der Skythen, der Perser und der andern
 Barbaren und Abwender von jedem tierischen und ungesetzlichen <lb n="5"/>
-Leben, Gesetze: Zerstörer der seit Ewigkeit unter den Griechen (geübten)
+Leben, Gesetze: Zerstörer der seit Ewigkeit unter den Griechen <supplied reason="undefined" resp="#editor">geübten</supplied>
 Sitten und Lehrer einer neuen und wahren Frömmigkeit. Was also
-haben derart gewagt *frühere Zauberer vor der Zeit unsers Erlösers,
+haben derart gewagt <corr resp="#editor">frühere</corr> Zauberer vor der Zeit unsers Erlösers,
 daß man mit Recht von ihm sagen könnte, er sei von andern unterstützt
 worden in dieser Zauberei? Wenn man aber einen andern nicht <lb n="10"/>
 nennen kann, der ihm ähnlich war, so war ihm also niemand die Ursache
-für so große Tüchtigkeit. Zeit ist *also zu bekennen, daß
+für so große Tüchtigkeit. Zeit ist <corr resp="#editor">also</corr> zu bekennen, daß
 eine fremde und göttlche Natur in die Welt gekommen sei, die allein
-(und) zuerst das tat, was niemals unter den Menschen berichtet wird.</p>
+<supplied reason="undefined" resp="#editor">und</supplied> zuerst das tat, was niemals unter den Menschen berichtet wird.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="18">
 <p>Nach diesem wollen wir ferner fragen, ob jemals jemand <lb n="15"/>
-mit seinen Augen sah oder durch Hören (sagen) erfuhr, daß es irgend
+mit seinen Augen sah oder durch Hören <supplied reason="undefined" resp="#editor">sagen</supplied> erfuhr, daß es irgend
 welche Zauberer und Giftmischer gebe, die ohne Spenden, Opfer und
 Anrufung von Dämonen zaubern, da doch jedermann bekannt und offenbar
-ist, daß jede Zauberei durch diese (Dinge) ausgeführt zu werden
+ist, daß jede Zauberei durch diese <supplied reason="undefined" resp="#editor">Dinge</supplied> ausgeführt zu werden
 <milestone unit="altnumbering" n="183"/> pflegt? Kann also etwa jemand auch gegen unsern Erlöser oder gegen <lb n="20"/>
 seine Jünger oder gegen diejenigen, die bis jetzt in seiner Lehre
 leben, eine derartige Verleumdung vorbringen? Ist es nicht auch dem
@@ -8834,8 +8838,8 @@ suchen und eher aufs Leben verzichten als es ertragen, unter die Dämonen <lb n=
 geknechtet zu werden? Wer aber weiß nicht, wie es uns lieb
 ist. eben mit dem Namen unsers Erlösers und mit seinen Gebeten jedes
 dämonische Geschlecht zu vertreiben? So hat das Wort unsers Erlösers
-und die von ihm (ausgehende) Lehre uns alle viel besser gemacht,
-als die unsichtbare und unbewährte Kraft (der Dämonen), und uns zu <lb n="30"/>
+und die von ihm <supplied reason="undefined" resp="#editor">ausgehende</supplied> Lehre uns alle viel besser gemacht,
+als die unsichtbare und unbewährte Kraft <supplied reason="undefined" resp="#editor">der Dämonen</supplied>, und uns zu <lb n="30"/>
 Feinden und Hassern der Dämonen bereitet, aber keineswegs zu Freunden
 und Genossen, geschweige denn zu Untertanen und Hörigen. Er also,
 der derartiges überlieferte denen, die sich von ihm überzeugen lassen,
@@ -8848,7 +8852,7 @@ ABBERV 23 „bereitet sind“] ἐπιτηδεύομεν D 28 „Geschlecht“] 
 Par. 470 am Rande | „So . . . das Wort“] ουτος ὁ . . . λόγος D</note>
 
 <pb n="v.3.pt.2.p.230"/>
-Geister bis jetzt vor seinem Namen erschrecken wie vor einer (Art)
+Geister bis jetzt vor seinem Namen erschrecken wie vor einer <supplied reason="undefined" resp="#editor">Art</supplied>
 von Qual und Strafe ihrer eigenen Natur und fortgehen und weichen
 vor seiner Kraft, wie sie auch einst zu der Zeit, wo er seinen Verkehr
 mit den Menschen ausübte, seinen Anblick nicht ertrugen, sondern
@@ -8860,22 +8864,22 @@ uns zu quälen?“</p>
 <p>Ein Mann, der nur auf die Zauberei seinen Sinn richtete und
 völlig verworfene Dinge angriffe, wäre der nicht seiner Art
 <lb n="10"/> und offenbar lüstern, schändlich, frevelhaft, gottlos
-Und wenn er so wäre, woher oder wie könnte er die (Worte)
+Und wenn er so wäre, woher oder wie könnte er die <supplied reason="undefined" resp="#editor">Worte</supplied>
 audere lehren oder die über die Keuschheit oder die über die
 Kenntnis Gottes oder die über die Unsterblichkeit der Seele oder die
-über die Gerechtigkeit und über das Gericht des über alles (waltenden)
+über die Gerechtigkeit und über das Gericht des über alles <supplied reason="undefined" resp="#editor">waltenden</supplied>
 <lb n="15"/> Gottes? Würde er denn nicht das Gegenteil von alledem
 indem er das täte, was der Schlechtigkeit entspräche, würde
 die Vorsehung Gottes leugnen, das Gericht Gottes und seine Gerechtigkeit
-als einen Mythos *verhöhnen und die Worte über die Tugend und <milestone unit="altnumbering" n="184"/>
+als einen Mythos <corr resp="#editor">verhöhnen</corr> und die Worte über die Tugend und <milestone unit="altnumbering" n="184"/>
 die Unsterblichkeit der Seele verspotten? Wenn derartiges gesehen
 <lb n="20"/> würde auch bei unserm <add>Erlöser</add>, so wäre nichts dagegen
 Wenn es aber ersichtlich ist, daß er bei allen seinen Worten und
-den oberhalb von allem (stehenden) Gott, den König des Alls
+den oberhalb von allem <supplied reason="undefined" resp="#editor">stehenden</supplied> Gott, den König des Alls
 und seine Jünger bereitete, so zu sein, und wenn er selbst
 und ein Lehrer besonnener Worte und wenn er ein Täter und Herold
-<lb n="25"/> der Gerechtigkeit, Wahrheit, (Menschen)freundlichkeit und jeder Tugend
-und wenn er ein (Weg)weiser der Verehrung des Allkönigs Gott
+<lb n="25"/> der Gerechtigkeit, Wahrheit, <supplied reason="undefined" resp="#editor">Menschen</supplied>freundlichkeit und jeder Tugend
+und wenn er ein <supplied reason="undefined" resp="#editor">Weg</supplied>weiser der Verehrung des Allkönigs Gott
 ist, wie sollte es nicht dem entsprechen, zu glauben, daß er nichts
 <note type="footnote">5 = Matth 8 29</note>
 <note type="footnote">5 ὄλλος ἄλλοθεν D „der andere von der anderen Seite“ Σ 14 „Gerechtigkeit“]
@@ -8900,7 +8904,7 @@ schmähen gewagt haben. Wenn sie sich aber wandeln und bekennen.
 er selbst sei zwar ein Lehrer reinen und keuschen Lebens und ein Einführer
 in die Lehre der Gottesverehrung gewesen, aber er habe die
 staunenswerten Taten, Kräfte und Wunder, die über ihn
-sind, und die göttlichen Taten, die besser sind als (die der)
+sind, und die göttlichen Taten, die besser sind als <supplied reason="undefined" resp="#editor">die der</supplied>
 nicht gewirkt, sondern seine Jünger hätten sie vollständig
 ist es Zeit, auch dieser Verleumdung zu begegnen.</p>
 <p>Wider diejenigen, die den Zeugnissen der ünger unsers unsers über
@@ -8920,10 +8924,10 @@ die Worte und die Lehren oder irgend eine Kunst lieben, überlassen
 sich dem Lehrer. Welchen Grund also könnte jemand nennen,
 <milestone unit="altnumbering" n="185"/>die Jünger unsers Erlösers q mit ihm verkehrten und was
 sich um ihn zu bekümmern? Als Lehrer welcher Lehren erkannten sie
-ihn an? Oder ist dies klar? Denn (es ist) durchaus (notwendig, daß
-sie ihn als Lehrer dessen anerkannten), was sie von ihm lernten (und)
+ihn an? Oder ist dies klar? Denn <supplied reason="undefined" resp="#editor">es ist</supplied> durchaus <supplied reason="undefined" resp="#editor">notwendig, daß
+sie ihn als Lehrer dessen anerkannten</supplied>, was sie von ihm lernten <supplied reason="undefined" resp="#editor">und</supplied>
 auch zu andern sagten. Es waren dies aber Satzungen der Philosophie.
-und (folglich) war er der erste Prediger des über alles (waltenden)
+und <supplied reason="undefined" resp="#editor">folglich</supplied> war er der erste Prediger des über alles <supplied reason="undefined" resp="#editor">waltenden</supplied>
 <note type="footnote">14—28 = Dem. III</note>
 <note type="footnote">16 „fälschlich“] „anders“ Σ = ἄλλως &lt; D 20 δι’ ἣν (sc. αἰτίαν)
 μαθηταὶ ὁ δὲ διδόσκαλος ἐχρημάτισαν D . . . „in die Welt hervorgingen“
@@ -8935,20 +8939,20 @@ Lee statt „Anfang“) irgend einer Lehre“ Σ 25 ἐπεγράφοντο D
 
 <pb n="v.3.pt.2.p.232"/>
 Gottes, der Vorsehung Gottes, des gerechten Gerichts Gottes, der Unsterblichkeit
-der Seele, der Scheidung der (ewigen) Wohnungen der
-Guten und Bösen und anderer, dem verwandter (Lehren), die in
+der Seele, der Scheidung der <supplied reason="undefined" resp="#editor">ewigen</supplied> Wohnungen der
+Guten und Bösen und anderer, dem verwandter <supplied reason="undefined" resp="#editor">Lehren</supplied>, die in
 Büchern geschrieben sind. Es waren dies aber auch Vorschriften
 <lb n="5"/> ein philosophisches Leben, das er ihnen beschrieb, indem er sagte: „Ihr
-sollt kein Gold besitzen noch Silber in euren Beuteln und (überhaupt)
+sollt kein Gold besitzen noch Silber in euren Beuteln und <supplied reason="undefined" resp="#editor">überhaupt</supplied>
 keine Reisetaschen“ und anderes derart, sondern sie sollten sich
 der alles verwaltenden Vorsehung überlassen und nicht sorgen um die
-Bedürfnisse. wie er sie (auch) ermahnte, Besseres zu sinnen, als
-in Juden, denen Mose befahl. Denn der habe (ihnen) das Gesetz gegeben:
+Bedürfnisse. wie er sie <supplied reason="undefined" resp="#editor">auch</supplied> ermahnte, Besseres zu sinnen, als
+in Juden, denen Mose befahl. Denn der habe <supplied reason="undefined" resp="#editor">ihnen</supplied> das Gesetz gegeben:
 nicht zu töten als solchen, die zu einem Morde geneigt waren,
 aber auch: nicht zu ehebrechen als geilen und ehebrecherischen Leuten,
-ferner aber: nicht zu stehlen als (erbärmlichen) Menschen, denen
+ferner aber: nicht zu stehlen als <supplied reason="undefined" resp="#editor">erbärmlichen</supplied> Menschen, denen
 Knechtschaft geziemt, und: nicht zu veruntreuen als habgierigen
-<lb n="15"/> Menschen; für sie (die Jünger Jesu) selbst aber sei es
+<lb n="15"/> Menschen; für sie <supplied reason="undefined" resp="#editor">die Jünger Jesu</supplied> selbst aber sei es
 wissen, daß sie solcher Gesetze nicht bedürften, sondern mehr
 die Leidenschaftslosigkeit der Seele in ihren Augen zu achten und von
 unten wie aus der Wurzel ihres Geistes die Schößlinge des Bösen
@@ -8962,8 +8966,8 @@ rühmen, daß sie andere nicht beraubten, sondern darüber,
 was habe ich nötig, alles das zusammenzutragen, was er lehrte und
 lernten? Er riet ihnen aber außerdem, an der Wahrheit so
 daß man nicht einmal eines Treueides bedürfe, geschweige
-Mein(eides), sondern ihren Charakter (so) zu machen, daß er
-<lb n="30"/> erschien als jeder Eid, bis zum (einfachen) „Ja“ fortzuschreiten und
+Mein<supplied reason="undefined" resp="#editor">eides</supplied>, sondern ihren Charakter <supplied reason="undefined" resp="#editor">so</supplied> zu machen, daß er
+<lb n="30"/> erschien als jeder Eid, bis zum <supplied reason="undefined" resp="#editor">einfachen</supplied> „Ja“ fortzuschreiten und
 Wort mit Wahrhaftigkeit zu gebrauchen.</p>
 </div>
 <note type="footnote">4—S. 233,21 = Dem. III 433—38 5 = Matth 109f. 11 ff.
@@ -8978,8 +8982,8 @@ erschienen“ Σ</note>
 <pb n="v.3.pt.2.p.233"/>
 <milestone unit="altnumbering" n="186"/> <div type="textpart" subtype="chapter" n="22">
 <p>Wir müssen also fragen, ob es irgend einen Grund gibt,
-meinen, daß diejenigen, die Ηörer dieser (Worte) waren und auf
-Stelle auch als Lehrer anderer, *eigener Jünger auftraten, alles das
+meinen, daß diejenigen, die Ηörer dieser <supplied reason="undefined" resp="#editor">Worte</supplied> waren und auf
+Stelle auch als Lehrer anderer, <corr resp="#editor">eigener</corr> Jünger auftraten, alles das
 haben, was sie als Taten ihres Meisters bezeugt haben. Was
 aber ist daran ϋberzeugend, wenn man meint, daß alle übereinstimmend
 gelogen hätten, sind doch zwölf an Zahl die Auserwählten
@@ -8989,7 +8993,7 @@ kommen“? Aber kein Grund kann gesagt werden, warum man
 ganzen Schar von Menschen nicht glauben darf, die ein reines und <lb n="10"/>
 gottesfürchtiges Leben liebten, alle ihre Hausgenossen
 und anstatt ihrer Geliebten, ich meine aber ihrer Weiber, Kinder und
-ihrer ganzen Familie, ihre Leben(sart) besitzlos machten und ein ϋbereinstimmendes
+ihrer ganzen Familie, ihre Leben<supplied reason="undefined" resp="#editor">sart</supplied> besitzlos machten und ein ϋbereinstimmendes
 Zeugnis über ihren Meister wie aus Einem Munde unter
 alle Menschen hinaustrugen.</p>
 </div>
@@ -8999,21 +9003,21 @@ alle Menschen hinaustrugen.</p>
 und wahre, wäre dies; prüfen wir aber auch das hauptsächliche <lb n="15"/>
 und wahre, wäre dires; prüfen wir aber auch das Gegenteil!</p>
 <p>Er möge nämlich nämlich der Lehrer und sie die Jünger
-möge er nach der (fingierten) Voraussetzung der Rede nicht das
+möge er nach der <supplied reason="undefined" resp="#editor">fingierten</supplied> Voraussetzung der Rede nicht das
 Gesagte gelehrt haben, sondern das Gegenteil davon, nämlich: die
-übertreten, freveln, sündigen, veruntreuen, *rauben, Meineid leisten, <lb n="20"/>
+übertreten, freveln, sündigen, veruntreuen, <corr resp="#editor">rauben</corr>, Meineid leisten, <lb n="20"/>
 Verhaßtes tun und was sonst Böses genannt werden kann.
-aber ist vollkommen *fremd der Lehre unsers Erlösers und (ihr)
+aber ist vollkommen <corr resp="#editor">fremd</corr> der Lehre unsers Erlösers und <supplied reason="undefined" resp="#editor">ihr</supplied>
 schamlos und ohne Scheu, und nicht nur entgegengesetzt
 seinen Worten und seiner Lehre, sondern auch dem Leben, das bis jetzt
-allen Völkern überliefert ist (und) in allen seinen Kirchen geführt wird. <lb n="25"/>
+allen Völkern überliefert ist <supplied reason="undefined" resp="#editor">und</supplied> in allen seinen Kirchen geführt wird. <lb n="25"/>
 Indessen aber möge die Rede, wenn sie auch falsch und
-ist, dargeboten werden entsprechend der (fingierten) Voraussetzung,
-die wir zugestanden haben, damit auch so die uns vorliegenden (Fragen)
+ist, dargeboten werden entsprechend der <supplied reason="undefined" resp="#editor">fingierten</supplied> Voraussetzung,
+die wir zugestanden haben, damit auch so die uns vorliegenden <supplied reason="undefined" resp="#editor">Fragen</supplied>
 geprüft werden. Er möge also alles Böse und
-und es sei Fürsorge (bei ihm), in alledem verborgen zu bleiben, und die <lb n="30"/>
+und es sei Fürsorge <supplied reason="undefined" resp="#editor">bei ihm</supplied>, in alledem verborgen zu bleiben, und die <lb n="30"/>
 Sitte möge sehr geschickt versteckt sein unter dem Vorwand einer
-Lehre (und) der Verheißung einer neuen Frömmigkeit. Sie
+Lehre <supplied reason="undefined" resp="#editor">und</supplied> der Verheißung einer neuen Frömmigkeit. Sie
 <note type="footnote">6 vgl. Matth 10 7 = Luk 10 1 30—234, 14 = Dem. III</note>
 <note type="footnote">1 „Grund"] λόγον D „Wort" Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 13 τὸν ἀκτήμονα τρόπο
 ἑλομένων D 15 ὁ μὲν οὖν κύριος καὶ πρῶτος καὶ ἄλης λόγος ἂν εἴη οὗτος D
@@ -9024,12 +9028,12 @@ Lehre (und) der Verheißung einer neuen Frömmigkeit. Sie
 <pb n="v.3.pt.2.p.234"/>
 dem nachtrachten und dem, was noch schlimmer ist als dies wegen der <milestone unit="altnumbering" n="187"/>
 abschüssigen Bahn des Bösen und seiner
-In die Höhe erheben (gewaltig preisen) mögen sie ihren
+In die Höhe erheben <supplied reason="undefined" resp="#editor">gewaltig preisen</supplied> mögen sie ihren
 erdichteten Worten, ohne auch nur Ein lügnerisches Wort zu
-<lb n="5"/> Alle Alle Wunder (und) staunenswerten Taten mógen sie durch
+<lb n="5"/> Alle Alle Wunder <supplied reason="undefined" resp="#editor">und</supplied> staunenswerten Taten mógen sie durch
 ihm zuschreiben, damit man auch sie bewundere und ihnen die Glückseligkeit
 gebe, die gewürdigt waren, die Jünger
-(Meisters) zu werden.</p>
+<supplied reason="undefined" resp="#editor">Meisters</supplied> zu werden.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="24">
@@ -9038,8 +9042,8 @@ gebe, die gewürdigt waren, die Jünger
 seiner wagten. Denn man sagt, daß das Böse dem Bösen
 sei. und nicht einmal dem Guten. Woher also wurde bei der Menge
 aller dieser Menschen die Übereinstimmung im Bösen gefunden?
-war das Zeugnis über *dieselben Dinge bei allen übereinstimmend?
-<lb n="15"/> Woher die Lehre über die göttlichen Satzungen und *die
+war das Zeugnis über <corr resp="#editor">dieselben</corr> Dinge bei allen übereinstimmend?
+<lb n="15"/> Woher die Lehre über die göttlichen Satzungen und <corr resp="#editor">die</corr>
 über die Philosophie? Woher der Gedanke über das Leben der
 Tugend? Woher die Lehre, vor dem Bösen zu fliehen? Woher
 Wissen derartiger Worte und Schriften? Woher die Reinheit des
@@ -9049,7 +9053,7 @@ Woher die Zuversicht? Woher die Übereinstimmung bis zum Tode?
 Ein Mann aber, der Bitterböses lehrt, wie jemand sagen möchte,
 sich in solchen Dingen als Meister ausgibt, wer würde
 Sinn auf ihn richten? Man wird vielleicht sagen, weil andere Zauberer
-<lb n="25"/> in nichts schlechter waren als der Führer (als Christus). Haben
+<lb n="25"/> in nichts schlechter waren als der Führer <supplied reason="undefined" resp="#editor">als Christus</supplied>. Haben
 denn nicht geachtet auf das Ende ihres Meisters und welches Todes er
 sich bediente? Warum also beharrten sie nach seinem schimpflichsten
 Ende dabei und nannten den Gestorbenen Gott, wenn sie sich nicht
@@ -9081,7 +9085,7 @@ zu überwinden, und wenn sie derartiges diejenigen lehrten, die
 von ihnen zu Jüngern gemacht wurden, so ist wahrscheinlich, daß sie
 keine Geschäfte machten und keinen Reichtum anhäuften noch an einem
 Leben der Ruhe und des Ergötzens teil hatten. Da sie also durch eins
-von diesen (Dingen) nicht geleitet wurden, *wie ertrugen sie es, für <lb n="15"/>
+von diesen <supplied reason="undefined" resp="#editor">Dingen</supplied> nicht geleitet wurden, <corr resp="#editor">wie</corr> ertrugen sie es, für <lb n="15"/>
 nichts eine böse Strafe und eine Züchtigung zu empfangen nur für das
 Zeugnis über ihren Meister, der nicht mehr war?</p>
 </div>
@@ -9093,17 +9097,17 @@ also haben sie ihn auch nach dem Tode, und noch viel mehr damals
 als früher, Gott genannt? Denn während er bei den Menschen war,
 sollen sie ihn sogar verlassen und verleugnet haben, in jener Zeit, wo
 ihm der Hinterhalt bereitet wurde. Nachdem er aber von den Menschen
-*fortgegangen war, wollten sie freudig lieber selbst sterben als von dem <lb n="25"/>
-guten Zeugnis über ihn ablassen. Sie also, die *nichts Gutes wußten
+<corr resp="#editor">fortgegangen</corr> war, wollten sie freudig lieber selbst sterben als von dem <lb n="25"/>
+guten Zeugnis über ihn ablassen. Sie also, die <corr resp="#editor">nichts</corr> Gutes wußten
 über ihren Meister, kein Leben, keine Handlung, keine Lehre, keine
 Tat, die des Preises wert war, und auch in nichts von ihm unterstützt
 wurden, abgesehen von der Bosheit und der Verführung der Menschen,
-warum starben sie (so) leicht, in nichts getadelt als weil sie Ehrbares <lb n="30"/>
+warum starben sie <supplied reason="undefined" resp="#editor">so</supplied> leicht, in nichts getadelt als weil sie Ehrbares <lb n="30"/>
 und Lobenswertes über ihn bezeugten, während es doch einem jeden
 von ihnen freistand, sorglos zu leben und im eigenen Wohnhause mit
 seinen Lieben ein sturmfreies Leben zu führen. Wie sollten aber verführende
 und verführte Männer willig den Tod auf sich nehmen für
-einen andern, von dem sie genauer (und) besser als jedermann wußten, <lb n="35"/>
+einen andern, von dem sie genauer <supplied reason="undefined" resp="#editor">und</supplied> besser als jedermann wußten, <lb n="35"/>
 daß er nicht einmal zu irgend etwas Gutem, wie jemand sagen möchte,
 <note type="footnote">8—S. 236, 14 = Dem. III 440—43 23 vgl. Matth 26 56. 75</note>
 <note type="footnote">15 „und wie“ Σstr. <foreign xml:lang="abbr">ABBREV</foreign> 25 1. <foreign xml:lang="abbr">ABBREV</foreign> Bernstein mit HS 261. <foreign xml:lang="abbr">ABBREV</foreign> mit HS
@@ -9117,23 +9121,23 @@ Tod ruhmreich erleiden. Wer aber böse ist in seinem Charakter,
 <lb n="5"/> er allein dem zeitlichen und an Begierden angenehmen Leben nachjagt, <milestone unit="altnumbering" n="189"/>
 würde niemals den Tod dem Leben vorziehen und nicht einmal
 seine Lieben eine harte Strafe erdulden, geschweige denn für den,
-wegen seiner Bosheit getadelt (und verurteilt) wird. Wie sollten also
+wegen seiner Bosheit getadelt <supplied reason="undefined" resp="#editor">und verurteilt</supplied> wird. Wie sollten also
 die Jünger des Genannten, wenn er ein Verführer und Zauberer
 <lb n="10"/> w	enn ihnen nicht verborgen war, daß er so sei, aber auch sie selbst in
 einer äßlicheren Art des ösen betreffs ihrer Seelen befangen waren,
 von ihren Volksgenossen alle Qualen und alle Arten von Strafen auf
-sich nehmen für das Zeugnis über ihn? Nicht aber ist dies (die
+sich nehmen für das Zeugnis über ihn? Nicht aber ist dies <supplied reason="undefined" resp="#editor">die Eigentümlichkeit</supplied>
 der Natur des Bösen. Denn ich habe viele gesehen,
 <lb n="15"/> mit den Lebenden Eidgenossenschaft untrüglich hielten. Sogleich
 als sie starben, lösten sie das auf, was sie zwischen sich
-hatten. Die Sophisten(redner) aber, die sich in den Städten
+hatten. Die Sophisten<supplied reason="undefined" resp="#editor">redner</supplied> aber, die sich in den Städten
 und die gepriesen wurden durch das Gerücht ihres Wissens und
 Beweises ihrer Worte wegen — wir alle wissen genau, wie sie die
 <lb n="20"/> ἡγεμόνες der Völker und diejenigen, welche große
 mit Lobpreisen priesen, solange es ihnen die Herrschaft erlaubte.
 Sogleich aber, als für jene eine Änderung eintrat, änderten auch
 ihre Worte und wollten fernerhin keine Frwähnung tun derer, die
-(regierten), aus Furcht vor denen, die in der Gegenwart herrschten.</p>
+<supplied reason="undefined" resp="#editor">regierten</supplied>, aus Furcht vor denen, die in der Gegenwart herrschten.</p>
 </div>
 <lb n="25"/> <div type="textpart" subtype="chapter" n="26">
 <p>Wenn also die Jünger unsers Erlösers
@@ -9144,7 +9148,7 @@ nachdem ihr Meister von den Menschen fortgegangen war, in die ganze
 <lb n="30"/> Welt hinausziehen und seine Gottheit bezeugen? Durch welchen Gedanken
 danken wurden sie bezaubert, dies zu wagen? Durch welche Kraft
 vollführten sie, was sie versuchten? Denn es mag sein, daß
-Leute in ihrem eigenen Lande umherschweifen und umherirren, die (Tat-
+Leute in ihrem eigenen Lande umherschweifen und umherirren, die <supplied reason="undefined" resp="#editor">Tatsache</supplied> 
 <note type="footnote">25—S. 240,16 = Dem. III</note>
 <note type="footnote">2 „Sieg“] κατορθώματος D 15 wörtlicher „Genossenschaft
 28 ἐπαίοντες D „hören“ Σ 33 ἔστω γὰρ ἐπὶ τῆς οἰκείας γῆς
@@ -9152,16 +9156,16 @@ Leute in ihrem eigenen Lande umherschweifen und umherirren, die (Tat-
 D „in ihren Häusern“</note>
 
 <pb n="v.3.pt.2.p.237"/>
-sache) aber, daß sie in ein fremdes Land reisen nnd die Sache
-ruhig (liegen) lassen, sondern den Kamen unsers Erlösers
-verkünden und seine wunderbaren Taten *nicht nur, sondern auch
-Befehle in Dorf und Stadt lehren, und (daß) die einen in die
+aber, daß sie in ein fremdes Land reisen nnd die Sache
+ruhig <supplied reason="undefined" resp="#editor">liegen</supplied> lassen, sondern den Kamen unsers Erlösers
+verkünden und seine wunderbaren Taten <corr resp="#editor">nicht</corr> nur, sondern auch
+Befehle in Dorf und Stadt lehren, und <supplied reason="undefined" resp="#editor">daß</supplied> die einen in die
 der Römer und in die königliche Stadt sich verbreiten, die andern in
 <milestone unit="altnumbering" n="190"/> Land der Perser, andere in das Land der Armenier, andere zum Volk der
-Parther und ferner auch zu den Skythen, und (daß) andere sogar bis
+Parther und ferner auch zu den Skythen, und <supplied reason="undefined" resp="#editor">daß</supplied> andere sogar bis
 den Enden der Welt ausziehen und ins Land der Inder vordringen, und
-(daß) andere jenseits des Ozeans bis zu den (so)genannten
-Inseln hinÜbergehen — dies, meine ich, ist nicht (Sache) von Menschen,
+<supplied reason="undefined" resp="#editor">daß</supplied> andere jenseits des Ozeans bis zu den <supplied reason="undefined" resp="#editor">so</supplied>genannten
+Inseln hinÜbergehen — dies, meine ich, ist nicht <supplied reason="undefined" resp="#editor">Sache</supplied> von Menschen,
 geschweige denn von Geringen und Laien, und noch weniger von Verführern
 und Zauberern.</p>
 </div>
@@ -9171,7 +9175,7 @@ erprobten und eben seinen Todesausgang mit ihren Augen sahen, welcher
 Worte bedienten sie sich denn, um mit einander übereinstimmend über <lb n="15"/>
 ihn zu faseln? Denn wie aus Einem Munde bezeugten sie alle die Reinigung
 der Aussätzigen, die Vertreibung der Dämonen,
-der Toten, das (Wiedererhalten des) Gesichts der Blinden und Myriaden
+der Toten, das <supplied reason="undefined" resp="#editor">Wiedererhalten des</supplied> Gesichts der Blinden und Myriaden
 andere Heilungen, die von ihm geschahen,</p>
 </div>
 
@@ -9185,11 +9189,11 @@ und einen Eid darauf geleistet und eine Übereinkunft zwischen
 sich festgesetzt, zu erdichten und zu lügen, was niemals geschehen ist? <lb n="25"/>
 Kann man überzeugend sagen, welche Worte sie bei dieser Übereinkunft
 gebrauchten? Oder waren es etwa solche: „Liebe Männer!
-kennen genauer (und) besser als jedermann den Verführer und
+kennen genauer <supplied reason="undefined" resp="#editor">und</supplied> besser als jedermann den Verführer und
 des Betruges von gestern und vorgestern, der vor den Augen aller
-die äußerste Strafe erlitt, (und wissen), wer er war, da wir ja die Mysten <lb n="30"/>
+die äußerste Strafe erlitt, <supplied reason="undefined" resp="#editor">und wissen</supplied>, wer er war, da wir ja die Mysten <lb n="30"/>
 seiner Geheimnisse geworden sind. Als ein Reiner erschien er den
-meisten, und er war (auch) darauf bedacht, etwas mehr zu besitzen als
+meisten, und er war <supplied reason="undefined" resp="#editor">auch</supplied> darauf bedacht, etwas mehr zu besitzen als
 die meisten, aber er erwarb nichts Großes noch etwas der
 Würdiges, außer wenn jemand das Hinterlistige und
 <note type="footnote">1 „reisen“] „geschickt werden“ Σ = στέλλεσθαι (vgl. Stud. 133 3 „und
@@ -9199,7 +9203,7 @@ nicht nur“ Σ str. <foreign xml:lang="abbr">ABBREV</foreign> 5 νείμασθ
 D 32 καί τι πλέον ἔχειν παρὰ τοὺς πολλοὺς ἐφρόνει D</note>
 
 <pb n="v.3.pt.2.p.238"/>
-Charakters nennt und die (Tatsache), daß er Verdrehtes uns lehrte
+Charakters nennt und die <supplied reason="undefined" resp="#editor">Tatsache</supplied>, daß er Verdrehtes uns lehrte
 die Aufgeblasenheit des Irrwahns. Dafür, wohlan, wollen wir
 die Rechte geben und alle zumal einen Vertrag unter uns festsetzen,
 damit wir übereinstimmend den Betrug in betreff seiner unter alle Menschen
@@ -9209,7 +9213,7 @@ den Tauben das Gehör schenkte, was niemals einer</add> gehört
 wie er die Aussätzigen rein und die Toten lebendig machte. Und
 es zusammenfassend zu sagen, was wir weder mit unsern Augen gesehen <milestone unit="altnumbering" n="191"/>
 <lb n="10"/> haben als von ihm geschehen, noch mit unsern Ohren gehört
-haben als (von ihm) gesagt, *das wollen wir als in Wahrheit geschehen
+haben als <supplied reason="undefined" resp="#editor">von ihm</supplied> gesagt, <corr resp="#editor">das</corr> wollen wir als in Wahrheit geschehen
 kräftig behaupten. Aber wenn auch sein letztes Ende berühmt
 und er offenkundig den Tod empfing, sodaß niemand ihn
 kann, so wollen wir auch dies ohne Scheu auflösen, indem wir
@@ -9224,7 +9228,7 @@ nötig wäre, auch Einkerkerung, Schmach und Not für
 zu erdulden? Auch dies wrollen wir sogleich auf uns nehmen!
 Wir wollen aber alle zumal übereinstimmend lügen und faseln zu
 <lb n="25"/> Vorteil, weder zu unserm noch zu dem derer, die wir
-noch zu dem (Vorteil) dessen, über den von uns die Lügen gesagt
+noch zu dem <supplied reason="undefined" resp="#editor">Vorteil</supplied> dessen, über den von uns die Lügen gesagt
 daß er Gott sei. Wir wollen aber die Lüge nicht
 auf unsere Volksgenossen, sondern sie auch zu allen Menschen hinaus
 bringen und die ganze Schöpfung füllen mit dem, was wir
@@ -9247,18 +9251,18 @@ Römern vor allem befehlen, nicht diejenigen zu verehren, die ihre Vorfahren
 für Götter hielten, wollen aber auch nach Griechenland wandern <lb n="5"/>
 und vielmehr auch im Gegensatz zu ihren Weisen predigen, und auch
 die Ägypter nicht übergehen, sondern auch ihre Gtter bekämpfen,
-indem wir nicht wider sie drohen die (Taten) des Mose, die einst wider
+indem wir nicht wider sie drohen die <supplied reason="undefined" resp="#editor">Taten</supplied> des Mose, die einst wider
 sie geschahen, sondern ihnen den Tod eben unsers Erlösers als ein
 Schreckmittel entgegenhalten, und die Kunde über die Götter, die von <lb n="10"/>
 Ewigkeit her von ihnen zu allen Menschen drang, nicht mit Worten
 und Geschichten, sondern durch die Kraft unsers gekreuzigten Meisters
 aufheben, wollen ferner aber auch in ein anderes barbarisches Land
-gehen und das bei jedermann (Geltende) zerstören. An dem Willen
-(hierzu) möge niemand von uns es fehlen lassen! Denn keineswegs <lb n="15"/>
+gehen und das bei jedermann <supplied reason="undefined" resp="#editor">Geltende</supplied> zerstören. An dem Willen
+<supplied reason="undefined" resp="#editor">hierzu</supplied> möge niemand von uns es fehlen lassen! Denn keineswegs <lb n="15"/>
 ist klein der ἆθλος dessen, was wir wagen, da auch nicht die gewöhnliehen
-<milestone unit="altnumbering" n="192"/> Sieges (kränze) uns erwarten, sondern, wie es billig ist, Strafen
-von den Gesetzen, die an jedem Ort (bestehen), Fesseln nämlich, Foltern,
-Einkerkerung, Feuer, Eisen, Kreuze und (wilde) Tiere, um derentwillen
+<milestone unit="altnumbering" n="192"/> Sieges <supplied reason="undefined" resp="#editor">kränze</supplied> uns erwarten, sondern, wie es billig ist, Strafen
+von den Gesetzen, die an jedem Ort <supplied reason="undefined" resp="#editor">bestehen</supplied>, Fesseln nämlich, Foltern,
+Einkerkerung, Feuer, Eisen, Kreuze und <supplied reason="undefined" resp="#editor">wilde</supplied> Tiere, um derentwillen
 wir besonders in Freuden wollen und auf das Verderben gerade lossehen. <lb n="20"/>
 die wir unsern Meister als Vorbild besitzen. Denn was ist schöner
 als dies, daß wir um keines Vorteils willen den Göttern und Menschen
@@ -9268,10 +9272,10 @@ noch überhaupt die Hoffnung auf etwas Gutes erwerben, sondern eitel <lb n="25"/
 unnütz irren und andere irreführen? Denn dies ist das Nützliche:
 allen Völkern entgegen zu sein, mit den Göttern zu kämpfen, die von
 Ewigkeit her jedermann bekennt, und vielmehr unsern Meister, der vor
-unsern Augen starb, als Gott und Gottessohn zu verkünden, *für den
+unsern Augen starb, als Gott und Gottessohn zu verkünden, <corr resp="#editor">für</corr> den
 wir bereit sind zu sterben, obwohl wir nichts Wahres noch Vorteilhaftes <lb n="30"/>
 von ihm gelernt haben. Darum wollen wir ihn um so mehr
-ehren, weil er nichts in guten (Dingen) uns genützt hat, wollen alles
+ehren, weil er nichts in guten <supplied reason="undefined" resp="#editor">Dingen</supplied> uns genützt hat, wollen alles
 tun, um seinen Namen zu preisen, alle Schmähungen und Strafen er-
 • dulden und jede Art des Todes für nichts Wahres ertragen. Denn
 das Wahre ist vielleicht böse, das Unwahre aber hat in sich das Gegenteil <lb n="35"/>
@@ -9287,12 +9291,12 @@ anderer wunderbarer Werke geworden sei, obwohl wir keine derartigen
 Dinge an ihm kennen, sondern für uns selbst alles dieses faseln und
 verführen, soviele wir können. Wenn aber jemand sich
 <lb n="5"/> läßt, so wollen wir doch für das, was wir unter
-haben, den gebührenden (Lohn) für den Irrtum uns selbst zuziehen.“</p>
+haben, den gebührenden <supplied reason="undefined" resp="#editor">Lohn</supplied> für den Irrtum uns selbst zuziehen.“</p>
 </div>
 <div type="textpart" subtype="chapter" n="29">
 <p>Erscheint dir dies überzeugend und redest du dir noch ein,
 daß derartiges faselten und als Vertrag unter sich festsetzten
-und laienhafte (Leute) und (dann) ins Reich der Römer
+und laienhafte <supplied reason="undefined" resp="#editor">Leute</supplied> und <supplied reason="undefined" resp="#editor">dann</supplied> ins Reich der Römer
 <lb n="10"/> Oder daß die menschliche Natur, die die Liebe zum Leben zu
 besitzt, jemals aus freiem Willen den Tod für nichts ertragen
 Oder daß die Jünger unsers Erlösers zu so großer
@@ -9305,20 +9309,20 @@ dafür bereitwillig starben?</p>
 <div type="textpart" subtype="chapter" n="30">
 <p>Aber sie zogen keineswegs
 eines Vertrages zu der Verkündigung über ihn aus noch setzten
-(einen solchen) unter sich fest. Woher (stammt) ihnen (denn) die
-Übereinstimmung ihres Zeugnisses über seine Taten? *Natürlich
+<supplied reason="undefined" resp="#editor">einen solchen</supplied> unter sich fest. Woher <supplied reason="undefined" resp="#editor">stammt</supplied> ihnen <supplied reason="undefined" resp="#editor">denn</supplied> die
+Übereinstimmung ihres Zeugnisses über seine Taten? <corr resp="#editor">Natürlich</corr>
 <lb n="20"/> dem Anblick dessen, was von ihm geschah. Denn Eins von beiden
-(gilt): entweder setzten sie einen Vertrag zwischen sich fest und faselten,
+<supplied reason="undefined" resp="#editor">gilt</supplied>: entweder setzten sie einen Vertrag zwischen sich fest und faselten,
 oder sie sahen mit ihren Augen und bezeugten. Wenn sie also die
 Wahrheit sahen und sie jedermann verkündeten, so waren sie wert,
 man ihnen glaubte, wenn sie über ihren Erlöser sagten, er sei
-<lb n="25"/> und habe ihnen (Gelegenheit) gegeben, mit ihren Augen göttliche
+<lb n="25"/> und habe ihnen <supplied reason="undefined" resp="#editor">Gelegenheit</supplied> gegeben, mit ihren Augen göttliche
 Zeichen und wunderbare Taten zu sehen. Wenn sie aber nichts in
-Wahrheit von dem sahen, was *geschrieben wurde, und Lügenworte
-webten und dann mit einander Recht (sschlag) und Eidvertrag machten
+Wahrheit von dem sahen, was <corr resp="#editor">geschrieben</corr> wurde, und Lügenworte
+webten und dann mit einander Recht <supplied reason="undefined" resp="#editor">sschlag</supplied> und Eidvertrag machten
 darüber, nichts Wahres zu sagen, sondern zu faseln und Lügen
 <lb n="30"/> ihren Meister zu bezeugen, wie konnten sie dann in Wahrheit für
-Wahres sterben, (wie) vermochten weder Feuer noch Eisen noch wilde
+Wahres sterben, <supplied reason="undefined" resp="#editor">wie</supplied> vermochten weder Feuer noch Eisen noch wilde
 Tiere noch die Tiefe des Meeres, daß sie für Lüge
 den sie über ihren Meister erdichtet hatten?</p>
 </div>
@@ -9335,16 +9339,16 @@ würden, da sie die Zerstörung der Götter der Römer zumal und der
 Griechen und der Barbaren einführten. Die Geschichte über sie zeigt
 deutlich, daß nach dem Tode ihres Meisters gewisse Feinde und Nachsteller
 des Logos sie ergriffen, zuerst dem Gefängnis übergaben, dann <lb n="5"/>
-sie befreiten und ihnen befahlen, mit niemandem (mehr) über den Namen
+sie befreiten und ihnen befahlen, mit niemandem <supplied reason="undefined" resp="#editor">mehr</supplied> über den Namen
 Jesu zu reden. Da man sie hinterher fand, wie sie öffentlich die
 Menge über ihn belehrten, schleppte man sie hinweg und geißelte sie
-und bedrohte sie, nicht (mehr) zu lehren, während Simon Petrus ihnen
+und bedrohte sie, nicht <supplied reason="undefined" resp="#editor">mehr</supplied> zu lehren, während Simon Petrus ihnen
 antwortete, indem er sagte: „Man muß Gott mehr gehorchen als den <lb n="10"/>
 Menschen.“ Darnach aber wurde Stephanus gesteinigt und getötet, darob
 daß er freimütig mit der Menge der Juden redete, und eine keineswegs
 geringe Verfolgung erhob sich wider die, welche den Namen Jesu predigten.
 <milestone unit="altnumbering" n="194"/> Und wiederum zu anderer Zeit, als Herodes König der Juden
-(War), tötete er den Jakobus, den Bruder des Johannes, mit dem Schwerte, <lb n="15"/>
+<supplied reason="undefined" resp="#editor">War</supplied>, tötete er den Jakobus, den Bruder des Johannes, mit dem Schwerte, <lb n="15"/>
 den Simon Petrus band ebenderselbe mit Fesseln, wie in den Πραξεῖς
 der Apostel geschrieben ist. Während sie dies litten, harrten die überigen
 Jünger aus und hingen fest an der Lehre unsers Erlösers und
@@ -9363,7 +9367,7 @@ Erlöser und seine wunderbaren Taten freimütig bezeugten.</p>
 </div>
    
 <div type="textpart" subtype="chapter" n="32">
-<p>Und fürwahr, wenn Lügen wären und (wenn) sie nach Verabredung
+<p>Und fürwahr, wenn Lügen wären und <supplied reason="undefined" resp="#editor">wenn</supplied> sie nach Verabredung
 faselten das, was sie über ihn verkündigten, so müßte man sich wundern
 wie eine so große Schar die Ubereinstimmung in ihren Lügen bis zum
 Tode bewahrte und niemals einer von ihnen sich fürchtete wegen der
@@ -9376,7 +9380,7 @@ ebd. II 25 5 III 181 1
 Eusebius III*.</note>
 
 <pb n="v.3.pt.2.p.242"/>
-(daß) auch der geldgierige (Judas), der ihn seinen *Feinden
+<supplied reason="undefined" resp="#editor">daß</supplied> auch der geldgierige <supplied reason="undefined" resp="#editor">Judas</supplied>, der ihn seinen <corr resp="#editor">Feinden</corr>
 wagte, durch sich selbst sogleich die Strafe auf sich nahm.</p>
 </div>
 
@@ -9384,7 +9388,7 @@ wagte, durch sich selbst sogleich die Strafe auf sich nahm.</p>
 <p>Wie sollte aber dies nicht voll Wunder sein, daß betrügerische
 laienhafte Männer, die weder mehr zu reden noch zu hören
 <lb n="5."/> als die Sprache ihrer Väter, nicht nur <add>zu überlegen</add> wagten,
-und umherzugehen bei allen Völkern, sondern (auch)
+und umherzugehen bei allen Völkern, sondern <supplied reason="undefined" resp="#editor">auch</supplied>
 und die Sache ausführten? Überlege aber, wie das sei, daß
 einer von ihnen jemals ein entgegengesetztes Wort über die Taten des
 Meisters vorbrachte. Denn wenn bei allen Dingen, über die es Zweifel <milestone unit="altnumbering" n="195"/>
@@ -9402,9 +9406,9 @@ und Tod, deswegen weil auch sie von Gott bestätigt wurden, der
 in alle Ewigkeit verbürgt.</p>
 </div>
 <div type="textpart" subtype="chapter" n="34">
-<p>Dies also sei (genug) geprüft, nachdem wir dafür
+<p>Dies also sei <supplied reason="undefined" resp="#editor">genug</supplied> geprüft, nachdem wir dafür
 dem Zugeständnis einen unziemlichen Anfang gemacht haben.
-die (Tatsache), daß jemand das Gegenteil der Schrift vermute und
+die <supplied reason="undefined" resp="#editor">Tatsache</supplied>, daß jemand das Gegenteil der Schrift vermute und
 <lb n="25"/> daß der gemeinsame Erlöser aller ein Lehrer
 keuschen Worten, sondern der Ungerechtigkeit, Übervorteilung und jeder
 Lüsternheit gewesen sei, und daß seine Jünger eben dies
@@ -9413,7 +9417,7 @@ als alle Menschen von Ewigkeit her, haben wir der Hypothese gemäß
 <lb n="30"/> zugestanden, was das allerungeziemendste ist. Denn es ist ähnlich, wie
 wenn jemand den Mose, der im Gesetz sagt: „Du sollst nicht töten,
 ehebrechen, stehlen, falsch Zeugnis ablegen“ verdrehte und
-und behauptete, er sage dies in *Ironie und Heuchelei. Denn er wolle,
+und behauptete, er sage dies in <corr resp="#editor">Ironie</corr> und Heuchelei. Denn er wolle,
 <note type="footnote">1 vgl. Act 116 ff. 12 = Dtn 1915 II Kor 131 31 = Ex 20 13—16</note>
 <note type="footnote">11 l. <foreign xml:lang="abbr">ABBREV</foreign> mit HS (Druckfehler) 5 μὴ μόνον διανοηθῆναι
 προελθεῖν D 1. + <foreign xml:lang="abbr">ABBREV</foreign> 10 ἔν τε τοῖς κατὰ νόμους
@@ -9426,19 +9430,19 @@ daß die Gehorsamen töten, ehebrechen und das Gegenteil
 von dem, was er scheinbar zum Gesetz mache, daß sie aber sich
 und erheucheln sollten ein reines Lebeu. Es gibl aber nichts
 Schamloseres als dies. So könnte aber auch jemand die Lehren
-Philosophen unter den Griechen verleumden, *ihr enthaltsames Leben <lb n="5"/>
-und *alle ihre Worte, und sagen, sie seien im Gegensatz zu dem, was
-geschrieben ist, gewesen und hätten (im Gegensatz dazu) gelebt,
+Philosophen unter den Griechen verleumden, <corr resp="#editor">ihr</corr> enthaltsames Leben <lb n="5"/>
+und <corr resp="#editor">alle</corr> ihre Worte, und sagen, sie seien im Gegensatz zu dem, was
+geschrieben ist, gewesen und hätten <supplied reason="undefined" resp="#editor">im Gegensatz dazu</supplied> gelebt,
 sich aber heuchlerisch gestellt, als wären sie in einem
 Leben. So aber könnte man, um es einfach zu sagen, alle
-der Vorfahren verleumden und die in ihnen (vorhandene) Wahrheit verwerfen <lb n="10"/>
-<milestone unit="altnumbering" n="196"/> und das, was in ihnen ist, ins Gegenteil aufnehmen (verkehren).
+der Vorfahren verleumden und die in ihnen <supplied reason="undefined" resp="#editor">vorhandene</supplied> Wahrheit verwerfen <lb n="10"/>
+<milestone unit="altnumbering" n="196"/> und das, was in ihnen ist, ins Gegenteil aufnehmen <supplied reason="undefined" resp="#editor">verkehren</supplied>.
 Aber wie derjenige, der Verstand hat, nicht zögern würde,
 zu nennen, so auch bei den Worten unsers Erlösers und
-Lehren, wenn jemand die in ihnen (vorhandene) Wahrheit verderben
+Lehren, wenn jemand die in ihnen <supplied reason="undefined" resp="#editor">vorhandene</supplied> Wahrheit verderben
 und versuchen wollte, ihnen die entgegengesetzte Meinung aufzudrängen <lb n="15"/>
 von dem, was er lehrte. Indessen aber auch dies wurde entsprechend
-der Hypothese gegeben (ausgeführt), damit zum Überfluß auch
+der Hypothese gegeben <supplied reason="undefined" resp="#editor">ausgeführt</supplied>, damit zum Überfluß auch
 das unziemliche Zugeständnis die Haltlosigkeit des Wortes des
 erscheine.</p>
 </div>
@@ -9452,7 +9456,7 @@ Männer, laienhaft in der Rede, aber zur Liebe frommer Lehre und Philosophie <lb
 fortgeschritten, hätten ein enthaltsames und mühseliges
 gewonnen, das durch Fasten, durch Enthaltsamkeit von Wein und Fleisch,
 durch viele andere Demütigung des Leibes, durch Gebet und Flehen
-Gott und viel mehr (noch) durch höchste Keuschheit und Heiligkeit
+Gott und viel mehr <supplied reason="undefined" resp="#editor">noch</supplied> durch höchste Keuschheit und Heiligkeit
 Leibes und der Seele entstehen kann. Wer wollte sie nicht bewundern. <lb n="30"/>
 die wegen der Vorzüglichkeit der Weisheit sogar der nach dem
 ihnen gestatteten Weiber sich enthalten, von keiner natürlichen
@@ -9489,7 +9493,7 @@ freuen“, wie wurde da nicht offensichtlich, daß sie fest und tief
 ihrem Charakter, da sie vor den Anstrengungen der Seele nicht flohen
 <lb n="20"/> noch den Lüsten nachjagten, daß aber auch ihr Meister
 durch Betrug bezauberte und ihnen das Angenehme riet und sie sich
-(SO) zu eigen machte, sondern indem er mit wahrem und freiem Wort
+<supplied reason="undefined" resp="#editor">so</supplied> zu eigen machte, sondern indem er mit wahrem und freiem Wort
 prophezeite, was ihnen zustoßen werde, bewirkte er, daß sie
 ihm gemäße Lebensführung wählten. Derartig war auch
 <lb n="25"/> über die Verfolgungen voraussagte, die ihnen in Zukunft zustoßen
@@ -9515,8 +9519,8 @@ Christi zu sein, wird er sogleich freigelassen, selbst wenn er wegen
 vieler schlechter Dinge gefangen gesetzt wäre. Was habe ich
 vieles anzuhäufen, der ich versuche, das Leben der Jünger
 zu schreiben, da das Gesagte genügt zum Beweise der vorliegenden
-(Sache)? Dem wollen wir aber ferner folgendes hinzufügen, und
-(ist es) am Platze, auch darüber unsere Rede zu begrenzen.</p>
+<supplied reason="undefined" resp="#editor">Sache</supplied>? Dem wollen wir aber ferner folgendes hinzufügen, und
+<supplied reason="undefined" resp="#editor">ist es</supplied> am Platze, auch darüber unsere Rede zu begrenzen.</p>
 </div>
 <div type="textpart" subtype="chapter" n="37">
 <p>Der Apostel Matthäus leitete sein früheres
@@ -9524,7 +9528,7 @@ von einem besseren Umgang ab, sondern von denen, die um Zölle
 und Übervorteilung sich bemühen. Dies hat keiner von den übrigen
 Evangelisten uns geoffenbart, weder sein Mitapostel Johannes noch
 Lukas noch Markus, die Verfasser der übrigen Evangelien. Matthäus
-<milestone unit="altnumbering" n="198"/> aber beschrieb sein eigenes früheres Leben und wurde (so) sein
+<milestone unit="altnumbering" n="198"/> aber beschrieb sein eigenes früheres Leben und wurde <supplied reason="undefined" resp="#editor">so</supplied> sein
 Ankläger. Höre also, wie er deutlich sich selbst mit Namen
 seiner Schrift und so redet:</p>
 </div> <lb n="15"/>
@@ -9534,21 +9538,21 @@ beim Zollhaus sitzen, mit Namen Matthäus, und sprach zu ihm:
 mir nach. Und er erhob sich und ging ihm nach. Und es geschah,
 als er zu Tische lag in dem Hause, und siehe da! viel Zöllner und
 lagen mit Jesus zu Tische und mit seinen Jüngern.“ Und wiederum, <lb n="20"/>
-als (Mätthäus) fortfuhr und eine Aufzählung der übrigen
+als <supplied reason="undefined" resp="#editor">Mätthäus</supplied> fortfuhr und eine Aufzählung der übrigen
 legte er sich den Namen des Zöllners bei und sagte so:
 Namen ’der zwölf Apostel sind folgende: zuerst Simon, der Petrus
 und Andreas, sein Bruder, Jakobus, des Zebedäus Sohn und
 sein Bruder, Philippus und Bartholomäus, Thomas und Matthäus, der <lb n="25"/>
 Zöllner.“ So zeigte also Matthäus in der Vorzüglichkeit
 seinen wahrheitsliebenden Charakter und nannte sich einen Zöllner,
-sein früheres Leben zu verbergen und (indem) er sich zu den
+sein früheres Leben zu verbergen und <supplied reason="undefined" resp="#editor">indem</supplied> er sich zu den
 rechnete und sich als zweiten seines Mitapostels Mitapostels Denn
 mit Thomas wie Simon mit Andreas, Jakobus mit Johannes und <lb n="30"/>
 Philippus mit Bartholomäus, stellte er den Thomas voran und ehrte
 als den besseren Mitapostel, während die übrigen Evangelisten
 Gegenteil taten. Höre also, wie Lukas, indem er den Matthäus
 ihn keinen Zöllner nennt noch dem Thomas nachsetzt, sondern ihn,
-er ihn als den besseren kannte, zuerst aufzählt und (erst) nach ihm <lb n="35"/>
+er ihn als den besseren kannte, zuerst aufzählt und <supplied reason="undefined" resp="#editor">erst</supplied> nach ihm <lb n="35"/>
 den Thomas bringt, wie auch Markus getan hat. Es lauten aber seine
 <note type="footnote">8—33 = 16. Bruchstück der griech. Theoph. 16 = Matth 9 9 f.
 Matth 10 8 f. 36 vgl. Mark 3 14 ff.</note>
@@ -9557,11 +9561,11 @@ Matth 10 8 f. 36 vgl. Mark 3 14 ff.</note>
 
 <pb n="v.3.pt.2.p.246"/>
 Worte so: „Und als es Tag ward, rief er seine Jünger und wählte
-aus ihnen aus, die er (auch) Apostel nannte: Simon, den er (auch) Petrus
-nannte, und Andreas, seinen Bruder, *Jakobus und Johannes und
+aus ihnen aus, die er <supplied reason="undefined" resp="#editor">auch</supplied> Apostel nannte: Simon, den er <supplied reason="undefined" resp="#editor">auch</supplied> Petrus
+nannte, und Andreas, seinen Bruder, <corr resp="#editor">Jakobus</corr> und Johannes und
 Philippus und Bartholomäus und Matthäus und Thomas.“
 <lb n="5"/> Lukas den Matthäus, „wie ihm diejenigen überliefert haben, die
-Anfang an Augenzeugen und *Diener des Wortes wurden.“ So
+Anfang an Augenzeugen und <corr resp="#editor">Diener</corr> des Wortes wurden.“ So
 verkleinerte Matthäus durch Demut sich selbst, bekannte, daß
 Zöllner sei und zählte sich als zweiten nach seinem Mitapostel.</p>
 </div>
@@ -9578,8 +9582,8 @@ offenbarte sich aber nicht mit Namen.</p>
 zu schreiben, aus einem Übermaß von Sehen. Markus aber, der
 sein Vertrauter und Jünger geworden war, soll die Worte Simons
 die Taten unsers Erlösers berichtet haben. Als er in seiner Schrift
-den (Worten) kam, wo Jesus fragte, was die Menschen über ihn sagten,
-<lb n="20"/> und als Simon ihm *antwortete, welche Meinung seine Jünger über
+den <supplied reason="undefined" resp="#editor">Worten</supplied> kam, wo Jesus fragte, was die Menschen über ihn sagten,
+<lb n="20"/> und als Simon ihm <corr resp="#editor">antwortete</corr>, welche Meinung seine Jünger über
 hätten, und sagte: „Du bist Christus“, da schrieb er, daß
 weder antwortete noch etwas zu ihm sagte, außer daß er
 sie möchten dies niemandem sagen. Dies aber schrieb Markus, da
@@ -9587,7 +9591,7 @@ nicht zugegen war, als Jesus dies sagte, sondern es nur von Simon
 <lb n="25"/> hörte, als er es lehrte. Petrus aber wollte das, was Jesus zu ihm
 seinetwegen sagte, nicht durch sein eigenes Zeugnis vorbringen. Was
 das aber war, was zu ihm gesagt wurde, zeigt Matthäus durch
-(Worte): „Ihr aber, was sagt ihr, wer ich sei? Sagte ihm Simon: Du
+<supplied reason="undefined" resp="#editor">Worte</supplied>: „Ihr aber, was sagt ihr, wer ich sei? Sagte ihm Simon: Du
 bist Christus, der Sohn des lebendigen Gottes. Antwortete ihm Jesus
 <lb n="30"/> und sprach zu ihm: Selig bist du, Simon Barjonan. Fleisch und Blut
 haben es dir nicht geoffenbart, sondern mein Vater im Himmel. Und
@@ -9609,9 +9613,9 @@ Erden, soll im Himmel gelöst sein“. Obwohl dies alles von Jesus zu <lb n="5"/
 Simon Petrus gesagt ward, erwähnte Markus keins von diesen
 deswegen, weil auch Petrus, wie es wahrscheinlich ist, dies in seiner
 Lehre nicht sagte. Dies also verschwieg Simon Petrus mit Recht, sodaß
-deswegen auch Markus es ausließ. Die (Umstände)
-aber verkündete verkundete er bei allen Menschen und schrieb (so) wider <lb n="10"/>
-<milestone unit="altnumbering" n="200"/> sich selbst die Anklage, *da er darüber bitter weinte. Du findest
+deswegen auch Markus es ausließ. Die <supplied reason="undefined" resp="#editor">Umstände</supplied>
+aber verkündete verkundete er bei allen Menschen und schrieb <supplied reason="undefined" resp="#editor">so</supplied> wider <lb n="10"/>
+<milestone unit="altnumbering" n="200"/> sich selbst die Anklage, <corr resp="#editor">da</corr> er darüber bitter weinte. Du findest
 daß Markus folgendes über ihn schreibt: Während Simon
 war, kam zu ihm Eine von den Mägden des Hohenpriesters, und da
 ihn sich wärmen sah, blickte sie ihn an und sagte zu ihm: Auch
@@ -9624,7 +9628,7 @@ wiederum die Umstehenden zu Simon: Du gehörst in Wahrheit zu ihnen, <lb n="20"/
 weil auch du ein Galiläer bist, bist. Er aber begann zu fluchen und zu
 sagen: Ich kenne diesen Menschen nicht, von dem ihr sagt, und sogleich
 krähte der Hahn zum zweiten Mal.“ Dies schreibt Markus,
-bezeugt Simon Petrus über sich selbst. Denn alle (Worte) des Markus
+bezeugt Simon Petrus über sich selbst. Denn alle <supplied reason="undefined" resp="#editor">Worte</supplied> des Markus
 sollen Erinnerungen der Worte Simons sein.</p>
 </div> <lb n="25"/>
 <div type="textpart" subtype="chapter" n="41">
@@ -9643,26 +9647,26 @@ daß sie faselten und logen, und sie als Betrüger zu schmähen versuchen, <lb n
 δὲ διαθέσεως σαφῆ καὶ ἐναργῆ τεκμήρια παρεσχηκέναι D</note>
 
 <pb n="v.3.pt.2.p.248"/>
-wie sollten sie nicht *lächerlich werden, als Freunde des Neides
+wie sollten sie nicht <corr resp="#editor">lächerlich</corr> werden, als Freunde des Neides
 der Eifersucht und als Feinde der Wahrheit erfunden werden? Denn
-wie wiiren nicht derart die, welche über *diejenigen, die ohne List und
-ohne häßliche Gewohnheit, eben (über) diejenigen, die durch
+wie wiiren nicht derart die, welche über <corr resp="#editor">diejenigen</corr>, die ohne List und
+ohne häßliche Gewohnheit, eben <supplied reason="undefined" resp="#editor">über</supplied> diejenigen, die durch
 <lb n="5"/> ihre Art als wahrhaftig und ihre Sitte als rein zeigten, zu sagen wagten,
 daß sie schlaue und gewandte Sophisten seien und das Nichtseiende
 und ihrem Meister das, was er niemals tat, willig beigelegt hätten?
 Es scheint mir gut, sie zu fragen, ob wir alles den Jüngern
 Erlösers glauben dürfen oder nicht, und ob wir nur
-<lb n="10"/> nicht glauben dürfen oder auch allen denen (nicht), die von
+<lb n="10"/> nicht glauben dürfen oder auch allen denen <supplied reason="undefined" resp="#editor">nicht</supplied>, die von
 her bei den Griechen und bei den Barbaren Erinnerungen über das
 Leben und die Worte derer, die zu verschiedenen Zeiten wegen gewisser
-Siegestaten berühmt waren, geschrieben haben, *oder (ob) sie es für <milestone unit="altnumbering" n="201"/>
+Siegestaten berühmt waren, geschrieben haben, <corr resp="#editor">oder</corr> <supplied reason="undefined" resp="#editor">ob</supplied> sie es für <milestone unit="altnumbering" n="201"/>
 Recht halten, den andern zu glauben, ihnen allein aber nicht zu glauben?
 <lb n="15"/> Wie ist da nicht ihr Neid offenbar?</p>
 </div>
 <div type="textpart" subtype="chapter" n="42">
 <p>Wie aber? Diejenigen, die in betreff ihres Meisters logen und
 in ihrer Schrift das, was von ihm nicht geschah, als geschehen überlieferten,
-haben sie auch *die Leiden und die Trübsale betreffs
+haben sie auch <corr resp="#editor">die</corr> Leiden und die Trübsale betreffs
 erlogen? Den Verrat eines Jüngers, meine ich, die Anklage derer,
 <lb n="20"/> ihn verleumdeten, das Gelächter und die Verspottung der Richter,
 Mißhandlungen und die Schläge auf seine Wangen, die Hiebe
@@ -9677,7 +9681,7 @@ haben, oder sollen wir glauben, daß sie hierbei wahrhaftig
 <lb n="30"/> ihnen aber in dem Ruhmvollen nicht glauben? Aber wie soll dies
 zwiespältige Dogma bestehen? Denn behaupten, daß
 wahr reden und wiederum über dasselbe lügen, heißt
-als in demselben (Augenblicke) Entgegengesetztes von ihnen sagen.
+als in demselben <supplied reason="undefined" resp="#editor">Augenblicke</supplied> Entgegengesetztes von ihnen sagen.
 <note type="footnote">19 vgl. Matth 26 f.</note>
 <note type="footnote">1 καταγέλαστοι D „ein Gelächter“ Σ 1. <foreign xml:lang="abbr">ABBREV</foreign> 3. l. <foreign xml:lang="abbr">ABBREV</foreign>
 οἵγε τοὺς οὕτως ἀπανούργους καὶ ἄπλαστον ὡς ἀληθῶς καὶ ἀκέραιον ἦθος διὰ
@@ -9686,27 +9690,27 @@ als in demselben (Augenblicke) Entgegengesetztes von ihnen sagen.
 seines Jüngers“ Σ τὴν ἑνὸς λιγῶ (Σ = λόγῳ) μαθητοῦ προδοσίαν D</note>
 
 <pb n="v.3.pt.2.p.249"/>
-Welches ist nun die Widerlegung dieser (Dinge)? Denn wenn sie sich
+Welches ist nun die Widerlegung dieser <supplied reason="undefined" resp="#editor">Dinge</supplied>? Denn wenn sie sich
 das Ziel gesetzt hätten, zu faseln und mit Lügenworten
 zu erheben und ihn mit Wundern zu schmücken, so hätten
 das vorher Gesagte gegen sich geschrieben noch den spätern
 geoffenbart, daß er, den sie predigten, betrübt, bekümmert und in seiner <lb n="5"/>
 Seele verwirrt war, oder daß sie ihn im Stiche ließen
 oder daß der Auserwählte aller, sein Apostel und Jünger,
-berühmte Simon Petrus, ohne Fesseln und Drohungen der *Fürsten ihn
+berühmte Simon Petrus, ohne Fesseln und Drohungen der <corr resp="#editor">Fürsten</corr> ihn
 dreimal verleugnete. Denn wenn auch andere dies gesagt hätten, so
 hätten doch sie dies leugnen müssen, die sich nichts anderes vorgenommen <lb n="10"/>
-hatten als mit Lügenworten sich und ihrem Meister *die
-(Taten) gütig zuzusprechen.</p>
+hatten als mit Lügenworten sich und ihrem Meister <corr resp="#editor">die</corr>
+<supplied reason="undefined" resp="#editor">Taten</supplied> gütig zuzusprechen.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="43">
 <p>Wenn sie aber
 <milestone unit="altnumbering" n="202"/> in den traurigen Erzählungen über ihn erscheinen, so sind sie noch
-mehr derartig auch in den (ihn) verherrlichenden (Geschichten). Denn
+mehr derartig auch in den <supplied reason="undefined" resp="#editor">ihn</supplied> verherrlichenden <supplied reason="undefined" resp="#editor">Geschichten</supplied>. Denn
 diejenigen, die Ein Mal vorzogen zu lügen, hätten das Traurige viel <lb n="15"/>
 mehr vermeiden müssen, entweder durch Stillschweigen oder
-Leugnung dieser (Dinge), da die Späteren das Verschwiegene
+Leugnung dieser <supplied reason="undefined" resp="#editor">Dinge</supplied>, da die Späteren das Verschwiegene
 tadeln können. Warum logen sie denn nicht und behaupteten,
 Judas, der ihn verriet, nachdem er gewagt hatte, den Kuß als Zeichen
 des Verrates zu zeigen, sogleich zu Stein wurde, daß dem, der ihn auf <lb n="20"/>
@@ -9718,9 +9722,9 @@ er unsichtbar ward und ihre Gerichtsstätte verspottete, daß diejenigen <lb n="
 aber, die ihn verleumdeten, durch gottgesandte Halluzinationen irre
 gingen und etwas gegen den zu tun glaubten, der nicht da war. Was
 aber? War es nicht lobenswerter als zu faseln, daß er Tote
-und ein Täter wunderbarer Handlungen war, (vielmehr) das
+und ein Täter wunderbarer Handlungen war, <supplied reason="undefined" resp="#editor">vielmehr</supplied> das
 schreiben, daß ihm nichts Menschliches noch Sterbliches zustieß,
-(daß) er alles mit göttlicher Kraft tat und seinen
+<supplied reason="undefined" resp="#editor">daß</supplied> er alles mit göttlicher Kraft tat und seinen
 Himmel mit göttlichem Ruhme vollführte? Denn nicht
 diejenigen leugnen, die ihren anderen Geschichten glaubten. Sie also
 <note type="footnote">1—9 = 17. Bruchstück der griech. Theoph. 5 vgl. Matth 26 57 ff.
@@ -9732,13 +9736,13 @@ Th. gr. 1. <foreign xml:lang="abbr">ABBREV</foreign> 11 οὐδὲν ἄλλο �
 
 <pb n="v.3.pt.2.p.250"/>
 die in keiner Weise die Wahrheit in den betrübenden
-(Ereignissen) verderbten, wie sollen sie nicht für würdig
-auch in den übrigen (und) andern (Dingen), die sie von ihm bezeugten,
+<supplied reason="undefined" resp="#editor">Ereignissen</supplied> verderbten, wie sollen sie nicht für würdig
+auch in den übrigen <supplied reason="undefined" resp="#editor">und</supplied> andern <supplied reason="undefined" resp="#editor">Dingen</supplied>, die sie von ihm bezeugten,
 ohne bösen Verdacht zu sein? Genügend also ist
 <lb n="5"/> unsern Erlöser, aber nichts hindert, zum Überfluß auch den Hebräer
-Josephus als Zeugen zu gebrauchen, der im achtzehnten (Buche) seiner
-jüdischen Archäologie, indem er die (Begebenheiten)
-beschreibt, unsern Erlöser in folgenden (Worten) erwähnt:</p>
+Josephus als Zeugen zu gebrauchen, der im achtzehnten <supplied reason="undefined" resp="#editor">Buche</supplied> seiner
+jüdischen Archäologie, indem er die <supplied reason="undefined" resp="#editor">Begebenheiten</supplied>
+beschreibt, unsern Erlöser in folgenden <supplied reason="undefined" resp="#editor">Worten</supplied> erwähnt:</p>
 <p>Von Josephus. Über Christus.</p>
 </div>
    
@@ -9748,7 +9752,7 @@ man ihn einen Menschen heißen darf. Denn er war ein
 Werke und ein Lehrer der Menschen, die mit Vergnügen
 aufnahmen, und sammelte viele aus den Juden und viele aus den
 Heiden. Dieser war der Christus. Ihn verließen, als Pilatus ihn auf <milestone unit="altnumbering" n="203"/>
-<lb n="15"/> die Anklage der ersten Männer (und) Fürsten bei uns
+<lb n="15"/> die Anklage der ersten Männer <supplied reason="undefined" resp="#editor">und</supplied> Fürsten bei uns
 in den Kopf gesetzt hatte, diejenigen nicht, die ihn vorher liebgewonnen
 hatten. Denn er erschien ihnen am dritten Tage wiederum lebendig,
 da die göttlichen Propheten dies und vieles andere über
@@ -9757,7 +9761,7 @@ hatten, weshalb bis jetzt von jenem an nicht afugehört hat
 </div>
   
 <div type="textpart" subtype="chapter" n="45">
-<p>Wenn also (auch) gemäß (diesem) Schriftsteller
+<p>Wenn also <supplied reason="undefined" resp="#editor">auch</supplied> gemäß <supplied reason="undefined" resp="#editor">diesem</supplied> Schriftsteller
 daß er ein Täter wunderbarer Werke war und nicht
 und siebzig Jünger sich gewann, sondern auch Myriaden andere aus
 den Juden und Myriaden aus den Heiden sich verband, so ist klar, daß
@@ -9767,7 +9771,7 @@ wenn er nicht Wunder und wunderbare Taten und seltsame Lehren gebrauchte?
 Es bezeugt aber auch die Schrift der Πραξεῖς der Apostel,
 daß es viele Myriaden jüdischer Männer
 <lb n="30"/> sei der Christus Gottes, der von den Propheten verkündigt
-(Geschichts) schreibung lehrt auch, daß eine große
+<supplied reason="undefined" resp="#editor">Geschichts</supplied> schreibung lehrt auch, daß eine große
 <note type="footnote">10—20 = Jos. Ant. XVIII 33; Euseb. Hist. eccles. I 117 f. 28 vgl. Act 2 41
 31 vgl. Euseb. Hist. eccles. IV 5</note>
 <note type="footnote">9 stammt nicht von Eusebius her &lt; D 12 ἀνθρώπων τῶν ἡδονῇ τἀληθῆ
@@ -9777,26 +9781,26 @@ daß es viele Myriaden jüdischer Männer
 ἀνθρώπους D „abgesehen von den übrigen Menschen“ Σ</note>
 
 <pb n="v.3.pt.2.p.251"/>
-Jerusalem war, die von den Juden gesammelt war (und dauerte) bis
+Jerusalem war, die von den Juden gesammelt war <supplied reason="undefined" resp="#editor">und dauerte</supplied> bis
 auf die Zeit der Belagerung unter Hadrian. Man sagt aber, daß die
 ersten, die dort Bischöfe der Reihe nach wurden, fünfzehn gewesen
 seien, deren Namen bis jetzt bei den Ortsansässigen
 werden, sodaß auch hierdurch jede Verleumdung wider die Jünger aufgehoben <lb n="5"/>
-wird, seitdem von ihnen, und (auch) abgesehen von ihrem
+wird, seitdem von ihnen, und <supplied reason="undefined" resp="#editor">auch</supplied> abgesehen von ihrem
 Zeugnis, bekannt wird, daß der Christus Gottes durch die
 Taten, die er vollbrachte, viele aus den Juden und aus den Heiden in
 seine Hand brachte.</p>
 </div>
 <div type="textpart" subtype="chapter" n="46">
-<p>Auch du aber wirst prüfen (können) die Göttlichkeit seiner <lb n="10"/>
+<p>Auch du aber wirst prüfen <supplied reason="undefined" resp="#editor">können</supplied> die Göttlichkeit seiner <lb n="10"/>
 Kraft, wenn du bedenkst, was er seiner Natur nach gewesen ist und
 von wie großer Vorzüglichkeit der göttlichen Kraft er
 Ausführung der Dinge war, die alle Worte in den
-stellen. Denn er beschloß, was niemals einer (beschloß),
+stellen. Denn er beschloß, was niemals einer <supplied reason="undefined" resp="#editor">beschloß</supplied>,
 Gesetz und eine fremde Lehre unter alle Völker zu säen und sich selbst <lb n="15"/>
 als Lehrer des ganzen Menschengeschlechts für die Verehrung
-<milestone unit="altnumbering" n="204"/> oberhalb von allem (stehenden) Gottes zu erweisen, und wollte (daher)
-diejenigen, die dörfischer und geringer als alle Menschen (sind),
+<milestone unit="altnumbering" n="204"/> oberhalb von allem <supplied reason="undefined" resp="#editor">stehenden</supplied> Gottes zu erweisen, und wollte <supplied reason="undefined" resp="#editor">daher</supplied>
+diejenigen, die dörfischer und geringer als alle Menschen <supplied reason="undefined" resp="#editor">sind</supplied>,
 Diener seines Willens benutzen, und es ist wahrscheinlich, daß
 glaubt, er habe dies ungeziemend getan. Denn wie sollten diejenigen. <lb n="20"/>
 die nicht einmal ihre Lippen aufheben konnten, jemals Lehrer Eines
@@ -9809,7 +9813,7 @@ als seine Nachfolger besaß, hauchte er ihnen göttliche Kraft
 erfüllte sie mit Kraft und Beherztheit, und da er selbst in
 der Logos Gottes und Täter so großer Wunder ist, so machte er
 Fischern der geistigen und vernünftigen Seelen und fürgte die Tat dem <lb n="30"/>
-Worte hinzu, das da *sagt: „Folgt mir nach, so will ich euch <add>zu
+Worte hinzu, das da <corr resp="#editor">sagt</corr>: „Folgt mir nach, so will ich euch <add>zu
 Menschenfischern</add> machen“ <add>und</add> erwarb sie zugleich als Täter
 <note type="footnote">10—S. 258, 4 = Dem. III 75—38 25. 31 = Mark 1 17 25 vgl. o. S. 171</note>
 <note type="footnote">6 „vor ihnen . . . bekennen“ Σ ὃτε καὶ πρὸς αὐτῶν καὶ δίχα τῆς αὐτῶν
@@ -9824,23 +9828,23 @@ Lehrer der Gottesverebrang zu eigen und schickte sie dann zu allen
 Völkern in der ganzen Schöpfung und machte sie zu
 Lehre. Wer wollte sich nicht wundern und mit Recht dem unwahrscheinlichen
 Wunder mißtrauen, da niemals geschrieben ist, daß
-<lb n="5"/> von den Menschen, die besser (verühmter) waren, derartiges
-noch auch zu dem kam. was diesem ähnlich ist. Denn das (schon) wäre
+<lb n="5"/> von den Menschen, die besser <supplied reason="undefined" resp="#editor">verühmter</supplied> waren, derartiges
+noch auch zu dem kam. was diesem ähnlich ist. Denn das <supplied reason="undefined" resp="#editor">schon</supplied> wäre
 einem jeden von ihnen lieb, wenn er auch nur in dem eigenen Lande
 seine eigene Anordnung durchführte und im stande war, die
 die ihm gut zu sein schienen, in Einem, in seinem eigenen Volke zu
 <lb n="10"/> bestätigen. Er aber, der nichts Menschliches noch Sterbliches
-— sieh zu, ob er <add>nicht</add> in Wahrheit wiederum die Stimme Gottes (ertönen)
+— sieh zu, ob er <add>nicht</add> in Wahrheit wiederum die Stimme Gottes <supplied reason="undefined" resp="#editor">ertönen</supplied>
 ließ, indem er wörtlich seinen armen Jüngern
 und lehret alle Völker.“ So aber mochten wahrscheinlich seine
 sagen, indem sie ihrem Meister antworteten: Wie können wir dies
 <lb n="15"/> Wie sollen wir denn den Römern verkündigen? Wie mit
 reden? Welches Wort gegen die Griechen gebrauchen als Männer,
 nur in der syrischen Sprache erzogen sind? Wie sollen wir die Perser,
-Armenier, Chaldäer, Skythen, Inder und die andern (so) genannten
+Armenier, Chaldäer, Skythen, Inder und die andern <supplied reason="undefined" resp="#editor">so</supplied> genannten
 überreden, sich von den Göttern ihrer Vorfahren abzuwenden und <milestone unit="altnumbering" n="205"/>
 <lb n="20"/> den Einen Schöpfer des Alls zu verehren? Auf welche
-der Worte aber sollen wir vertrauen und zu diesem (Werke) übergehen?
+der Worte aber sollen wir vertrauen und zu diesem <supplied reason="undefined" resp="#editor">Werke</supplied> übergehen?
 Oder welche Hoffnung auf Sieg sollen wir haben, wenn wir wagen, allen
 Völkern Gesetze zu geben entgegengesetzt den von Ewigkeit her
 Gesetzen in betreff der Götter? Welche Kraft haben wir,
@@ -9863,7 +9867,7 @@ D 27 μιᾷ προσθήκῃ λέξεως Σ 1. μιᾶς 29 „siegen“ = 
 <pb n="v.3.pt.2.p.253"/>
 jedes Knie sich beuge im Himmel, auf Erden und unter der Erde“, zeigte
 er mit Recht also die Vorzüglichkeit der verborgenen Kraft, die den
-meisten verborgen ist, in seinem Namen und fügte (daher) das Wort
+meisten verborgen ist, in seinem Namen und fügte <supplied reason="undefined" resp="#editor">daher</supplied> das Wort
 hinzu: „in meinem Namen.“ Dann weissagte er auch genau die
 und sagte: „Dies mein Evangelium muß in der ganzen Welt verkündigt <lb n="5"/>
 werden zum Zeugnis für alle Völker.“ Dies Wort aber
@@ -9884,10 +9888,10 @@ ihrer Väter und in den Worten ihrer Vorfahren auf.</p>
 <div type="textpart" subtype="chapter" n="47">
 <p>In Verlegenheit aber würde sich jemand geziemenderweise befinden
 <milestone unit="altnumbering" n="206"/> darüber), wie die Art der Lehre der Jünger unsers
-Gingen sie mitten in die Stadt, *standen dann auf dem Markte, erhoben
-eine laute Stimme und riefen die (zusammen), die zufällig kamen,
+Gingen sie mitten in die Stadt, <corr resp="#editor">standen</corr> dann auf dem Markte, erhoben
+eine laute Stimme und riefen die <supplied reason="undefined" resp="#editor">zusammen</supplied>, die zufällig kamen,
 redeten darauf mit dem Volke? Was war das Wort ihrer Volksrede, von
-dem es wahrscheinlich ist, daß sich die Zuhörer (davon) überzeugen ließen? <lb n="25"/>
+dem es wahrscheinlich ist, daß sich die Zuhörer <supplied reason="undefined" resp="#editor">davon</supplied> überzeugen ließen? <lb n="25"/>
 Wie konnten Männer Volksreden halten, die in Worten unerfahren
 fern von jeder Bildung waren? Aber sie redeten nicht mit der Menge,
 sondern mit den Einzelnen, die gerade kamen. Welche und welcherlei
@@ -9905,36 +9909,36 @@ und dann redeten sie“? Σ ἀλλὰ μὴν (Var. μὴ) οὐ κατὰ πλ
 <pb n="v.3.pt.2.p.254"/>
 und nicht vor jedermann bekannt hätten, was und wieviel er von
 luden litt, sondern allein das Ehrbare und Preiswürdige vorbrachten
-ich meine aber seine *wunderbaren Werke und staunenswerten Taten
+ich meine aber seine <corr resp="#editor">wunderbaren</corr> Werke und staunenswerten Taten
 und philosophischen Lehren — auch so wäre die Rede nicht leicht
 <lb n="5"/> um die Zuhörer willig ihren Worten zustimmend zu
-weil ihr Wort fremd war und (weil) sie jetzt neue Reden hörten
-Menschen, die ihnen nichts Glaubwürdiges *brachten zum Zeugnis
-was von ihnen *gesagt wurde.</p>
+weil ihr Wort fremd war und <supplied reason="undefined" resp="#editor">weil</supplied> sie jetzt neue Reden hörten
+Menschen, die ihnen nichts Glaubwürdiges <corr resp="#editor">brachten</corr> zum Zeugnis
+was von ihnen <corr resp="#editor">gesagt</corr> wurde.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="48">
 <p>Indessen aber würde ihnen das
-glaubwürdiger erschienen sein. Jetzt (aber) verkündeten
+glaubwürdiger erschienen sein. Jetzt <supplied reason="undefined" resp="#editor">aber</supplied> verkündeten
 <lb n="10"/> daß der von ihnen Gepredigte Gott in einem menschlichen Leibe
 und nichts anderes seiner Natur nach sei, als der Logos Gottes,
-(und) deswegen auch alle diese Wunder und Kräfte getan habe,
+<supplied reason="undefined" resp="#editor">und</supplied> deswegen auch alle diese Wunder und Kräfte getan habe,
 aber im Gegensatz dazu, daß er Schmach und Unehre ertrug und
 schimpflichste Ende und die Strafe durchs Kreuz, die den allerschlimmsten
 <lb n="15"/> Menschen wegen ihrer Taten auferlegt wird. Wer sollte sie nicht geziemend
 verspotten als solche, die Entgegengesetztes sagen? Wer wäre
 so töricht gewesen in seinem Sinne, willig zu glauben denen, die
-*sie hätten ihn nach seinem Tode auferstanden von den Toten
+<corr resp="#editor">sie</corr> hätten ihn nach seinem Tode auferstanden von den Toten
 ihn, der nicht einmal, als er noch lebte, sich helfen konnte? Wer hätte
 <lb n="20"/> sich aber von jenenLaien und Geringen jemals überzeugen lassen, die sagten:
 Ihr müßt die Dinge eurer Väter verachten <add>und</add> die Torheit der Weisen <milestone unit="altnumbering" n="207"/>
 von Ewigkeit her tadeln und euch nur von uns überzeugen lassen und
 von den Befehlen, die von dem Gekreuzigten ausgegeben sind. Denn
 er ist allein der geliebte und einzige Sohn des alleinigen, oberhalb von
-<lb n="25"/> allem (stehenden) Gottes.</p>
+<lb n="25"/> allem <supplied reason="undefined" resp="#editor">stehenden</supplied> Gottes.</p>
 </div>
 <div type="textpart" subtype="chapter" n="49">
-<p>Während ich also in Liebe zur Wahrheit das Wort *bei
+<p>Während ich also in Liebe zur Wahrheit das Wort <corr resp="#editor">bei</corr>
 prüfe, sehe ich keine überzeugende Kraft darin und nichts Großes
 nichts Glaubwürdiges und nicht einmal soviel Überzeugendes, daß
 auch nur Einen von den unkundigen, geschweige denn von den weisen
@@ -9955,13 +9959,13 @@ in den großen Städten gebaut sind — ich meine im
 in Alexandrien und Antiochien und in ganz Ägypten und Libyen, in
 Europa und Asien, in den Dörfern und Ortschaften und in allen
 Völkern — so bin ich wiederum notwendig gezwungen, zur Prüfung der <lb n="5"/>
-Ursache (zurück)zueilen Und zu bekennen, daß sie nicht
+Ursache <supplied reason="undefined" resp="#editor">zurück</supplied>zueilen Und zu bekennen, daß sie nicht
 Wagnis durchsetzen konnten als durch göttliche Kraft, die größer
-als (die der) Menschen, und durch die Hilfe dessen, der zu ihnen
+als <supplied reason="undefined" resp="#editor">die der</supplied> Menschen, und durch die Hilfe dessen, der zu ihnen
 sagte: „Gehet hin und lehrt alle Völker in meinem Namen.“
 aber dies zu ihnen gesagt hatte, verband er damit die Verheißung, durch <lb n="10"/>
 die sie bereitet wurden, zu vertrauen und sich willig dem hinzugeben,
-was (ihnen) befohlen war. Er sagte ihnen nämlich: „Siehe ich bin
+was <supplied reason="undefined" resp="#editor">ihnen</supplied> befohlen war. Er sagte ihnen nämlich: „Siehe ich bin
 euch alle Tage bis ans Ende der Welt.“ Es wird aber auch
 daß er ihnen den heiligen Geist eingehaucht und ihnen eine
 und wunderwirkende Kraft gegeben habe, indem er einmal sagt: „Nehmet <lb n="15"/>
@@ -9977,16 +9981,16 @@ bezeugt, wie sie, indem sie über sich selbst erzählten, durch
 <milestone unit="altnumbering" n="208"/> Taten im Namen Jesu, die von ihnen getan wurden, diejenigen, die zugegen
 waren und es sahen, in Erstaunen setzten. In Erstaunen setzten
 sie aber, wie es natürlich ist, die Zuschauer zuerst durch Taten.
-machten sie sie (derart), daß sie wdllig fragten, wer der sei, durch dessen <lb n="25"/>
+machten sie sie <supplied reason="undefined" resp="#editor">derart</supplied>, daß sie wdllig fragten, wer der sei, durch dessen <lb n="25"/>
 Kraft und in dessen Namen das Wunder geschah. Indem sie sie darauf
 belehrten, fanden sie, daß sie durch den Glauben ihrer Lehre
 waren. Denn da sie sich nicht durch Worte überzeugen
-ließen, sondern (da) sie durch Taten zuvor (gewonnen) waren, so
+ließen, sondern <supplied reason="undefined" resp="#editor">da</supplied> sie durch Taten zuvor <supplied reason="undefined" resp="#editor">gewonnen</supplied> waren, so
 man sie leicht dahin, dem Gesagten zuzustimmen. Man sagt aber, daß <note type="marginal">30</note>
 Einige Opfer und Spenden ihnen bald wie Göttern darbrachten und
 sie Einen von ihnen für Hermes, den andern für Zeus hielten,
 setzte der Beweis der wunderbaren Taten ihren Sinn in Erstaunen. Da
-sie so waren, *so wurde fortan alles, was (die Jünger) über
+sie so waren, <corr resp="#editor">so</corr> wurde fortan alles, was <supplied reason="undefined" resp="#editor">die Jünger</supplied> über
 <note type="footnote">9 = Matth 28 19 12 = Matth 2820 15 = Job 20 22 16 = Matth 10 8
 32 vgl. Act 14 12 f.
 25 εἶθ’ οὕτως προθύμους εἶχον αὐτοὺς ἐπὶ τὸ φιλοπευστεῖν D 34 str. <foreign xml:lang="abbr">ABBREV</foreign>
@@ -9995,17 +9999,17 @@ sie so waren, *so wurde fortan alles, was (die Jünger) über
 <pb n="v.3.pt.2.p.256"/>
 Erlöser verkündigten, sclinell und geziemend aufgenommen.
 von den Toten bezeugten sie nicht mit bloßen und
-Worten, sondern sie überzeugten eben durch *Taten, indem sie
+Worten, sondern sie überzeugten eben durch <corr resp="#editor">Taten</corr>, indem sie
 lebendige Werke zeigten.</p>
 </div>
 
 <div type="textpart" subtype="chapter" n="51">
 <p>Wenn sie aber ündigten, ß er
 <lb n="5"/> Gott sei und der Sohn Gottes und vor seinem Kommen unter die
-Menschen beim Vater gewesen sei, wie sollten sie dem nicht (noch)
+Menschen beim Vater gewesen sei, wie sollten sie dem nicht <supplied reason="undefined" resp="#editor">noch</supplied>
 mehr hinzufügen, indem sie meinten, daß das
 und unglaublich sei? Denn mit Recht erachteten sie, daß das,
-geschah, unmöglich für menschliche, sondern (nur)
+geschah, unmöglich für menschliche, sondern <supplied reason="undefined" resp="#editor">nur</supplied>
 <lb n="10"/> Taten gehalten werden dürfe, auch wenn es vielleicht niemand sage.</p>
 </div>
 <div type="textpart" subtype="chapter" n="52">
@@ -10021,7 +10025,7 @@ und betrachtet, daß dies nicht menschlich war, wie niemals
 <lb n="20"/> anderer Zeit früher viele Völker der ganzen Welt in der
 Macht, der Römer, waren als seit der Zeit unseres Erlöser. Denn sogleich <milestone unit="altnumbering" n="209"/>
 als er unter die Menschen ging, ereignete es sich, daß auch
-(Macht) der Römer wuchs, da in jener Zeit Augustus zuerst
+<supplied reason="undefined" resp="#editor">Macht</supplied> der Römer wuchs, da in jener Zeit Augustus zuerst
 vieler Völker war und zu seiner Zeit Kleopatra gefangen
 <lb n="25"/> wurde und die Nachfolge der Ptolemäer in Ägypten
 wurde. Denn seit jener Zeit bis jetzt ist das seit Ewigkeit und sozusagen
@@ -10030,7 +10034,7 @@ ausgerottet. Seit jener Zeit aber wurde auch das Volk der Juden den
 Römern Untertan und ebenso auch das der Syrer, der Kappadokier,
 <lb n="30"/> Makedonier, der Bithynier und der Griechen, und um es zusammenfassend
 zu sagen, all der übrigen, die in die Hand der römischen
-(kamen). Daß nicht ohne Gott dies zusammen mit der Lehre
+<supplied reason="undefined" resp="#editor">kamen</supplied>. Daß nicht ohne Gott dies zusammen mit der Lehre
 Erlösers sich ereignete, wer wollte dies nicht bekennen, indem
 bedenkt, daß es den Jüngern nicht leicht war, in fremden
 <note type="footnote">3 1. ABBERV mit HS 12 ὁποίᾳ δυνάμει περιγεγόνασι . . . οἱ
@@ -10044,19 +10048,19 @@ reisen, da alle Völker gegeneinander gespalten waren, und da es keinen
 unter ihnen gab wegen der vielen Satrapen an jedem Ort und in jeder
 Stadt. Infolge ihrer Vernichtung aber taten sie bald und ohne Furcht
 und in Ruhe das, was ihnen auferlegt war, da der oberhalb des Alls
-(stehende) Gott ihren Weg vorher friedlich gemacht hatte und den <lb n="5"/>
+<supplied reason="undefined" resp="#editor">stehende</supplied> Gott ihren Weg vorher friedlich gemacht hatte und den <lb n="5"/>
 Grimm der Dämonenverehrer in den Städten durch die Furcht
 größeren Reiche zurückhielt. Überlege nämlich, daß
-die durch den Irrtum (der Verehrung) vieler Götter in
+die durch den Irrtum <supplied reason="undefined" resp="#editor">der Verehrung</supplied> vieler Götter in
 versetzt waren, gehindert hätte, mit der Lehre Christi zu streiten,
 du vielleicht dann in jeder Stadt und in jedem Dorf gegenseitige Aufstände, <lb n="10"/>
 Verfolgungen und nicht gering Kriege sehen würdest, wenn
 Dämonenverehrer die Macht bei sich gehabt hätten. Jetzt aber
-dies das Werk des oberhalb von allem (waltenden) Gottes, daß er
+dies das Werk des oberhalb von allem <supplied reason="undefined" resp="#editor">waltenden</supplied> Gottes, daß er
 größere Furcht vor dem vorzüglichen Reiche die Feinde
 Wortes unterworfen hat. Denn er will, daß es jeden Tag wachse und <lb n="15"/>
 unter allen Menschen blühe. Wiederum aber, damit man nicht
-daß es durch das *Zugeständnis der Herrscher und nicht
+daß es durch das <corr resp="#editor">Zugeständnis</corr> der Herrscher und nicht
 die Vorzüglichkeit VorzÜglichkeit der göttlichen Kraft stark sei,
 von den Tyrannen durch Bosheit hingerissen ward und sich vornahm
 mit dem Worte Christi zu streiten, so gestattete der Gott des Alls, daß <lb n="20"/>
@@ -10066,14 +10070,14 @@ das Bestehen des Wortes keineswegs eine Folge des menschlichen
 Willens, sondern der göttlichen Kraft sei. Wer wollte nicht
 bewundern, was in derartigen Zeiten zu geschehen pflegt? Denn die <lb n="25"/>
 Athleten der Gottesfurcht, die früher den Menschen ihrer
-nach verborgen waren, wurden *in jener Zeit jedermann offenbar und
+nach verborgen waren, wurden <corr resp="#editor">in</corr> jener Zeit jedermann offenbar und
 sichtbar, geschmückt mit den Siegeskränzen von Gott. Die
 Gottesfurcht aber empfingen die gebührenden Strafen, indem sie durch
-gottgesandte Schläge gezüchtigt wurden und (indem) ihr ganzer Körper <lb n="30"/>
+gottgesandte Schläge gezüchtigt wurden und <supplied reason="undefined" resp="#editor">indem</supplied> ihr ganzer Körper <lb n="30"/>
 mit schweren, unheilbaren Leiden verderbt ward, sodaß sie sogleich
 zum Bekenntnis ihres Frevels gegen unsern Erlöser zu kommen
 wurden. Alle übrigen aber, die des göttlichen Namen
-sind und sich rühmen, die (Dinge) Christi zu treiben, wurden (nur) kurze
+sind und sich rühmen, die <supplied reason="undefined" resp="#editor">Dinge</supplied> Christi zu treiben, wurden <supplied reason="undefined" resp="#editor">nur</supplied> kurze
 <note type="footnote">1 πορείαν ἐπὶ τῆς ἀλλοδαπῆς στείλασθαι D „geschickt zu werden (= στείλασθαι)
 und zu reisen (= πορείαν)“ . . . Σ 10 „dann“] wörtlich
 14 φόβῳ τῆς ἀνωτάτω ἀρχῆς D 17 1. ABBERV Bernstein mit HS
@@ -10084,7 +10088,7 @@ Eusebius III*.</note>
 <pb n="v.3.pt.2.p.258"/>
 Zeit durch Versuchungen erprobt, zeigten die Reinheit und Lauterkeit
 ihrer Gesinnung und empfingen dann ihre eigene Freiheit Freiheit
-suchte Gott sie (gnädig) heim, während er durch sie alle
+suchte Gott sie <supplied reason="undefined" resp="#editor">gnädig</supplied> heim, während er durch sie alle
 den Erlóserlogos strahlen ließ.</p>
 <note>Zu Ende ist das Schreiben der fünf Bücher des
 die genannt werden: die Theophanie.</note>


### PR DESCRIPTION
The OCR didn't originally catch the sections below the book level. I added those divs, and numbered them in arabic instead of the original roman. I also disambiguated the marginal numbering schemes, encoded the critical punctuation, and caught a lot of OCR errors, though there are plenty more in here - the ends of lines were often cut off. It now is citable so that tlg010.opp-grc1 can reference it though, which was the goal.