### PR TITLE
Update tlg1216.tlg001.opp-grc1.xml

### DIFF
--- a/data/tlg1216/tlg001/tlg1216.tlg001.opp-grc1.xml
+++ b/data/tlg1216/tlg001/tlg1216.tlg001.opp-grc1.xml
@@ -4,7 +4,7 @@
   <teiHeader>
     <fileDesc>
       <titleStmt>
-        <title>Barnabae epistula</title>
+        <title xml:lang="lat">Barnabae epistula</title>
         <author>Barnabas</author>
         <editor>Kirsopp Lake</editor>
         <funder>A Google Digital Humanities Award</funder>
@@ -50,7 +50,7 @@
                   <name>Kirsopp Lake</name>
                 </persName>
               </editor>
-              <author ref="urn:cts:greekLit:tlg1216">Barnabas</author>
+              <author ref="urn:cts:greekLit:tlg1216" xml:lang="lat">Barnabas</author>
               <imprint>
                 <publisher>Harvard University Press</publisher>
                 <pubPlace>Cambridge, Massachusetts, USA</pubPlace>

--- a/data/tlg1216/tlg001/tlg1216.tlg001.opp-grc1.xml
+++ b/data/tlg1216/tlg001/tlg1216.tlg001.opp-grc1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
+  <teiHeader xml:lang="eng">
     <fileDesc>
       <titleStmt>
         <title xml:lang="lat">Barnabae epistula</title>
@@ -73,6 +73,7 @@
     <profileDesc>
       <langUsage>
         <language ident="grc">Greek</language>
+        <language ident="lat">Latin</language>
       </langUsage>
     </profileDesc>
     <revisionDesc>

--- a/data/tlg1216/tlg001/tlg1216.tlg001.opp-grc1.xml
+++ b/data/tlg1216/tlg001/tlg1216.tlg001.opp-grc1.xml
@@ -44,7 +44,7 @@
         <listBibl>
           <biblStruct>
             <monogr>
-              <title>The Apostolic Fathers I</title>
+              <title>The Apostolic Fathers</title>
               <editor>
                 <persName>
                   <name>Kirsopp Lake</name>
@@ -54,7 +54,7 @@
               <imprint>
                 <publisher>Harvard University Press</publisher>
                 <pubPlace>Cambridge, Massachusetts, USA</pubPlace>
-                <date>1985</date>
+                <date>1912</date>
               </imprint>
               <biblScope unit="volume">1</biblScope>
             </monogr>


### PR DESCRIPTION
I edited the data a bit here, namely taking the volume number out of the title, and changing the date to the publication date of the original volume 1912, since 1985 was just the reprinting date.