### PR TITLE
tlg0099.tlg001_to_tlg004

### DIFF
--- a/data/tlg0099/tlg001/__cts__.xml
+++ b/data/tlg0099/tlg001/__cts__.xml
@@ -1,7 +1,0 @@
-<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0099" xml:lang="grc" urn="urn:cts:greekLit:tlg0099.tlg001">
-  <ti:title xml:lang="lat">Geographiae Chrestomathia</ti:title>
-  <ti:edition urn="urn:cts:greekLit:tlg0099.tlg001.1st1K-grc1" workUrn="urn:cts:greekLit:tlg0099.tlg001">
-    <ti:label xml:lang="lat">Geographiae Chrestomathia</ti:label>
-    <ti:description xml:lang="mul">Anonymous, author; Geographi graeci minores Volumen Secundum, ed. Karl Müller; Ambroise Firmin Didot, Paris, 1861</ti:description>
-  </ti:edition>
-</ti:work>

--- a/data/tlg0099/tlg004/__cts__.xml
+++ b/data/tlg0099/tlg004/__cts__.xml
@@ -1,0 +1,7 @@
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0099" xml:lang="grc" urn="urn:cts:greekLit:tlg0099.tlg004">
+  <ti:title xml:lang="lat">Geographiae Chrestomathia</ti:title>
+  <ti:edition urn="urn:cts:greekLit:tlg0099.tlg004.1st1K-grc1" workUrn="urn:cts:greekLit:tlg0099.tlg004">
+    <ti:label xml:lang="lat">Geographiae Chrestomathia</ti:label>
+    <ti:description xml:lang="mul">Anonymous. Geographi graeci minores, Volume 2. Müller, Karl, editor. Paris: Ambroise Firmin Didot, 1861.</ti:description>
+  </ti:edition>
+</ti:work>

--- a/data/tlg0099/tlg004/tlg0099.tlg004.1st1K-grc1.xml
+++ b/data/tlg0099/tlg004/tlg0099.tlg004.1st1K-grc1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
     <teiHeader xml:lang="eng">
         <fileDesc>
@@ -9,7 +9,7 @@
             Geographia. Selections Chrestomathia
             </title>
                 <author>Strabo</author>
-            <editor xml:lang="lat">Carolus Müllerus</editor>
+            <editor>Karl Müller</editor>
             <funder>Harvard Library Arcadia Fund</funder>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -40,7 +40,7 @@
             <publicationStmt>
                 <authority>Harvard College Library</authority>
                 
-            <idno type="filename">tlg0099.tlg001.1st1K-grc1.xml</idno>
+            <idno type="filename">tlg0099.tlg004.1st1K-grc1.xml</idno>
 
                 <availability>
                     <licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available under a Creative Commons Attribution-ShareAlike 4.0 International
@@ -58,23 +58,18 @@
                             <title xml:lang="lat">Geographi Graeci Minores</title>
                             <editor>
                                 <persName>
-                                    <name xml:lang="lat">Carolus Müllerus</name>
-                                    <addName xml:lang="deu">Karl Müller</addName>
+                                    <name>Karl Müller</name>
                                 </persName>
                             </editor>
-                        <author ref="urn:cts:greekLit:tlg0099">Strabo</author>
-                  
-                            
+                        <author ref="urn:cts:greekLit:tlg0099">Strabo</author>                                              
                         <imprint>
                         <publisher>Ambroise-Firmin Didot</publisher>
                         <pubPlace>Paris</pubPlace>
                         <date>1861</date>
-                        </imprint>
-                        
-                        <biblScope unit="volume">2</biblScope>
-                        
+                        </imprint>                        
+                        <biblScope unit="volume">2</biblScope>                        
                         </monogr>
-                    <ref target="https://archive.org/details/bub_gb_63VfAAAAMAAJ">The Internet Archive</ref>
+                        <ref target="https://archive.org/details/bub_gb_63VfAAAAMAAJ/page/528/mode/2up">The Internet Archive</ref>
                     </biblStruct>
                 
                 </listBibl>
@@ -113,12 +108,13 @@
             </langUsage>
         </profileDesc>
         <revisionDesc>
+            <change who="Alison Babeu">Updated the work ID, edited metadata</change>
             <change who="Chiara Palladino">created the file</change>
         </revisionDesc>
     </teiHeader>
     <text>
         <body>
-        <div type="edition" xml:lang="grc" n="urn:cts:greekLit:tlg0099.tlg001.1st1K-grc1">
+        <div type="edition" xml:lang="grc" n="urn:cts:greekLit:tlg0099.tlg004.1st1K-grc1">
                 
                
 


### PR DESCRIPTION
Updated this work ID as the TLG has a separate work ID for the Chrestomathia and the catalog has other editions cataloged under tlg0099.tlg004.