### PR TITLE
(tlg0627)-tlg0627.tlg016-updated metadata

### DIFF
--- a/data/tlg0627/tlg016/tlg0627.tlg016.1st1K-grc1.xml
+++ b/data/tlg0627/tlg016/tlg0627.tlg016.1st1K-grc1.xml
@@ -63,11 +63,14 @@
                             <pubPlace>Paris</pubPlace>
                             <biblScope unit="volume">5</biblScope>
                             <biblScope unit="pp" from="510" to="572">510-572</biblScope>
+                            <biblScope unit="volume">9</biblScope>
+                            <biblScope unit="pp" from="6" to="74">6-74</biblScope>
                             <date>1846</date>
                         </imprint>
                     </monogr>
-                    <ref target="https://hdl.handle.net/2027/ucm.5321352158?urlappend=%3Bseq=518">HathiTrust</ref>
-                </biblStruct>
+                    <ref target="https://hdl.handle.net/2027/ucm.5321352158?urlappend=%3Bseq=518">HathiTrust</ref><!-- Volume 5 -->
+                    <ref target="https://hdl.handle.net/2027/pst.000022913487?urlappend=%3Bseq=17">HathiTrust</ref><!--Volume 9  -->           
+                    </biblStruct>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>


### PR DESCRIPTION
Updated the bibliographic description and added a link upon discovering this work is in two different volumes. The work itself in the XML file is complete but I wanted the metadata to reflect this as well.