### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_deploy:
   - git commit -m "Removed failing files" -m "Release $GIT_TAG"
   - git tag $GIT_TAG -a -m "$DATE" -m "PASSING FILES" -m "$results"
   - git push -q https://$GITPERM@github.com/OpenGreekAndLatin/First1KGreek --tags
-  - ls -R
 
 deploy:
   provider: releases


### PR DESCRIPTION
Removed the `ls -R` command. It is not necessary and produces log files that are too long for Travis.