### PR TITLE
tlg0609_tlg1763

### DIFF
--- a/data/tlg0609/tlg001/__cts__.xml
+++ b/data/tlg0609/tlg001/__cts__.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0609"
 	projid="greekLit:tlg001" urn="urn:cts:greekLit:tlg0609.tlg001" xml:lang="grc">
-	<ti:title xml:lang="lat">De tropis</ti:title>
-	<ti:title xml:lang="eng">On tropes</ti:title>
-	
+	<ti:title xml:lang="lat">De tropis</ti:title>	
 	<ti:edition urn="urn:cts:greekLit:tlg0609.tlg001.1st1K-grc1"
 		workUrn="urn:cts:greekLit:tlg0609.tlg001" xml:lang="grc">
 		<ti:label xml:lang="grc">Περὶ τρόπων</ti:label>
 		<ti:description xml:lang="mul">Rhetores Graeci, Vol. IΙI. Spengel, Leonhard von, editor.
-			Leipzig: Teubner. 1856.</ti:description>
+			Leipzig: Teubner, 1856.</ti:description>
 	</ti:edition>
 	
 </ti:work>

--- a/data/tlg1763/tlg001/__cts__.xml
+++ b/data/tlg1763/tlg001/__cts__.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg1763" projid="greekLit:tlg001" urn="urn:cts:greekLit:tlg1763.tlg001" xml:lang="grc">
     <ti:title xml:lang="lat">De tropis (olim sub auctore Gregorio Corintho)</ti:title>
-    <ti:title xml:lang="eng">On tropes (formerly attributed to Gregory of Corinth)</ti:title>
-
     <ti:edition urn="urn:cts:greekLit:tlg1763.tlg001.1st1K-grc1" workUrn="urn:cts:greekLit:tlg1763.tlg001" xml:lang="grc">
         <ti:label xml:lang="grc">Γρηγορίου τοῦ Κορινθίου περὶ τρόπων</ti:label>
         <ti:description xml:lang="mul">Rhetores Graeci, Vol. IΙI. Spengel, Leonhard von, editor. Leipzig: Teubner, 1856.</ti:description>


### PR DESCRIPTION
A tale of two Tryphons.
I deleted the English titles because the viewer kept defaulting to them and there are no translated
titles used in this edition, so typically I believe we only used translated titles found in an edition
itself.
Also fixed one typo.