### PR TITLE
Update tlg3156.tlg001._cts.xml

### DIFF
--- a/data/tlg3156/tlg001/__cts__.xml
+++ b/data/tlg3156/tlg001/__cts__.xml
@@ -1,9 +1,10 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg3156"
     xml:lang="grc" urn="urn:cts:greekLit:tlg3156.tlg001">
-    <ti:title xml:lang="deu">Glossen und Scholien zur hesiodischen Theogonie mit Prolegomena</ti:title>
+    <ti:title xml:lang="lat">Exegesis in Hesiodi theogoniam</ti:title>
     <ti:edition urn="urn:cts:greekLit:tlg3156.tlg001.1st1K-grc1"
         workUrn="urn:cts:greekLit:tlg3156.tlg001">
-        <ti:label xml:lang="deu">Glossen und Scholien zur hesiodischen Theogonie mit Prolegomena</ti:label>
-        <ti:description xml:lang="mul">Glossen und Scholien zur hesiodischen Theogonie mit Prolegomena, Anonymus, Flach, Teubner, 1876</ti:description>
+        <ti:label xml:lang="lat">Exegesis in Hesiodi theogoniam</ti:label>
+        <ti:description xml:lang="mul">Anonymus, Exegesis in Hesiodi theogoniam, Glossen und Scholien 
+            zur hesiodischen Theogonie mit Prolegomena, Flach, Teubner, 1876</ti:description>
     </ti:edition>
 </ti:work>


### PR DESCRIPTION
Deleted the German title here because it was the title of the edition within which this Greek work 
was only part, not a translated German title for the work itself. have instead entered the Latin title of the work as given in the TLG and in spreadsheet.