### PR TITLE
Fixed typo in __cts__.xml for urn:cts:greekLit:tlg0527.tlg012

### DIFF
--- a/data/tlg0527/tlg012/__cts__.xml
+++ b/data/tlg0527/tlg012/__cts__.xml
@@ -1,7 +1,7 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0527" xml:lang="grc" urn="urn:cts:greekLit:tlg0527.tlg012">
-  <ti:title xml:lang="eng">Regnorum Ii (Samuelis Ii In Textu Masoretico)</ti:title>
+  <ti:title xml:lang="eng">Regnorum ii (Samuelis ii In Textu Masoretico)</ti:title>
   <ti:edition urn="urn:cts:greekLit:tlg0527.tlg012.opp-grc2" workUrn="urn:cts:greekLit:tlg0527.tlg012">
-    <ti:label xml:lang="eng">Regnorum Ii (Samuelis Ii In Textu Masoretico)</ti:label>
-    <ti:description xml:lang="eng">Septuaginta, Regnorum Ii (Samuelis Ii In Textu Masoretico)</ti:description>
+    <ti:label xml:lang="eng">Regnorum ii (Samuelis ii In Textu Masoretico)</ti:label>
+    <ti:description xml:lang="eng">Septuaginta, Regnorum ii (Samuelis ii In Textu Masoretico)</ti:description>
   </ti:edition>
 </ti:work>


### PR DESCRIPTION
Fixed typo.