### PR TITLE
Standardized header for tlg0085.tlg007.opp-grc3.xml

### DIFF
--- a/data/tlg0085/tlg007/tlg0085.tlg007.opp-grc3.xml
+++ b/data/tlg0085/tlg007/tlg0085.tlg007.opp-grc3.xml
@@ -5,9 +5,8 @@
     <fileDesc>
       <titleStmt>
         <title type="work" n="Eum.">Eumenides</title>
-        <title type="sub">Machine readable text</title>
         <author n="Aesch.">Aeschylus</author>
-        <editor role="editor" n="Smyth">Arthur Sidgwick</editor>
+        <editor role="editor">Arthur Sidgwick</editor>
         <sponsor>Perseus Project, Tufts University</sponsor>
         <principal>Gregory Crane</principal>
         <respStmt>
@@ -27,7 +26,8 @@
           <monogr>
             <author>Aeschylus</author>
             <title>Aeschyli Tragoediae : cum fabularum deperditarum fragmentis,
-                    poetae vita et operum catalogo / recensuit Arturus Sidgwick.</title>
+                    poetae vita et operum catalogo</title>
+            <editor>Arthur Sidgwick</editor>
             <imprint>
               <pubPlace>Oxford</pubPlace>
               <publisher>Clarendon Press</publisher>


### PR DESCRIPTION
Deleted "machine readable text" as subtitle for header consistency and added in editor information.