### PR TITLE
tlg0086.tlg001.1st1K-grc1.xml-incorrect_reference_target

### DIFF
--- a/data/tlg0086/tlg001/tlg0086.tlg001.1st1K-grc1.xml
+++ b/data/tlg0086/tlg001/tlg0086.tlg001.1st1K-grc1.xml
@@ -66,7 +66,7 @@
 							<date>1837</date>
 						</imprint>
 					</monogr>
-					<ref target="https://catalog.hathitrust.org/Record/0012225470">HathiTrust</ref>
+					<ref target="https://hdl.handle.net/2027/mdp.39015027645400?urlappend=%3Bseq=70">HathiTrust</ref>
 				</biblStruct>
 			</sourceDesc>
 		</fileDesc>


### PR DESCRIPTION
Adding in a correct reference target in the HathiTrust, couldn't find in the Internet Archive.