### PR TITLE
tlg2021.tlg2021.001_tlg2021.003

### DIFF
--- a/data/tlg2021/tlg001/__cts__.xml
+++ b/data/tlg2021/tlg001/__cts__.xml
@@ -1,7 +1,7 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg2021" xml:lang="grc" urn="urn:cts:greekLit:tlg2021.tlg001">
   <ti:title xml:lang="lat">Ancoratus</ti:title>
-  <ti:edition urn="urn:cts:greekLit:tlg2021.tlg001.opp-grc1" workUrn="urn:cts:greekLit:tlg2021.tlg001" xml:lang="grc">
+  <ti:edition urn="urn:cts:greekLit:tlg2021.tlg001.1st1K-grc1" workUrn="urn:cts:greekLit:tlg2021.tlg001" xml:lang="grc">
     <ti:label xml:lang="lat">Ancoratus</ti:label>
-    <ti:description xml:lang="mul">Epiphanius. Epiphanius,  Volume 1. Holl, Karl, editor. Leipzig: Hinrichs, 1915.</ti:description>
+    <ti:description xml:lang="mul">Epiphanius. Epiphanius, Volume 1. Holl, Karl, editor. Leipzig: Hinrichs, 1915.</ti:description>
   </ti:edition>
 </ti:work>

--- a/data/tlg2021/tlg001/tlg2021.tlg001.1st1K-grc1.xml
+++ b/data/tlg2021/tlg001/tlg2021.tlg001.1st1K-grc1.xml
@@ -51,7 +51,7 @@
       </titleStmt>
       <publicationStmt>
 <authority>University of Leipzig</authority>
-<idno type="filename">tlg2021.tlg001.opp-grc1.xml</idno>
+<idno type="filename">tlg2021.tlg001.1st1K-grc1.xml</idno>
 <availability>
  <licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available under a Creative Commons Attribution-ShareAlike 4.0 International
  License</licence>
@@ -64,7 +64,7 @@
 <listBibl>
  <biblStruct>
  <monogr>
-  <title xml:lang="deu">Epiphanius</title>
+  <title>Epiphanius</title>
   <title type="sub" xml:lang="deu">(Ancoratus und Panarion)</title>
   <editor>Karl Holl</editor>
   <author ref="urn:cts:greekLit:tlg2021">Epiphanius</author>
@@ -105,7 +105,7 @@
 </teiHeader>
   <text>
     <body>
-	    <div type="edition" n="urn:cts:greekLit:tlg2021.tlg001.opp-grc1" xml:lang="grc">
+	    <div type="edition" n="urn:cts:greekLit:tlg2021.tlg001.1st1K-grc1" xml:lang="grc">
 <pb n="1"/>
 <div type="textpart" subtype="chapter" n="pr_0">
    <div type="textpart" subtype="section" n="0">

--- a/data/tlg2021/tlg002/__cts__.xml
+++ b/data/tlg2021/tlg002/__cts__.xml
@@ -1,6 +1,6 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg2021" xml:lang="grc" urn="urn:cts:greekLit:tlg2021.tlg002">
   <ti:title xml:lang="lat">Panarion (Adversus Haereses)</ti:title>
-  <ti:edition urn="urn:cts:greekLit:tlg2021.tlg002.opp-grc1" workUrn="urn:cts:greekLit:tlg2021.tlg002" xml:lang="grc">
+  <ti:edition urn="urn:cts:greekLit:tlg2021.tlg002.1st1K-grc1" workUrn="urn:cts:greekLit:tlg2021.tlg002" xml:lang="grc">
     <ti:label xml:lang="lat">Panarion (Adversus Haereses)</ti:label>
     <ti:description xml:lang="mul">Epiphanius. Epiphanius, Volume 1-3. Holl, Karl, editor. Leipzig: Hinrichs, 1915-1933.</ti:description>
   </ti:edition>

--- a/data/tlg2021/tlg002/tlg2021.tlg002.1st1K-grc1.xml
+++ b/data/tlg2021/tlg002/tlg2021.tlg002.1st1K-grc1.xml
@@ -52,7 +52,7 @@
       </titleStmt>
       <publicationStmt>
 <authority>University of Leipzig</authority>
-<idno type="filename">tlg2021.tlg002.opp-grc1.xml</idno>
+<idno type="filename">tlg2021.tlg002.1st1K-grc1.xml</idno>
 <availability>
  <licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available under a Creative Commons Attribution-ShareAlike 4.0 International
  License</licence>
@@ -107,7 +107,7 @@
 </revisionDesc>
 </teiHeader>
   <text>
-    <body><div type="edition" n="urn:cts:greekLit:tlg2021.tlg002.opp-grc1" xml:lang="grc">
+    <body><div type="edition" n="urn:cts:greekLit:tlg2021.tlg002.1st1K-grc1" xml:lang="grc">
 
 <div type="textpart" subtype="haeresis" n="praef1a">
 <pb n="153"/>

--- a/data/tlg2021/tlg003/__cts__.xml
+++ b/data/tlg2021/tlg003/__cts__.xml
@@ -1,6 +1,6 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg2021" xml:lang="grc" urn="urn:cts:greekLit:tlg2021.tlg003">
   <ti:title xml:lang="lat">Anacephalaeosis [Sp.]</ti:title>
-  <ti:edition urn="urn:cts:greekLit:tlg2021.tlg003.opp-grc1" workUrn="urn:cts:greekLit:tlg2021.tlg003" xml:lang="grc">
+  <ti:edition urn="urn:cts:greekLit:tlg2021.tlg003.1st1K-grc1" workUrn="urn:cts:greekLit:tlg2021.tlg003" xml:lang="grc">
     <ti:label xml:lang="lat">Anacephalaeosis [Sp.]</ti:label>
     <ti:description xml:lang="mul">Epiphanius. Epiphanius, Volume 1‑3. Holl, Karl, editor. Leipzig: Hinrich, 1915-1933.</ti:description>
   </ti:edition>

--- a/data/tlg2021/tlg003/tlg2021.tlg003.1st1K-grc1.xml
+++ b/data/tlg2021/tlg003/tlg2021.tlg003.1st1K-grc1.xml
@@ -50,7 +50,7 @@
       </titleStmt>
       <publicationStmt>
 <authority>University of Leipzig</authority>
-<idno type="filename">tlg2021.tlg003.opp-grc1.xml</idno>
+<idno type="filename">tlg2021.tlg003.1st1K-grc1.xml</idno>
 <availability>
 <licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available under a Creative Commons Attribution-ShareAlike 4.0 International
 License</licence>
@@ -103,7 +103,7 @@ License</licence>
 </revisionDesc>
 </teiHeader>
   <text>
-    <body><div type="edition" n="urn:cts:greekLit:tlg2021.tlg003.opp-grc1" xml:lang="grc">
+    <body><div type="edition" n="urn:cts:greekLit:tlg2021.tlg003.1st1K-grc1" xml:lang="grc">
 
 <pb n="1"/>
 <p>Τάδε ἔνεστι καὶ ἐν τῷ τρίτῳ τόμῳ τοῦ πρώτου βιβλίου, ἐν ᾧ εἰσιν <note type="marginal">P229 D214 0424</note> 


### PR DESCRIPTION
Updated URNs to 1st1K to avoid conflict with catalog.