### PR TITLE
tlg2255_to_tlg0593--Textgroup renaming from Gorgias (historian) to Gorgias of Leontini

### DIFF
--- a/data/tlg0593/1st1K001/__cts__.xml
+++ b/data/tlg0593/1st1K001/__cts__.xml
@@ -1,0 +1,8 @@
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0593" xml:lang="grc" urn="urn:cts:greekLit:tlg0593.1st1K001">
+  <ti:title xml:lang="eng">Encomium of Helen</ti:title>
+  <ti:edition urn="urn:cts:greekLit:tlg0593.1st1K001.1st1K-grc1" workUrn="urn:cts:greekLit:tlg0593.1st1K001">
+    <ti:label xml:lang="grc">ΕΛΕΝΗΣ ΕΓΚΩΜΙΟΝ</ti:label>
+    <ti:description xml:lang="mul">Gorgias, Encomium of Helen, Antiphontis orationes et fragmenta adiunctis Gorgiae, 
+      Antisthenis, Alcidamantis declamationibus, Teubner, Blass, 1908</ti:description>
+  </ti:edition>
+</ti:work>

--- a/data/tlg0593/1st1K001/tlg0593.1st1K001.1st1K-grc1.xml
+++ b/data/tlg0593/1st1K001/tlg0593.1st1K001.1st1K-grc1.xml
@@ -8,6 +8,31 @@
         <title xml:lang="grc">ΕΛΕΝΗΣ ΕΓΚΩΜΙΟΝ</title>
         <author>Gorgias of Leontini</author>
         <editor role="editor">Friedrich Blass</editor>
+        <principal>Gregory Crane</principal>
+<respStmt>
+    <persName xml:id="DDD">Digital Divide Data</persName>
+    <resp>Corrected and encoded the text</resp>
+</respStmt>
+<respStmt>
+    <persName>Gregory Crane</persName>
+    <resp>Editor-in-Chief, Perseus Digital Library</resp>
+</respStmt>
+<respStmt>
+    <persName>Matt Munson</persName>
+    <resp>Project Manager (University of Leipzig), 2016 - present</resp>
+</respStmt>
+<respStmt>
+    <persName>Annette Gessner</persName>
+    <resp>Project Assistant (University of Leipzig) 2015 - present</resp>
+</respStmt>
+<respStmt>
+    <persName>Thibault Clérice</persName>
+    <resp>Lead Developer (University of Leipzig)</resp>
+</respStmt>
+<respStmt>
+    <persName>Bruce Robertson</persName>
+    <resp>Technical Advisor</resp>
+</respStmt>
       </titleStmt>
       <publicationStmt>
         <publisher>Trustees of Tufts University</publisher>
@@ -17,8 +42,8 @@
       <sourceDesc>
         <biblStruct>
           <monogr>
-            <title type="m">Antiphontis orationes et fragmenta</title>
-            <title type="s">adiunctis Gorgiae, Antisthenis, Alcidamantis declamationibus</title>
+            <title type="m" xml:lang="lat">Antiphontis orationes et fragmenta</title>
+            <title type="s" xml:lang="lat">adiunctis Gorgiae, Antisthenis, Alcidamantis declamationibus</title>
             <author ref="urn:cts:greekLit:tlg0593">Gorgias of Leontini</author>
             <editor role="editor">Friedrich Blass</editor>
             <imprint>
@@ -41,6 +66,7 @@
     <profileDesc>
       <langUsage>
         <language ident="grc">Greek</language>
+        <language ident="lat">Latin</language>
       </langUsage>
     </profileDesc>
 

--- a/data/tlg0593/1st1K001/tlg0593.1st1K001.1st1K-grc1.xml
+++ b/data/tlg0593/1st1K001/tlg0593.1st1K001.1st1K-grc1.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
-    
+  <teiHeader xml:lang="eng">    
     <fileDesc>
       <titleStmt>
         <title>Encomium of Helen</title>
-        <author>Gorgias</author>
+        <title xml:lang="grc">ΕΛΕΝΗΣ ΕΓΚΩΜΙΟΝ</title>
+        <author>Gorgias of Leontini</author>
         <editor role="editor">Friedrich Blass</editor>
       </titleStmt>
       <publicationStmt>
@@ -17,8 +17,9 @@
       <sourceDesc>
         <biblStruct>
           <monogr>
-            <title>ΕΛΕΝΗΣ ΕΓΚΩΜΙΟΝ</title>
-            <author>ΓΟΡΓΙΟΥ</author>
+            <title type="m">Antiphontis orationes et fragmenta</title>
+            <title type="s">adiunctis Gorgiae, Antisthenis, Alcidamantis declamationibus</title>
+            <author ref="urn:cts:greekLit:tlg0593">Gorgias of Leontini</author>
             <editor role="editor">Friedrich Blass</editor>
             <imprint>
               <publisher>Teubner</publisher>
@@ -52,7 +53,7 @@
 
   <text>
     <body>
-      <div type="edition" n="urn:cts:greekLit:tlg2255.perseus001.perseus-grc1" xml:lang="grc">
+      <div type="edition" n="urn:cts:greekLit:tlg0593.1st1K001.1st1K-grc1" xml:lang="grc">
         <pb ed="alt" n="p. 91 R."/>
         <head>ΓΟΡΓΙΟΥ ΕΛΕΝΗΣ ΕΓΚΩΜΙΟΝ.</head>
         <div type="textpart" subtype="section" n="1">

--- a/data/tlg0593/1st1K002/__cts__.xml
+++ b/data/tlg0593/1st1K002/__cts__.xml
@@ -1,0 +1,8 @@
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0593" xml:lang="grc" urn="urn:cts:greekLit:tlg0593.1st1K002">
+  <ti:title xml:lang="eng">Defense of Palamedes</ti:title>
+  <ti:edition urn="urn:cts:greekLit:tlg0593.1st1K002.1st1K-grc1" workUrn="urn:cts:greekLit:tlg0593.1st1K002">
+    <ti:label xml:lang="grc">ΥΠΕΡ ΠΑΛΑΜΗΔΟΥΣ ΑΠΟΛΟΓΙΑ</ti:label>
+    <ti:description xml:lang="mul">Gorgias, Defense of Palamedes, Antiphontis orationes et fragmenta adiunctis Gorgiae, 
+      Antisthenis, Alcidamantis declamationibus, Teubner, Blass, 1908</ti:description>
+  </ti:edition>
+</ti:work>

--- a/data/tlg0593/1st1K002/tlg0593.1st1K002.1st1K-grc1.xml
+++ b/data/tlg0593/1st1K002/tlg0593.1st1K002.1st1K-grc1.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-	<teiHeader>
-    
+	<teiHeader xml:lang="eng">    
 		<fileDesc>
 			<titleStmt>
 				<title>Defense of Palamedes</title>
-				<author>Gorgias</author>
+				<title xml:lang="grc">ΥΠΕΡ ΠΑΛΑΜΗΔΟΥΣ ΑΠΟΛΟΓΙΑ</title>
+				<author>Gorgias of Leontini</author>
 				<editor role="editor">Friedrich Blass</editor>
 			</titleStmt>
 			<publicationStmt>
@@ -17,8 +17,9 @@
 			<sourceDesc>
 				<biblStruct>
 					<monogr>
-						<title>ΥΠΕΡ ΠΑΛΑΜΗΔΟΥΣ ΑΠΟΛΟΓΙΑ</title>
-						<author>ΓΟΡΓΙΟΥ</author>
+						<title type="m">Antiphontis orationes et fragmenta</title>
+						<title type="s">adiunctis Gorgiae, Antisthenis, Alcidamantis declamationibus</title>
+						<author  ref="urn:cts:greekLit:tlg0593">Gorgias of Leontini</author>
 						<editor role="editor">Friedrich Blass</editor>
 						<imprint>
 							<publisher>Teubner</publisher>
@@ -46,7 +47,7 @@
 
 	<text>
 		<body>
-			<div type="edition" n="urn:cts:greekLit:tlg2255.perseus002.perseus-grc1" xml:lang="grc">
+			<div type="edition" n="urn:cts:greekLit:tlg0593.1st1K002.1st1K-grc1" xml:lang="grc">
 				<head>ΓΟΡΓΙΟΥ ΥΠΕΡ ΠΑΛΑΜΗΔΟΥΣ ΑΠΟΛΟΓΙΑ</head>
 				<div type="textpart" subtype="section" n="1">
 					<p>Ἡ μὲν κατηγορία καὶ [ἡ ἀπολογία] κρίσις οὐ περὶ θανάτου γίγνεται· θάνατον μὲν γὰρ ἡ

--- a/data/tlg0593/1st1K002/tlg0593.1st1K002.1st1K-grc1.xml
+++ b/data/tlg0593/1st1K002/tlg0593.1st1K002.1st1K-grc1.xml
@@ -8,6 +8,31 @@
 				<title xml:lang="grc">ΥΠΕΡ ΠΑΛΑΜΗΔΟΥΣ ΑΠΟΛΟΓΙΑ</title>
 				<author>Gorgias of Leontini</author>
 				<editor role="editor">Friedrich Blass</editor>
+				<principal>Gregory Crane</principal>
+<respStmt>
+    <persName xml:id="DDD">Digital Divide Data</persName>
+    <resp>Corrected and encoded the text</resp>
+</respStmt>
+<respStmt>
+    <persName>Gregory Crane</persName>
+    <resp>Editor-in-Chief, Perseus Digital Library</resp>
+</respStmt>
+<respStmt>
+    <persName>Matt Munson</persName>
+    <resp>Project Manager (University of Leipzig), 2016 - present</resp>
+</respStmt>
+<respStmt>
+    <persName>Annette Gessner</persName>
+    <resp>Project Assistant (University of Leipzig) 2015 - present</resp>
+</respStmt>
+<respStmt>
+    <persName>Thibault Clérice</persName>
+    <resp>Lead Developer (University of Leipzig)</resp>
+</respStmt>
+<respStmt>
+    <persName>Bruce Robertson</persName>
+    <resp>Technical Advisor</resp>
+</respStmt>
 			</titleStmt>
 			<publicationStmt>
 				<publisher>Trustees of Tufts University</publisher>
@@ -17,8 +42,8 @@
 			<sourceDesc>
 				<biblStruct>
 					<monogr>
-						<title type="m">Antiphontis orationes et fragmenta</title>
-						<title type="s">adiunctis Gorgiae, Antisthenis, Alcidamantis declamationibus</title>
+						<title type="m" xml:lang="lat">Antiphontis orationes et fragmenta</title>
+						<title type="s" xml:lang="lat">adiunctis Gorgiae, Antisthenis, Alcidamantis declamationibus</title>
 						<author  ref="urn:cts:greekLit:tlg0593">Gorgias of Leontini</author>
 						<editor role="editor">Friedrich Blass</editor>
 						<imprint>
@@ -41,6 +66,7 @@
 		<profileDesc>
 			<langUsage>
 				<language ident="grc">Greek</language>
+				<language ident="lat">Latin</language>
 			</langUsage>
 		</profileDesc>
 	</teiHeader>

--- a/data/tlg0593/__cts__.xml
+++ b/data/tlg0593/__cts__.xml
@@ -1,0 +1,4 @@
+<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:greekLit:tlg0593">
+  <ti:groupname xml:lang="eng">Gorgias of Leontini</ti:groupname>
+  <ti:groupname xml:lang="grc">ΓΟΡΓΙΟΥ</ti:groupname>
+</ti:textgroup>

--- a/data/tlg2255/__cts__.xml
+++ b/data/tlg2255/__cts__.xml
@@ -1,3 +1,0 @@
-<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:greekLit:tlg2255">
-  <ti:groupname xml:lang="eng">Gorgias</ti:groupname>
-</ti:textgroup>

--- a/data/tlg2255/perseus001/__cts__.xml
+++ b/data/tlg2255/perseus001/__cts__.xml
@@ -1,7 +1,0 @@
-<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg2255" xml:lang="grc" urn="urn:cts:greekLit:tlg2255.perseus001">
-  <ti:title xml:lang="eng">Encomium of Helen</ti:title>
-  <ti:edition urn="urn:cts:greekLit:tlg2255.perseus001.perseus-grc1" workUrn="urn:cts:greekLit:tlg2255.perseus001">
-    <ti:label xml:lang="grc">ΕΛΕΝΗΣ ΕΓΚΩΜΙΟΝ</ti:label>
-    <ti:description xml:lang="grc">ΓΟΡΓΙΟΥ ΕΛΕΝΗΣ ΕΓΚΩΜΙΟΝ</ti:description>
-  </ti:edition>
-</ti:work>

--- a/data/tlg2255/perseus002/__cts__.xml
+++ b/data/tlg2255/perseus002/__cts__.xml
@@ -1,7 +1,0 @@
-<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg2255" xml:lang="grc" urn="urn:cts:greekLit:tlg2255.perseus002">
-  <ti:title xml:lang="eng">Defense of Palamedes</ti:title>
-  <ti:edition urn="urn:cts:greekLit:tlg2255.perseus002.perseus-grc1" workUrn="urn:cts:greekLit:tlg2255.perseus002">
-    <ti:label xml:lang="grc">ΥΠΕΡ ΠΑΛΑΜΗΔΟΥΣ ΑΠΟΛΟΓΙΑ</ti:label>
-    <ti:description xml:lang="grc">ΓΟΡΓΙΟΥ ΥΠΕΡ ΠΑΛΑΜΗΔΟΥΣ ΑΠΟΛΟΓΙΑ</ti:description>
-  </ti:edition>
-</ti:work>


### PR DESCRIPTION
Deleted the cts and work files under tlg2200--Gorgias
Renamed and edited the files under text group tlg0593 (Gorgias of Leontini)
Also edited the metadata in the headers within the files, adding language tagging,
standardizing author name, and adding in more bibliographic information.

All per issue #1272 