### PR TITLE
Promote "Digital conversion and editing" in sort order

### DIFF
--- a/.scaife-viewer.yml
+++ b/.scaife-viewer.yml
@@ -5,6 +5,7 @@ attributions:
   - annotation
   - Corrected and encoded the text
   - CTS conversion
+  - Digital conversion and editing
   - Keyboarding
   - proofreader
   - Proofreading


### PR DESCRIPTION
See tweak order of credits -- put the principals at the bottom, move students up ([scaife-viewer/scaife-viewer#611](https://github.com/scaife-viewer/scaife-viewer/issues/611))