### PR TITLE
Fixed typo in __cts__.xml

### DIFF
--- a/data/tlg0527/tlg006/__cts__.xml
+++ b/data/tlg0527/tlg006/__cts__.xml
@@ -1,7 +1,7 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0527" xml:lang="grc" urn="urn:cts:greekLit:tlg0527.tlg006">
-  <ti:title xml:lang="eng">Josue (Cod. Vaticanus %7 Cod. Alexandrinus)</ti:title>
+  <ti:title xml:lang="eng">Josue (Cod. Vaticanus + Cod. Alexandrinus)</ti:title>
   <ti:edition urn="urn:cts:greekLit:tlg0527.tlg006.opp-grc2" workUrn="urn:cts:greekLit:tlg0527.tlg006">
-    <ti:label xml:lang="eng">Josue (Cod. Vaticanus %7 Cod. Alexandrinus)</ti:label>
-    <ti:description xml:lang="eng">Septuaginta, Josue (Cod. Vaticanus %7 Cod. Alexandrinus)</ti:description>
+    <ti:label xml:lang="eng">Josue (Cod. Vaticanus + Cod. Alexandrinus)</ti:label>
+    <ti:description xml:lang="eng">Septuaginta, Josue (Cod. Vaticanus + Cod. Alexandrinus)</ti:description>
   </ti:edition>
 </ti:work>


### PR DESCRIPTION
Fixed typo, replaced incorrect entity reference.