### PR TITLE
tlg0363.tlg007-Need to fix character error for title in   __cts__.xml

### DIFF
--- a/data/tlg0363/tlg007/__cts__.xml
+++ b/data/tlg0363/tlg007/__cts__.xml
@@ -1,7 +1,7 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0363" xml:lang="grc" urn="urn:cts:greekLit:tlg0363.tlg007">
-  <ti:title xml:lang="eng">Apotelesmatica (%6 Tetrabiblos)</ti:title>
+  <ti:title xml:lang="eng">Apotelesmatica (= Tetrabiblos)</ti:title>
   <ti:edition urn="urn:cts:greekLit:tlg0363.tlg007.opp-grc2" workUrn="urn:cts:greekLit:tlg0363.tlg007">
-    <ti:label xml:lang="eng">Apotelesmatica (%6 Tetrabiblos)</ti:label>
-    <ti:description xml:lang="eng">Claudius Ptolemaeus, Apotelesmatica (%6 Tetrabiblos)</ti:description>
+    <ti:label xml:lang="eng">Apotelesmatica (= Tetrabiblos)</ti:label>
+    <ti:description xml:lang="eng">Claudius Ptolemaeus, Apotelesmatica (= Tetrabiblos)</ti:description>
   </ti:edition>
 </ti:work>


### PR DESCRIPTION
So I have proposed a change here, but I'm not sure this is technically correct.  I was wondering what I should do about the HTML character entity here for the equals sign, which wasn't correct anyway since it should have been &#61.  I have copied in in the proper TLG title here: Apotelesmatica (= Tetrabiblos) since I'm not sure how to represent the = sign in the title.