### PR TITLE
tlg0661_to_tlg0616-Renumbering the Polyaenus text group

### DIFF
--- a/data/tlg0616/__cts__.xml
+++ b/data/tlg0616/__cts__.xml
@@ -1,0 +1,3 @@
+<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:greekLit:tlg0616">
+  <ti:groupname xml:lang="lat">Polyaenus Macedo</ti:groupname>
+</ti:textgroup>

--- a/data/tlg0616/tlg001/__cts__.xml
+++ b/data/tlg0616/tlg001/__cts__.xml
@@ -1,0 +1,7 @@
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0616" xml:lang="grc" urn="urn:cts:greekLit:tlg0616.tlg001">
+  <ti:title xml:lang="lat">Strategemata</ti:title>
+  <ti:edition urn="urn:cts:greekLit:tlg0616.tlg001.1st1K-grc1" workUrn="urn:cts:greekLit:tlg0616.tlg001">
+    <ti:label xml:lang="lat">Strategematon</ti:label>
+    <ti:description xml:lang="mul">Polyaenus Macedo, Strategematon, Melber and Woelfflin, Teubner, 1887</ti:description>
+  </ti:edition>
+</ti:work>

--- a/data/tlg0616/tlg001/tlg0616.tlg001.1st1K-grc1.xml
+++ b/data/tlg0616/tlg001/tlg0616.tlg001.1st1K-grc1.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-<teiHeader>
-    
+<teiHeader xml:lang="eng">    
 <fileDesc>
 <titleStmt>
-	<title>Polyaeni Strategematon Libri Octo</title>
+	<title xml:lang="lat">Strategemata</title>
 	<author>Polyaenus</author>
-<editor>Johannes Melbre</editor>
+	<editor>Johannes Melber</editor>
+	<editor>Eduard von Woelfflin</editor>
 	<funder>Harvard Library Arcadia Fund</funder>
 	<principal>Gregory Crane</principal>
 	<respStmt>
@@ -37,7 +37,7 @@
 </titleStmt>
 <publicationStmt>
 <authority>Harvard College Library</authority>
-	<idno type="filename">tlg0661.tlg001.1st1K-grc1.xml</idno>
+	<idno type="filename">tlg0616.tlg001.1st1K-grc1.xml</idno>
 <availability>
  <p>Available under a Creative Commons Attribution-ShareAlike 4.0 International
  License</p>
@@ -50,17 +50,22 @@
 <listBibl>
  <biblStruct>
  <monogr>
- 	<title>Polyaeni Strategematon Libri Octo</title>
+ 	<title xml:lang="lat">Polyaeni Strategematon Libri Octo</title>
   <editor>
 	<persName>
-		<name>Johannes Melbre</name>
+		<name>Johannes Melber</name>
 	</persName>
   </editor>
- 	<author ref="urn:cts:greekLit:tlg0661">Polyaenus</author>
+ 	<editor>
+ 		<persName>
+ 			<name>Eduard von Woelfflin</name>
+ 		</persName>
+ 	</editor>
+ 	<author ref="urn:cts:greekLit:tlg0616">Polyaenus</author>
   <imprint>
-	<publisher>Stuttgardt</publisher>
-	<pubPlace>Teubner</pubPlace>
-	<date>1920</date>
+	<publisher>Teubner</publisher>
+	<pubPlace>Leipzig</pubPlace>
+	<date>1887</date>
   </imprint>
  </monogr>
  	<ref target="https://archive.org/details/polyaenistratege00polyuoft">Internet Archive</ref>
@@ -87,7 +92,7 @@
 <text>
 	<body>
 		
-		<div type="edition" xml:lang="grc" n="urn:cts:greekLit:tlg0661.tlg001.1st1K-grc1">
+		<div type="edition" xml:lang="grc" n="urn:cts:greekLit:tlg0616.tlg001.1st1K-grc1">
 <head>ΠΟΛΥΑΙΝΟΥ ΣΤΡΑΤΗΓΙΚΑ.</head>
 <div type="textpart" subtype="book" n="1">
 	<div type="textpart" subtype="section" n="pref">

--- a/data/tlg0616/tlg002/__cts__.xml
+++ b/data/tlg0616/tlg002/__cts__.xml
@@ -1,0 +1,7 @@
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0616" xml:lang="grc" urn="urn:cts:greekLit:tlg0616.tlg002">
+  <ti:title xml:lang="lat">Excerpta Polyaeni</ti:title>
+  <ti:edition urn="urn:cts:greekLit:tlg0616.tlg002.1st1K-grc1" workUrn="urn:cts:greekLit:tlg0616.tlg002">
+    <ti:label xml:lang="lat">Excerpta Polyaeni</ti:label>
+    <ti:description xml:lang="mul">Polyaenus Macedo, Excerpta Polyaeni, Melber and Woelfflin, Teubner, 1887</ti:description>
+  </ti:edition>
+</ti:work>

--- a/data/tlg0616/tlg002/tlg0616.tlg002.1st1K-grc1.xml
+++ b/data/tlg0616/tlg002/tlg0616.tlg002.1st1K-grc1.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-<teiHeader>
-    
+<teiHeader xml:lang="eng">    
 <fileDesc>
 <titleStmt>
-	<title>Excerpta Polyaeni</title>
+	<title xml:lang="lat">Excerpta Polyaeni</title>
 	<author>Polyaenus</author>
-<editor>Johannes Melbre</editor>
+<editor>Johannes Melber</editor>
+	<editor>Eduard von Woelfflin</editor>
 	<funder>Harvard Library Arcadia Fund</funder>
 	<principal>Gregory Crane</principal>
 	<respStmt>
@@ -37,7 +37,7 @@
 </titleStmt>
 <publicationStmt>
 <authority>Harvard College Library</authority>
-	<idno type="filename">tlg0661.tlg002.1st1K-grc1.xml</idno>
+	<idno type="filename">tlg0616.tlg002.1st1K-grc1.xml</idno>
 <availability>
  <p>Available under a Creative Commons Attribution-ShareAlike 4.0 International
  License</p>
@@ -50,17 +50,22 @@
 <listBibl>
  <biblStruct>
  <monogr>
- 	<title>Polyaeni Strategematon Libri Octo</title>
-  <editor>
-	<persName>
-		<name>Johannes Melbre</name>
-	</persName>
-  </editor>
- 	<author ref="urn:cts:greekLit:tlg0661">Polyaenus</author>
+ 	<title xml:lang="lat">Polyaeni Strategematon Libri Octo</title>
+ 	<editor>
+ 		<persName>
+ 			<name>Johannes Melber</name>
+ 		</persName>
+ 	</editor>
+ 	<editor>
+ 		<persName>
+ 			<name>Eduard von Woelfflin</name>
+ 		</persName>
+ 	</editor>
+ 	<author ref="urn:cts:greekLit:tlg0616">Polyaenus</author>
   <imprint>
-	<publisher>Stuttgardt</publisher>
-	<pubPlace>Teubner</pubPlace>
-	<date>1920</date>
+	<publisher>Teubner</publisher>
+	<pubPlace>Leipzig</pubPlace>
+	<date>1887</date>
   </imprint>
  </monogr>
  	<ref target="https://archive.org/details/polyaenistratege00polyuoft">Internet Archive</ref>
@@ -85,7 +90,7 @@
 </teiHeader>
 <text>
 	<body>
-		<div type="edition" xml:lang="grc" n="urn:cts:greekLit:tlg0661.tlg002.1st1K-grc1">
+		<div type="edition" xml:lang="grc" n="urn:cts:greekLit:tlg0616.tlg002.1st1K-grc1">
 <div type="textpart" subtype="section" n="toc">
 <pb n="429"/>
 <head>Πίναξ ὑποθέσεων τῶν ἐκ τῶν στρατηγικῶν πράξεων.</head>

--- a/data/tlg0661/__cts__.xml
+++ b/data/tlg0661/__cts__.xml
@@ -1,3 +1,0 @@
-<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:greekLit:tlg0661">
-  <ti:groupname xml:lang="lat">Polyaenus Macedo</ti:groupname>
-</ti:textgroup>

--- a/data/tlg0661/tlg001/__cts__.xml
+++ b/data/tlg0661/tlg001/__cts__.xml
@@ -1,7 +1,0 @@
-<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0661" xml:lang="grc" urn="urn:cts:greekLit:tlg0661.tlg001">
-  <ti:title xml:lang="lat">Strategematon</ti:title>
-  <ti:edition urn="urn:cts:greekLit:tlg0661.tlg001.1st1K-grc1" workUrn="urn:cts:greekLit:tlg0661.tlg001">
-    <ti:label xml:lang="lat">Polyaeni Strategematon Libri Octo</ti:label>
-    <ti:description xml:lang="lat">Polyaenus Macedo, Strategematon, Woelfflin, Teubner, 1887</ti:description>
-  </ti:edition>
-</ti:work>

--- a/data/tlg0661/tlg002/__cts__.xml
+++ b/data/tlg0661/tlg002/__cts__.xml
@@ -1,7 +1,0 @@
-<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0661" xml:lang="grc" urn="urn:cts:greekLit:tlg0661.tlg002">
-  <ti:title xml:lang="lat">Excerpta Polyaeni</ti:title>
-  <ti:edition urn="urn:cts:greekLit:tlg0661.tlg002.1st1K-grc1" workUrn="urn:cts:greekLit:tlg0661.tlg002">
-    <ti:label xml:lang="lat">Excerpta Polyaeni</ti:label>
-    <ti:description xml:lang="lat">Polyaenus Macedo, Excerpta Polyaeni, Woelfflin, Teubner, 1887</ti:description>
-  </ti:edition>
-</ti:work>


### PR DESCRIPTION
Renumbered the text group from tlg0661 to tlg0616
Edited the various cts_.xml files
Added in language tagging and edited the bibliographic information in the XML files.

This pull request is attempt to resolve issue with Polyaenus identified here #984 
I hope I did this correctly @sonofmun 