### PR TITLE
(tlg0555)_all files

### DIFF
--- a/data/tlg0555/tlg001/__cts__.xml
+++ b/data/tlg0555/tlg001/__cts__.xml
@@ -1,6 +1,6 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0555" xml:lang="grc" urn="urn:cts:greekLit:tlg0555.tlg001">
   <ti:title xml:lang="lat">Protrepticus</ti:title>
-  <ti:edition urn="urn:cts:greekLit:tlg0555.tlg001.opp-grc1" workUrn="urn:cts:greekLit:tlg0555.tlg001">
+  <ti:edition urn="urn:cts:greekLit:tlg0555.tlg001.1st1K-grc1" workUrn="urn:cts:greekLit:tlg0555.tlg001">
     <ti:label xml:lang="lat">Protrepticus</ti:label>
     <ti:description xml:lang="mul">Clement of Alexandria. Clemens Alexandrinus, Volume 1: Protepticus und Paedagogus.
       Stählin, Otto, editor. Leipzig: Hinrichs, 1905</ti:description>

--- a/data/tlg0555/tlg001/tlg0555.tlg001.1st1K-grc1.xml
+++ b/data/tlg0555/tlg001/tlg0555.tlg001.1st1K-grc1.xml
@@ -28,7 +28,7 @@
             <title xml:lang="lat" level="s" >Clemens Alexandrinus</title>
             <biblScope unit="volume">Volume 1</biblScope>
            </series>
-           <ref target="http://www.archive.org/details/clemensalexandri01clemuoft">Internet Archive</ref>
+           <ref target="https://archive.org/details/clemensalexandri01clemuoft/page/2/mode/2up">Internet Archive</ref>
           </biblStruct>
         </sourceDesc>
     </fileDesc>
@@ -49,7 +49,7 @@
 </teiHeader>
 
 
- <text><body> <div type="edition" n="urn:cts:greekLit:tlg0555.tlg001.opp-grc1" xml:lang="grc">
+ <text><body> <div type="edition" n="urn:cts:greekLit:tlg0555.tlg001.1st1K-grc1" xml:lang="grc">
 <pb n="v.3.p.3"/>
 <head>ΠΡΟΤΡΕΠΤΙΚΟΣ ΠΡΟΣ ΕΛΛΗΝΑΣ</head>
 <milestone unit="section" n="1"/><div type="textpart" subtype="chapter" n="1"><p>Ἀμφίων ὁ Θηβαῖος καὶ Ἀρίων ὁ Μηθυμναῖος ἄμφω μὲν ἤστην 

--- a/data/tlg0555/tlg002/tlg0555.tlg002.opp-grc1.xml
+++ b/data/tlg0555/tlg002/tlg0555.tlg002.opp-grc1.xml
@@ -30,7 +30,7 @@
 						<title xml:lang="lat" level="s">Clemens Alexandrinus</title>
 						<biblScope unit="volume">Volume 1</biblScope>
 					</series>
-					<ref target="https://archive.org/details/clemensalexandri01clemuoft">Internet
+					<ref target="https://archive.org/details/clemensalexandri01clemuoft/page/86/mode/2up">Internet
 						Archive</ref>
 				</biblStruct>
 			</sourceDesc>

--- a/data/tlg0555/tlg004/__cts__.xml
+++ b/data/tlg0555/tlg004/__cts__.xml
@@ -1,0 +1,8 @@
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0555" xml:lang="grc" urn="urn:cts:greekLit:tlg0555.tlg004">
+  <ti:title xml:lang="lat">Stromateis</ti:title>
+  <ti:edition urn="urn:cts:greekLit:tlg0555.tlg004.opp-grc1" workUrn="urn:cts:greekLit:tlg0555.tlg004">
+    <ti:label xml:lang="lat">Stromata. Books 7-8.</ti:label>
+    <ti:description xml:lang="mul">Clement of Alexandria.  Clemens Alexandrinus, Volume 3: Stromata, Buch VII-VIII, Excerpta ex Theodoto, Eclogae
+      prophetica. Stählin, Otto, editor. Leipzig: Hinrichs, 1909.</ti:description>
+  </ti:edition>
+</ti:work>

--- a/data/tlg0555/tlg004/tlg0555.tlg004.opp-grc1.xml
+++ b/data/tlg0555/tlg004/tlg0555.tlg004.opp-grc1.xml
@@ -4,7 +4,7 @@
 	<teiHeader xml:lang="eng">    
 		<fileDesc>
 			<titleStmt>
-				<title xml:lang="lat">Stromata</title>
+				<title xml:lang="mul">Stromata. Book 7-8.</title>
 				<author>Clement of Alexandria</author>
 				<editor>Otto Stählin</editor>
 			</titleStmt>
@@ -31,7 +31,7 @@
 						</title>
 						<biblScope unit="volume">3</biblScope>
 					</series>									
-					<ref target="https://archive.org/details/clemensalexandri17clemuoft">Internet
+					<ref target="https://archive.org/details/clemensalexandri17clemuoft/page/2/mode/2up">Internet
 						Archive</ref>
 				</biblStruct>
 			</sourceDesc>
@@ -52,7 +52,7 @@
 
 	<text>
 		<body>
-			<div type="edition" n="urn:cts:greekLit:tlg0555.tlg004b.opp-grc1" xml:lang="grc">
+			<div type="edition" n="urn:cts:greekLit:tlg0555.tlg004.opp-grc1" xml:lang="grc">
 				<pb n="3"/>
 				<div type="textpart" subtype="book" n="7">
 					<milestone unit="section" n="1"/>

--- a/data/tlg0555/tlg004b/__cts__.xml
+++ b/data/tlg0555/tlg004b/__cts__.xml
@@ -1,7 +1,0 @@
-<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0555" xml:lang="grc" urn="urn:cts:greekLit:tlg0555.tlg004b">
-  <ti:title xml:lang="lat">Stromata Books 7-8</ti:title>
-  <ti:edition urn="urn:cts:greekLit:tlg0555.tlg004b.opp-grc1" workUrn="urn:cts:greekLit:tlg0555.tlg004b">
-    <ti:label xml:lang="lat">Stromata Books 7-8</ti:label>
-    <ti:description xml:lang="mul">Clement of Alexandria.  Clemens Alexandrinus, Volume 3. Stählin, Otto, editor. Leipzig: Hinrichs, 1909.</ti:description>
-  </ti:edition>
-</ti:work>

--- a/data/tlg0555/tlg005/__cts__.xml
+++ b/data/tlg0555/tlg005/__cts__.xml
@@ -2,6 +2,7 @@
   <ti:title xml:lang="lat">Eclogae propheticae</ti:title>
   <ti:edition urn="urn:cts:greekLit:tlg0555.tlg005.opp-grc1" workUrn="urn:cts:greekLit:tlg0555.tlg005">
     <ti:label xml:lang="lat">Eclogae propheticae</ti:label>
-    <ti:description xml:lang="mul">Clement of Alexandria.  Clemens Alexandrinus, Volume 3. Stählin, Otto, editor. Leipzig: Hinrichs, 1909.</ti:description>
+    <ti:description xml:lang="mul">Clement of Alexandria.  Clemens Alexandrinus, Volume 3: Stromata, Buch VII-VIII, Excerpta ex Theodoto, Eclogae
+      prophetica. Stählin, Otto, editor. Leipzig: Hinrichs, 1909.</ti:description>
   </ti:edition>
 </ti:work>

--- a/data/tlg0555/tlg005/tlg0555.tlg005.opp-grc1.xml
+++ b/data/tlg0555/tlg005/tlg0555.tlg005.opp-grc1.xml
@@ -31,7 +31,7 @@
 						</title>
 						<biblScope unit="volume">3</biblScope>
 					</series>			
-					<ref target="https://archive.org/details/clemensalexandri17clemuoft">Internet
+					<ref target="https://archive.org/details/clemensalexandri17clemuoft/page/134/mode/2up">Internet
 						Archive</ref>
 				</biblStruct>
 			</sourceDesc>

--- a/data/tlg0555/tlg006/__cts__.xml
+++ b/data/tlg0555/tlg006/__cts__.xml
@@ -1,7 +1,8 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0555" xml:lang="grc" urn="urn:cts:greekLit:tlg0555.tlg006">
   <ti:title xml:lang="lat">Quis dives salvetur</ti:title>
-  <ti:edition urn="urn:cts:greekLit:tlg0555.tlg006.opp-grc1" workUrn="urn:cts:greekLit:tlg0555.tlg006">
+  <ti:edition urn="urn:cts:greekLit:tlg0555.tlg006.1st1K-grc1" workUrn="urn:cts:greekLit:tlg0555.tlg006">
     <ti:label xml:lang="lat">Quis dives salvetur</ti:label>
-    <ti:description xml:lang="lat">Clement of Alexandria.  Clemens Alexandrinus, Volume 3. Stählin, Otto, editor. Leipzig: Hinrichs, 1909.</ti:description>
+    <ti:description xml:lang="mul">Clement of Alexandria.  Clemens Alexandrinus, Volume 3: Stromata, Buch VII-VIII, Excerpta ex Theodoto, Eclogae
+      prophetica. Stählin, Otto, editor. Leipzig: Hinrichs, 1909.</ti:description>
   </ti:edition>
 </ti:work>

--- a/data/tlg0555/tlg006/tlg0555.tlg006.1st1K-grc1.xml
+++ b/data/tlg0555/tlg006/tlg0555.tlg006.1st1K-grc1.xml
@@ -31,7 +31,7 @@
 						</title>
 						<biblScope unit="volume">3</biblScope>
 					</series>			
-					<ref target="https://archive.org/details/clemensalexandri17clemuoft">Internet
+					<ref target="https://archive.org/details/clemensalexandri17clemuoft/page/156/mode/2up">Internet
 						Archive</ref>
 				</biblStruct>
 			</sourceDesc>
@@ -54,7 +54,7 @@
 
 	<text>
 		<body>
-			<div type="edition" n="urn:cts:greekLit:tlg0555.tlg006.opp-grc1" xml:lang="grc">
+			<div type="edition" n="urn:cts:greekLit:tlg0555.tlg006.1st1K-grc1" xml:lang="grc">
 				<pb n="156"/>
 
 				<pb ed="alt" n="935 P"/>

--- a/data/tlg0555/tlg007/__cts__.xml
+++ b/data/tlg0555/tlg007/__cts__.xml
@@ -2,6 +2,7 @@
   <ti:title xml:lang="lat">Excerpta ex Theodoto</ti:title>
   <ti:edition urn="urn:cts:greekLit:tlg0555.tlg007.opp-grc1" workUrn="urn:cts:greekLit:tlg0555.tlg007">
     <ti:label xml:lang="lat">Excerpta ex Theodoto</ti:label>
-    <ti:description xml:lang="mul">Clement of Alexandria.  Clemens Alexandrinus, Volume 3. Stählin, Otto, editor. Leipzig: Hinrichs, 1909.</ti:description>
+    <ti:description xml:lang="mul">Clement of Alexandria.  Clemens Alexandrinus, Volume 3: Stromata, Buch VII-VIII, Excerpta ex Theodoto, Eclogae
+      prophetica. Stählin, Otto, editor. Leipzig: Hinrichs, 1909.</ti:description>
   </ti:edition>
 </ti:work>

--- a/data/tlg0555/tlg007/tlg0555.tlg007.opp-grc1.xml
+++ b/data/tlg0555/tlg007/tlg0555.tlg007.opp-grc1.xml
@@ -31,7 +31,7 @@
 						</title>
 						<biblScope unit="volume">3</biblScope>
 					</series>
-					<ref target="https://archive.org/details/clemensalexandri17clemuoft">Internet
+					<ref target="https://archive.org/details/clemensalexandri17clemuoft/page/102/mode/2up">Internet
 						Archive</ref>
 				</biblStruct>
 			</sourceDesc>


### PR DESCRIPTION
Updated all cts_.xml files and added in page level links to TEI-XML files.

Changed several URNs in the cts_.xml files and the TEI-XML files.
tlg0555.tlg001.opp-grc1 and tlg0555.006.opp-grc1 were changed to 1st1K URNs because there are already OPP URNs in the Perseus Catalog for these work.

Updated tlg0555.tlg004b to tlg0555.tlg004 because this is just part of the work (books 7-8) not a different work. Letters after work numbers have previously been used to indicate different works not parts of a work. The rest of this work is currently in Trello.