### PR TITLE
Correcting Name of tlg0541 textgroup 

### DIFF
--- a/data/tlg0541/__cts__.xml
+++ b/data/tlg0541/__cts__.xml
@@ -1,3 +1,3 @@
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:greekLit:tlg0541">
-  <ti:groupname xml:lang="eng">pseudo-Menander</ti:groupname>
+  <ti:groupname xml:lang="eng">Menander</ti:groupname>
 </ti:textgroup>


### PR DESCRIPTION
I have updated this to Menander, since pseudo-Menander is only affiliated with this one work in the repository (tlg0541.tlg042) and tlg0541 is used for all the plays of Menander (pseudo or otherwise it appears).