### PR TITLE
Added '.DS_Store' (Mac useless unimportant metadata) to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .directory 
+.DS_Store


### PR DESCRIPTION
These .DS_Store files showed up today. Never seen them before, internet says they are metadata for/from Finder like window-size, position and other really unnecessary information. Suggestions were to add them to .gitignore. Hope that helps. 