### PR TITLE
Update tlg3135.tlg001.opp-grc1.xml

### DIFF
--- a/data/tlg3135/tlg001/__cts__.xml
+++ b/data/tlg3135/tlg001/__cts__.xml
@@ -1,7 +1,7 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg3135" xml:lang="grc" urn="urn:cts:greekLit:tlg3135.tlg001">
-  <ti:title xml:lang="lat">Epitome Historiarum (Lib. 1-12)</ti:title>
+  <ti:title xml:lang="lat">Epitome Historiarum (Lib. 1-18)</ti:title>
   <ti:edition urn="urn:cts:greekLit:tlg3135.tlg001.opp-grc1" workUrn="urn:cts:greekLit:tlg3135.tlg001">
-    <ti:label xml:lang="lat">Epitome Historiarum (Lib. 1-12)</ti:label>
-    <ti:description xml:lang="mul">Joannes Zonaras, Epitome Historiarum (Lib. 1-12), Dindorf, Teubner, 1868</ti:description>
+    <ti:label xml:lang="lat">Epitome Historiarum (Lib. 1-18)</ti:label>
+    <ti:description xml:lang="mul">Joannes Zonaras, Epitome Historiarum (Lib. 1-18), Dindorf, Teubner, 1868-1870</ti:description>
   </ti:edition>
 </ti:work>

--- a/manifest.txt
+++ b/manifest.txt
@@ -1,0 +1,5 @@
+data/tlg0358/__cts__.xml
+data/tlg0358/tlg001/__cts__.xml
+data/tlg0358/tlg001/tlg0358.tlg001.1st1K-grc1.xml
+data/tlg0358/tlg005/__cts__.xml
+data/tlg0358/tlg005/tlg0358.tlg005.1st1K-grc1.xml


### PR DESCRIPTION
Standardized metadata.
Changed file ID.

Also @sonofmun : Should we change the title of this work as it does not reflect the reality of the file? Only volume 1 of Dindorf's edition
of this work seems to be contained in this file, but I couldn't quite figure out how many books of the full work were within this file.