### PR TITLE
tlg5034.tlg001a.perseus-grc1.xml

### DIFF
--- a/data/tlg5034/tlg001a/tlg5034.tlg001a.perseus-grc1.xml
+++ b/data/tlg5034/tlg001a/tlg5034.tlg001a.perseus-grc1.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-    <teiHeader xml:lang="eng">
-    
+    <teiHeader xml:lang="eng">    
         <fileDesc>
             <titleStmt>
                 <title xml:lang="mul">Scholia in Pindarum Olympian Odes</title>
-
                 <author>Pindar Scholia</author>
                 <editor>A. B. Drachmann</editor>
                 <funder>A Google Digital Humanities Award</funder>
@@ -47,17 +45,16 @@
                         <analytic/>
                         <monogr>
                             <author>Scholia Pindar</author>
-                            <title xml:lang="mul">Scholia in Pindarum Olympian Odes</title>
+                            <title xml:lang="lat">Scholia in Olympionicas</title>
                             <editor>A. B. Drachmann</editor>
                             <imprint>
                                 <pubPlace>Leipzig</pubPlace>
                                 <publisher xml:lang="lat">B.G. Teubneri</publisher>
                                 <date>1903</date>
-                            </imprint>
-                            
+                            </imprint>                            
                         </monogr>
-                        <series><title level="s" xml:lang="lat">Scholia in Olympionicas</title><biblScope n="volume">1</biblScope></series>
-                        
+                        <series><title level="s" xml:lang="lat">Scholia Vetera in Pindari Carmina</title>
+                            <biblScope n="volume">1</biblScope></series>
                         <ref type="https://archive.org/details/scholiaveterain00dracgoog">Internet Archive</ref>
                     </biblStruct>
                 </listBibl>


### PR DESCRIPTION
Edited the bibliographic information slightly
Changed the titles of the series and work title in the edition info to reflect how all of the other editions have been done, namely the edition title is typically used in the the <mongr> section, so I changed it from the work title, which had been listed twice.

I then changed the series title to reflect the title of the actual  series, which in this case, is Scholia Vetera in Pindari Carmina.