### PR TITLE
Standardized header for tlg0085.tlg006.opp-grc3.xml

### DIFF
--- a/data/tlg0085/tlg006/tlg0085.tlg006.opp-grc3.xml
+++ b/data/tlg0085/tlg006/tlg0085.tlg006.opp-grc3.xml
@@ -2,7 +2,6 @@
     <fileDesc>
       <titleStmt>
         <title type="work" n="Lib.">Libation Bearers</title>
-        <title type="sub">Machine readable text</title>
         <author n="Aesch.">Aeschylus</author>
         <editor role="editor">Arthur Sidgwick</editor>
         <sponsor>Perseus Project, Tufts University</sponsor>
@@ -25,7 +24,8 @@
           <monogr>
             <author>Aeschylus</author>
             <title>Aeschyli Tragoediae : cum fabularum deperditarum fragmentis,
-                    poetae vita et operum catalogo / recensuit Arturus Sidgwick.</title>
+                    poetae vita et operum catalogo</title>
+              <editor>Arthur Sidgwick</editor>
             <imprint>
               <pubPlace>Oxford</pubPlace>
               <publisher>Clarendon Press</publisher>


### PR DESCRIPTION
Deleted "machine readable text" as subtitle for header consistency and added in editor information.