### PR TITLE
Changing tlg0530.tlg035.opp-grc1 to tlg0057.tlg035.opp-grc2

### DIFF
--- a/data/tlg0057/tlg035/__cts__.xml
+++ b/data/tlg0057/tlg035/__cts__.xml
@@ -1,0 +1,7 @@
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0057" xml:lang="grc" urn="urn:cts:greekLit:tlg0057.tlg035">
+  <ti:title xml:lang="lat">De venereis</ti:title>
+  <ti:edition urn="urn:cts:greekLit:tlg0057.tlg035.1st1K-grc2" workUrn="urn:cts:greekLit:tlg0057.tlg035">
+    <ti:label xml:lang="eng">De venereis</ti:label>
+    <ti:description xml:lang="eng">Galen, De venereis</ti:description>
+  </ti:edition>
+</ti:work>

--- a/data/tlg0057/tlg035/tlg0057.tlg035.1st1K-grc2.xml
+++ b/data/tlg0057/tlg035/tlg0057.tlg035.1st1K-grc2.xml
@@ -5,7 +5,7 @@
         <fileDesc>
             <titleStmt>
                 <title>De venereis</title>
-                <author>pseudo-Galen</author>
+                <author>Galen</author>
                 <editor>Karl Gottlob Kühn</editor>
                 <funder>Andrew W. Mellon Foundation</funder>
                 <respStmt>
@@ -46,7 +46,7 @@
                     Mellon Foundation</authority>
                 <publisher>University of Leipzig</publisher>
                 <pubPlace>Germany</pubPlace>
-                <idno type="filename">tlg0530.tlg035.1st1K-grc1.xml</idno>
+                <idno type="filename">tlg0057.tlg035.1st1K-grc2.xml</idno>
                 <availability>
                     <licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available
                         under a Creative Commons Attribution-ShareAlike 4.0 International
@@ -58,7 +58,7 @@
                 <biblStruct>
                     <monogr>
                         <title>Claudii Galeni Opera Omnia</title>
-                        <author>pseudo-Galen</author>
+                        <author>Galen</author>
                         <editor>Karl Gottlob Kühn</editor>
                         <imprint>
                             <publisher>Cnobloch</publisher>
@@ -90,7 +90,7 @@
     <text>
         <body>
 
-            <div type="edition" xml:lang="grc" n="urn:cts:greekLit:tlg0530.tlg035.1st1K-grc1">
+            <div type="edition" xml:lang="grc" n="urn:cts:greekLit:tlg0057.tlg035.1st1K-grc2">
                 <pb n="911"/>
                 <div type="textpart" subtype="work" n="1">
                     <head>ΓΑΛΗΝΟΥ ΠΕΡΙ ΑΦΡΟΔΙΣΙΩΝ.</head>

--- a/data/tlg0530/tlg035/__cts__.xml
+++ b/data/tlg0530/tlg035/__cts__.xml
@@ -1,7 +1,0 @@
-<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0530" xml:lang="grc" urn="urn:cts:greekLit:tlg0530.tlg035">
-  <ti:title xml:lang="eng">De venereis</ti:title>
-  <ti:edition urn="urn:cts:greekLit:tlg0530.tlg035.1st1K-grc1" workUrn="urn:cts:greekLit:tlg0530.tlg035">
-    <ti:label xml:lang="eng">De venereis</ti:label>
-    <ti:description xml:lang="eng">Galen, De venereis</ti:description>
-  </ti:edition>
-</ti:work>


### PR DESCRIPTION
Per issue #908, I have deleted the files for De Venereis under Pseudo-Galenus and moved them to the directory for Galen.

So tlg0530.tlg035 is now tlg0057.tlg035.