### PR TITLE
Adding explicit Zenodo metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,52 @@
+{
+    "description": "XML files for the works in the First Thousand Years of Greek Project.", 
+    "license": "CC-BY-SA-4.0", 
+    "title": "First1kGreek", 
+    "creators": [
+        {
+            "affiliation": "Open Greek And Latin Steering Committee", 
+            "name": "Gregory R. Crane"
+        }, 
+        {
+            "affiliation": "Open Greek And Latin Steering Committee",
+            "name": "Leonard Muellner"
+        }, 
+        {
+            "affiliation": "Open Greek And Latin Steering Committee",
+            "name": "Bruce Robertson"
+        },
+        {
+            "affiliation": "Open Greek And Latin Steering Committee", 
+            "name": "Alison Babeu"
+        },
+        {
+            "affiliation": "Open Greek And Latin Steering Committee", 
+            "name": "Lisa Cerrato"
+        },
+        {
+            "affiliation": "Open Greek And Latin Steering Committee", 
+            "orcid": "0000-0002-9425-5850", 
+            "name": "Thomas Koentges"
+        }, 
+        {
+            "affiliation": "Open Greek And Latin Steering Committee", 
+            "name": "Rhea Lesage"
+        },
+        {
+            "affiliation": "Open Greek And Latin Steering Committee", 
+            "name": "Lucie Stylianopoulos"
+        },
+        {
+            "affiliation": "Open Greek And Latin Steering Committee", 
+            "name": "James Tauber"
+        }
+    ], 
+    "access_right": "open", 
+    "related_identifiers": [
+        {
+            "scheme": "doi", 
+            "identifier": "10.5281/zenodo.596723", 
+            "relation": "isVersionOf"
+        }
+    ]
+}


### PR DESCRIPTION
In order to be consistently cited, the OGL steering committee decided on those editors of the repository. Older contributions are still available via Github and represented in older Zenodo versions.