### PR TITLE
Add Scaife Viewer config file

### DIFF
--- a/.scaife-viewer.yml
+++ b/.scaife-viewer.yml
@@ -1,0 +1,549 @@
+attributions:
+  promoted:
+  - Publisher
+  - Additional proofreading and CTS conversion
+  - annotation
+  - Corrected and encoded the text
+  - CTS conversion
+  - Keyboarding
+  - proofreader
+  - Proofreading
+  - Proofreading and CTS conversion
+  - source
+  - Zoning and proofreading
+  substitutions:
+  - data:
+    - organization:
+        name: Open Greek and Latin
+      person:
+        name: Gregory Crane
+      role: Published original versions of the electronic texts
+    - organization:
+        name: Open Greek and Latin
+      person:
+        name: Leonard Muellner
+      role: Published original versions of the electronic texts
+    - organization:
+        name: Open Greek and Latin
+      person:
+        name: Bruce Robertson
+      role: Published original versions of the electronic texts
+    match:
+      names:
+      - Gregory Crane
+      - Leonard Muellner
+      - Bruce Robertson
+      orgs:
+      - Open Greek and Latin
+      role: Published original versions of the electronic texts
+  - data:
+    - organization:
+        name: Harvard University
+      person:
+        name: Mark Schiefsky
+      role: Published original versions of the electronic texts
+    - organization:
+        name: Universität Leipzig
+      person:
+        name: Gregory R. Crane
+      role: Published original versions of the electronic texts
+    - organization:
+        name: University of Warwick
+      person:
+        name: Uwe Vagelpohl
+      role: Published original versions of the electronic texts
+    match:
+      names:
+      - Mark Schiefsky, Harvard University
+      - Gregory R. Crane, Universität Leipzig
+      - Uwe Vagelpohl, University of Warwick
+      orgs:
+      - A Digital Corpus for Graeco-Arabic Studies, funded by the Andrew W. Mellon
+        Foundation
+      role: Published original versions of the electronic texts
+  - data:
+    - organization: {}
+      person:
+        name: Gregory R. Crane
+      role: Editor-in-Chief, Perseus Digital Library
+    match:
+      names:
+      - Gregory Crane
+      orgs: []
+      role: Editor-in-Chief, Perseus Digital Library
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Matt Munson
+      role: Project Manager
+    match:
+      names:
+      - Matt Munson
+      orgs: []
+      role: Project Manager (University of Leipzig)
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Annette Geßner
+      role: Project Assistant
+    match:
+      names:
+      - Annette Gessner
+      orgs: []
+      role: Project Assistant (University of Leipzig)
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Thibault Clérice
+      role: Lead Developer
+    match:
+      names:
+      - Thibault Clérice
+      orgs: []
+      role: Lead Developer (University of Leipzig) 2015 - 2017
+  - data:
+    - organization:
+        name: Mount Allison University
+      person:
+        name: Bruce Robertson
+      role: Technical Advisor
+    match:
+      names:
+      - Bruce Robertson
+      orgs: []
+      role: Technical Advisor
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Thibault Clérice
+      role: Lead Developer
+    match:
+      names:
+      - Thibault Clérice
+      orgs: []
+      role: Lead Developer (University of Leipzig)
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Annette Geßner
+      role: Project Assistant
+    match:
+      names:
+      - Annette Geßner
+      orgs: []
+      role: Project Assistant (University of Leipzig)
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Greta Franzini
+      role: Project Manager
+    match:
+      names:
+      - Greta Franzini
+      orgs: []
+      role: Project Manager (University of Leipzig), 2013-2014
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Frederik Baumgardt
+      role: Technical Manager
+    match:
+      names:
+      - Frederik Baumgardt
+      orgs: []
+      role: Technical Manager (University of Leipzig), 2013-2015
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Simona Stoyanova
+      role: Project Manager
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Simona Stoyanova
+      role: Project Assistant
+    match:
+      names:
+      - Simona Stoyanova
+      orgs: []
+      role: 'Project Manager (University of Leipzig), 2015
+
+        Project Assistant (University of Leipzig), 2013-2014'
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Annette Geßner
+      role: Project Assistant
+    match:
+      names:
+      - Annette Gessner
+      orgs: []
+      role: Project Assistant (University of Leipzig) 2015 - 2017
+  - data:
+    - organization: {}
+      person:
+        name: Gregory R. Crane
+      role: Prepared under the supervision of
+    match:
+      names: []
+      orgs: []
+      role: Prepared under the supervision of
+  - data:
+    - organization:
+        name: Perseus Digital Library
+      person: {}
+      role: Keyboarding
+    match:
+      names: []
+      orgs:
+      - Perseus Project
+      role: Keyboarding
+  - data:
+    - organization:
+        name: University of Virginia
+      person:
+        name: Rebecca Draughon
+      role: Digital conversion and editing
+    match:
+      names:
+      - Rebecca Draughon
+      orgs:
+      - University of Virigina
+      role: Zoning and proofreading
+  - data:
+    - organization: {}
+      person:
+        name: Caroline T. Schroeder
+      role: Annotation
+    - organization: {}
+      person:
+        name: Amir Zeldes
+      role: Annotation
+    match:
+      names: []
+      orgs: []
+      role: annotation
+  - data:
+    - organization: {}
+      person:
+        name: David Brakke
+      role: source
+    - organization: {}
+      person:
+        name: Hany Takla
+      role: source
+    - organization: {}
+      person:
+        name: J Warren Wells
+      role: source
+    match:
+      names: []
+      orgs: []
+      role: source
+  - data:
+    - organization: {}
+      person:
+        name: Rhea Lesage
+      role: Librarian for Hellenic Studies and Coordinator for the Classics Collection
+        Development
+    match:
+      names:
+      - RHEA LESAGE
+      orgs: []
+      role: Librarian for Hellenic Studies and Coordinator for the Classics Collection
+        Development
+  - data:
+    - organization:
+        name: Center for Hellenic Studies
+      person:
+        name: Michael Konieczny
+      role: Digital Editor
+    match:
+      names:
+      - Michael Konieczny
+      orgs: []
+      role: Proofreading and CTS conversion
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Matt Munson
+      role: Project Manager
+    match:
+      names:
+      - Matt Munson
+      orgs: []
+      role: Project Manager (University of Leipzig), 2016 - 2018
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Annette Gessner
+      role: Project Assistant
+    match:
+      names:
+      - Annette Gessner
+      orgs: []
+      role: Project Assistant (University of Leipzig), 2015 - 2017
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Thibault Clérice
+      role: Lead Developer
+    match:
+      names:
+      - Thibault Clérice
+      orgs: []
+      role: Lead Developer (University of Leipzig), 2015 - 2017
+  - data:
+    - organization:
+        name: Mount Allison University
+      person:
+        name: Kirsten Mason
+      role: Digital conversion and editing
+    match:
+      names:
+      - Kirsten Mason
+      orgs:
+      - Mt. Allison University
+      role: Proofreading
+  - data:
+    - organization:
+        name: University of Virginia
+      person:
+        name: Ann Burns
+      role: Digital conversion and editing
+    match:
+      names:
+      - Ann Burns University of Virginia
+      orgs: []
+      role: Proofreading
+  - data:
+    - organization:
+        name: Mount Allison University
+      person:
+        name: Bruce Robertson
+      role: Technical Advisor
+    match:
+      names:
+      - Bruce Robertson
+      orgs: []
+      role: Technical Advisor (Mount Allison University)
+  - data:
+    - organization:
+        name: Mount Allison University
+      person:
+        name: Janan Assaly
+      role: Digital conversion and editing
+    match:
+      names:
+      - Janan Assaly
+      orgs:
+      - Mt. Allison University
+      role: Proofreading
+  - data:
+    - organization:
+        name: Mount Allison University
+      person:
+        name: Janan Assaly
+      role: Digital conversion and editing
+    match:
+      names:
+      - Janan Assaly
+      orgs:
+      - Center for Hellenic Studies
+      role: Proofreading
+  - data:
+    - organization:
+        name: Mount Allison University
+      person:
+        name: Madeline McIntire
+      role: Digital conversion and editing
+    - organization:
+        name: Center for Hellenic Studies
+      person:
+        name: Michael Konieczny
+      role: Digital Editor
+    match:
+      names:
+      - Madeline McIntire
+      - Michael Konieczny
+      orgs: []
+      role: Proofreading and CTS conversion
+  - data:
+    - organization:
+        name: Mount Allison University
+      person:
+        name: Madeline McIntire
+      role: Digital conversion and editing
+    match:
+      names:
+      - Madeline McIntire
+      orgs: []
+      role: Proofreading and CTS conversion
+  - data:
+    - organization:
+        name: Center for Hellenic Studies
+      person:
+        name: Lia Hanhardt
+      role: Digital conversion and editing
+    match:
+      names:
+      - Hanhardt Lia
+      orgs: []
+      role: Proofreading
+  - data:
+    - organization:
+        name: Center for Hellenic Studies
+      person:
+        name: Lia Hanhardt
+      role: Digital conversion and editing
+    match:
+      names:
+      - Lia Hanhardt
+      orgs: []
+      role: proofreader
+  - data:
+    - organization:
+        name: Center for Hellenic Studies
+      person:
+        name: Lia Hanhardt
+      role: Digital conversion and editing
+    match:
+      names:
+      - Hanhardt Lia
+      orgs: []
+      role: proofreader
+  - data:
+    - organization:
+        name: Center for Hellenic Studies
+      person:
+        name: Lia Hanhardt
+      role: Digital conversion and editing
+    match:
+      names:
+      - Lia Hanhardt
+      orgs: []
+      role: Proofreading
+  - data:
+    - organization:
+        name: Mount Allison University
+      person:
+        name: Dawson Fraser
+      role: Digital conversion and editing
+    match:
+      names:
+      - Dawson Fraser
+      orgs:
+      - Mt. Allison University
+      role: Proofreading
+  - data:
+    - organization:
+        name: Mount Allison University
+      person:
+        name: Madeline McIntire
+      role: Digital conversion and editing
+    match:
+      names:
+      - Madeline McIntire
+      orgs:
+      - Mt. Allison University
+      role: Proofreading
+  - data:
+    - organization:
+        name: Mount Allison University
+      person:
+        name: Madeline McIntire
+      role: Digital conversion and editing
+    match:
+      names:
+      - Madeline McIntire
+      orgs: []
+      role: Proofreading
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Thibault Clérice
+      role: Lead Developer
+    match:
+      names:
+      - Thibault Clérice
+      orgs: []
+      role: Lead Developer (University of Leipzig) 2015-2017
+  - data:
+    - organization:
+        name: University of Virginia
+      person:
+        name: Jeannie Sellick
+      role: Digital conversion and editing
+    match:
+      names:
+      - Jeannie Sellick
+      orgs: []
+      role: Proofreading and CTS conversion
+  - data:
+    - organization:
+        name: University of Virginia
+      person:
+        name: Ann Burns
+      role: Digital conversion and editing
+    match:
+      names:
+      - Ann Burns
+      orgs: []
+      role: Proofreader
+  - data:
+    - organization:
+        name: Mount Allison University
+      person:
+        name: Kirsten Mason
+      role: Digital conversion and editing
+    match:
+      names:
+      - Kirsten Mason
+      orgs: []
+      role: proofreader
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Thibault Clérice
+      role: Lead Developer
+    match:
+      names:
+      - Thibault Clérice
+      orgs: []
+      role: Lead Developer (University of Leipzig) , 2015- 2017
+  - data:
+    - organization:
+        name: University of Leipzig
+      person:
+        name: Thibault Clérice
+      role: Lead Developer
+    match:
+      names:
+      - Thibault Clérice
+      orgs: []
+      role: Lead Developer (University of Leipzig) , 2015 - 2017
+  - data:
+    - organization:
+        name: University of Virginia
+      person:
+        name: Rebecca Frank
+      role: Digital conversion and editing
+    match:
+      names:
+      - Rebecca Frank
+      orgs: []
+      role: Proofreading and CTS conversion


### PR DESCRIPTION
Used to map attribution information from https://docs.google.com/spreadsheets/d/1hn5BrO7vEGugon_G5_AAahNfwSaWyG_V5usxz6GRrL0/edit#gid=522035422

When we extract attribution data from this repository for display on scaife.perseus.org:
- The `publisher` is extracted from `publicationStmt`
- Each additional `respStmt` is extracted, ending up with an attribution record with a person, organization or person + organization, and a role
- Scaife Viewer preserves the order of each `respStmt` as listed in the file.

The config file performs overrides as follows:

- `attributions.substitutions` allows us to map the spreadsheet corrections on top of the original files. If / when edits to the original files are made to update the headers, the mapping won't find a match, and we'll rely directly on the file.
- `attributions.promoted` lists `resp` values that should be sorted to the top of the attributions list for a given file (e.g. "Publisher" or "Proofreader")
