### PR TITLE
Standardized header for tlg0085.tlg002.opp-grc3.xml

### DIFF
--- a/data/tlg0085/tlg002/tlg0085.tlg002.opp-grc3.xml
+++ b/data/tlg0085/tlg002/tlg0085.tlg002.opp-grc3.xml
@@ -5,8 +5,7 @@
     <fileDesc>
       <titleStmt>
         <title type="work" n="Pers.">Persians</title>
-        <title type="sub">Machine readable text</title>
-        <author n="Aesch.">Aeschylus</author>
+         <author n="Aesch.">Aeschylus</author>
         <editor role="editor">Arthur Sidgwick</editor>
         <sponsor>Perseus Project, Tufts University</sponsor>
         <principal>Gregory Crane</principal>
@@ -27,8 +26,9 @@
           <monogr>
             <author>Aeschylus</author>
             <title>Aeschyli Tragoediae : cum fabularum deperditarum fragmentis,
-                    poetae vita et operum catalogo / recensuit Arturus Sidgwick.</title>
+                    poetae vita et operum catalogo</title>
             <imprint>
+              <editor>Arthur Sidgwick</editor>
               <pubPlace>Oxford</pubPlace>
               <publisher>Clarendon Press</publisher>
               <date>1902</date>

--- a/data/tlg0085/tlg002/tlg0085.tlg002.opp-grc3.xml
+++ b/data/tlg0085/tlg002/tlg0085.tlg002.opp-grc3.xml
@@ -27,8 +27,8 @@
             <author>Aeschylus</author>
             <title>Aeschyli Tragoediae : cum fabularum deperditarum fragmentis,
                     poetae vita et operum catalogo</title>
+                 <editor>Arthur Sidgwick</editor>
             <imprint>
-              <editor>Arthur Sidgwick</editor>
               <pubPlace>Oxford</pubPlace>
               <publisher>Clarendon Press</publisher>
               <date>1902</date>


### PR DESCRIPTION
Deleted "machine readable text" as subtitle for header consistency and added in editor information.