### PR TITLE
tlg2703-some edits to Anna Comnena files

### DIFF
--- a/data/tlg2703/__cts__.xml
+++ b/data/tlg2703/__cts__.xml
@@ -1,3 +1,4 @@
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:greekLit:tlg2703">
   <ti:groupname xml:lang="eng">Anna Comnena</ti:groupname>
+  <ti:groupname xml:lang="lat">Anna Comnenae</ti:groupname>
 </ti:textgroup>

--- a/data/tlg2703/tlg001/__cts__.xml
+++ b/data/tlg2703/tlg001/__cts__.xml
@@ -2,10 +2,10 @@
   <ti:title xml:lang="lat">Alexias</ti:title>
   <ti:edition urn="urn:cts:greekLit:tlg2703.tlg001.opp-grc2" xml:lang="grc" workUrn="urn:cts:greekLit:tlg2703.tlg001">
     <ti:label xml:lang="lat">Alexias</ti:label>
-    <ti:description xml:lang="mul">Anna Comnena, Alexias, Scopenus, Weber, 1839</ti:description>
+    <ti:description xml:lang="mul">Anna Comnena, Alexias, Schopenus, Weber, 1839</ti:description>
   </ti:edition><ti:translation urn="urn:cts:greekLit:tlg2703.tlg001.opp-lat1" xml:lang="lat" workUrn="urn:cts:greekLit:tlg2703.tlg001">
     <ti:label xml:lang="eng">Alexias</ti:label>
-    <ti:description xml:lang="eng">Anna Comnena, Alexias, Scopenus, Weber, 1839</ti:description>
+    <ti:description xml:lang="eng">Anna Comnena, Alexias, Schopenus, Weber, 1839</ti:description>
   </ti:translation>
   <ti:edition urn="urn:cts:greekLit:tlg2703.tlg001.opp-grc1" xml:lang="grc" workUrn="urn:cts:greekLit:tlg2703.tlg001">
     <ti:label xml:lang="lat">Alexias</ti:label>

--- a/data/tlg2703/tlg001/__cts__.xml
+++ b/data/tlg2703/tlg001/__cts__.xml
@@ -5,7 +5,7 @@
     <ti:description xml:lang="mul">Anna Comnena, Alexias, Schopenus, Weber, 1839</ti:description>
   </ti:edition><ti:translation urn="urn:cts:greekLit:tlg2703.tlg001.opp-lat1" xml:lang="lat" workUrn="urn:cts:greekLit:tlg2703.tlg001">
     <ti:label xml:lang="eng">Alexias</ti:label>
-    <ti:description xml:lang="eng">Anna Comnena, Alexias, Schopenus, Weber, 1839</ti:description>
+    <ti:description xml:lang="mul">Anna Comnena, Alexias, Schopenus, Weber, 1839</ti:description>
   </ti:translation>
   <ti:edition urn="urn:cts:greekLit:tlg2703.tlg001.opp-grc1" xml:lang="grc" workUrn="urn:cts:greekLit:tlg2703.tlg001">
     <ti:label xml:lang="lat">Alexias</ti:label>

--- a/data/tlg2703/tlg001/tlg2703.tlg001.opp-grc1.xml
+++ b/data/tlg2703/tlg001/tlg2703.tlg001.opp-grc1.xml
@@ -56,7 +56,7 @@
 <p>Available under a Creative Commons Attribution-ShareAlike 4.0 International
 License</p>
 </availability>
-<date>2014</date>
+<date>2016</date>
 <publisher>University of Leipzig</publisher>
 <pubPlace>Germany</pubPlace>
 </publicationStmt>

--- a/data/tlg2703/tlg001/tlg2703.tlg001.opp-grc1.xml
+++ b/data/tlg2703/tlg001/tlg2703.tlg001.opp-grc1.xml
@@ -5,7 +5,7 @@
     <fileDesc>
 <titleStmt><title xml:lang="lat">Alexias</title>
   <author xml:lang="lat">Annae Comnenae</author>
-  <editor xml:lang="lat">Augustus Reifferscheidii</editor>
+  <editor>Augustus Reifferscheid</editor>
 <sponsor>University of Leipzig</sponsor>
 <funder>European Social Fund Saxony</funder>
 <principal>Gregory Crane</principal>
@@ -64,13 +64,14 @@ License</p>
 <listBibl>
 <biblStruct>
 <monogr>
-  <title xml:lang="lat">Annae Comnenae</title>
+  <title xml:lang="lat" type="m">Annae Comnenae</title>
+  <title xml:lang="lat" type="s">Porphyrogenitae Alexias</title>
 <editor>
 <persName>
   <name xml:lang="lat">Augustus Reifferscheidii</name>
 </persName>
 </editor>
-  <author ref="urn:cts:greekLit:tlg2703">Annae Comnenae</author>
+  <author ref="urn:cts:greekLit:tlg2703" xml:lang="lat">Annae Comnenae</author>
 <imprint>
 <publisher>Teubner</publisher>
 <pubPlace>Leipzig</pubPlace>

--- a/data/tlg2703/tlg001/tlg2703.tlg001.opp-grc2.xml
+++ b/data/tlg2703/tlg001/tlg2703.tlg001.opp-grc2.xml
@@ -5,7 +5,8 @@
     <fileDesc>
       <titleStmt><title xml:lang="lat">Alexias</title>
         <author>Anna Comnena</author>
-        <editor xml:lang="lat">Ludovicus Schopenus.</editor>
+        <editor>Ludwig Schopen</editor>
+        <editor>B.G. Niebuhr</editor>
         <sponsor>University of Leipzig</sponsor>
         <funder>European Social Fund Saxony</funder>
         <principal>Gregory Crane</principal>
@@ -64,10 +65,15 @@
         <listBibl>
           <biblStruct>
             <monogr>
-              <title xml:lang="lat">Corpus Scriptorum Historiae Byzantinae.</title>
+              <title xml:lang="lat">Annae Comnenae Alexiadis</title>
               <editor>
                 <persName>
-                  <name xml:lang="lat">Ludovicus Schopenus; B. G. Niebuhrii C.F.</name>
+                  <name xml:lang="lat">Ludovicus Schopenus</name>
+                </persName>
+              </editor>
+              <editor>
+                <persName>
+                  <name xml:lang="lat">B.G. Niebuhrii</name>
                 </persName>
               </editor>
               <author ref="urn:cts:greekLit:tlg2703">Anna Comnena</author>
@@ -78,6 +84,10 @@
               </imprint>
               <biblScope unit="volume">1</biblScope>
             </monogr>
+            <series>
+              <title xml:lang="lat" level="s">Corpus Scriptorum Historiae Byzantinae</title>
+              <biblScope unit="volume">38</biblScope>
+            </series>
             <ref target="https://archive.org/details/corpusscriptorum02niebuoft">Internet Archive</ref>
           </biblStruct>
         </listBibl>

--- a/data/tlg2703/tlg001/tlg2703.tlg001.opp-grc2.xml
+++ b/data/tlg2703/tlg001/tlg2703.tlg001.opp-grc2.xml
@@ -57,7 +57,7 @@
           <p>Available under a Creative Commons Attribution-ShareAlike 4.0 International
             License</p>
         </availability>
-        <date>2014</date>
+        <date>2016</date>
         <publisher>University of Leipzig</publisher>
         <pubPlace>Germany</pubPlace>
       </publicationStmt>

--- a/data/tlg2703/tlg001/tlg2703.tlg001.opp-lat1.xml
+++ b/data/tlg2703/tlg001/tlg2703.tlg001.opp-lat1.xml
@@ -57,7 +57,7 @@
 <p>Available under a Creative Commons Attribution-ShareAlike 4.0 International
 License</p>
 </availability>
-<date>2014</date>
+<date>2016</date>
 <publisher>University of Leipzig</publisher>
 <pubPlace>Germany</pubPlace>
 </publicationStmt>

--- a/data/tlg2703/tlg001/tlg2703.tlg001.opp-lat1.xml
+++ b/data/tlg2703/tlg001/tlg2703.tlg001.opp-lat1.xml
@@ -5,7 +5,8 @@
     <fileDesc>
       <titleStmt><title xml:lang="lat">Alexias</title>
         <author>Anna Comnena</author>
-        <editor xml:lang="lat">Ludovicus Schopenus.</editor>
+        <editor>Ludwig Schopen</editor>
+        <editor>B.G. Niebuhr</editor>
 <sponsor>University of Leipzig</sponsor>
 <funder>European Social Fund Saxony</funder>
 <principal>Gregory Crane</principal>
@@ -64,12 +65,17 @@ License</p>
 <listBibl>
 <biblStruct>
 <monogr>
-  <title xml:lang="lat">Corpus Scriptorum Historiae Byzantinae.</title>
+  <title xml:lang="lat">Annae Comnenae Alexiadis</title>
 <editor>
 <persName>
-  <name xml:lang="lat">Ludovicus Schopenus; B. G. Niebuhrii C.F.</name>
+  <name xml:lang="lat">Ludovicus Schopenus</name>
 </persName>
 </editor>
+  <editor>
+    <persName>
+      <name xml:lang="lat">B.G. Niebuhrii</name>
+    </persName>
+  </editor>
   <author ref="urn:cts:greekLit:tlg2703">Anna Comnena</author>
 <imprint>
 <publisher>Weber</publisher>
@@ -78,6 +84,10 @@ License</p>
 </imprint>
 <biblScope unit="volume">1</biblScope>
 </monogr>
+  <series>
+    <title xml:lang="lat" level="s">Corpus Scriptorum Historiae Byzantinae</title>
+    <biblScope unit="volume">38</biblScope>
+  </series>
   <ref target="https://archive.org/details/corpusscriptorum02niebuoft">Internet Archive</ref>
 </biblStruct>
 </listBibl>


### PR DESCRIPTION
tlg2703_cts_.xml
Added in a Latin group name as found one in the files

tlg2703/tlg001/_cts_.xml
Fixed a typo in the editor's name

tlg2703.tlg001.opp-grc1.xml
Added in an English version of the editors name as well

tlg2703.tlg001.opp-grc2.xml
tlg2703.tlg001.opp-lat1.xml

Added in English versions of editor names (kept Latin ones as well)
Added in series information and updated the edition title