### PR TITLE
heb0001.heb010 updating cts_xml

### DIFF
--- a/data/heb0001/heb010/__cts__.xml
+++ b/data/heb0001/heb010/__cts__.xml
@@ -5,8 +5,8 @@
     <dct:hasVersion>urn:cts:greekLit:tlg0527.tlg048</dct:hasVersion>
     </cpt:structured-metadata>
   <ti:translation xml:lang= "eng" urn="urn:cts:hebrewlit:heb0001.heb010.1st1K-eng1" workUrn="urn:cts:hebrewlit:heb0001.heb010">
-    <ti:label xml:lang="lat">Isaias</ti:label>
-    <ti:description xml:lang="mul">Septuaginta. The Book of Isaiah According to the Septuagint (Codex Alexandrinus). Ottley, Richard, Rusden, editor. 
+    <ti:label xml:lang="lat">Isaiah (from the Hebrew)</ti:label>
+    <ti:description xml:lang="mul">The Book of Isaiah According to the Septuagint (Codex Alexandrinus). Ottley, Richard, Rusden, editor. 
       Cambridge: C.J. Clay and Sons, 1904.</ti:description>
   </ti:translation>
 </ti:work>

--- a/data/heb0001/heb010/__cts__.xml
+++ b/data/heb0001/heb010/__cts__.xml
@@ -6,6 +6,7 @@
     </cpt:structured-metadata>
   <ti:translation xml:lang= "eng" urn="urn:cts:hebrewlit:heb0001.heb010.1st1K-eng1" workUrn="urn:cts:hebrewlit:heb0001.heb010">
     <ti:label xml:lang="lat">Isaias</ti:label>
-    <ti:description xml:lang="mul">Hebrew Bible, Isaias, Ottley, Cambridge, 1904</ti:description>
+    <ti:description xml:lang="mul">Septuaginta. The Book of Isaiah According to the Septuagint (Codex Alexandrinus). Ottley, Richard, Rusden, editor. 
+      Cambridge: C.J. Clay and Sons, 1904.</ti:description>
   </ti:translation>
 </ti:work>

--- a/data/heb0001/heb010/heb0001.heb010.1st1K-eng1.xml
+++ b/data/heb0001/heb010/heb0001.heb010.1st1K-eng1.xml
@@ -3,7 +3,7 @@
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader xml:lang="eng">    
     <fileDesc>
-<titleStmt><title xml:lang="lat">Isaias</title>
+<titleStmt><title>Isaiah</title>
 <editor>Richard Rusden Ottley</editor>
 <sponsor>University of Leipzig</sponsor>
 <funder>European Social Fund Saxony</funder>

--- a/data/heb0001/heb010/heb0001.heb010.1st1K-eng1.xml
+++ b/data/heb0001/heb010/heb0001.heb010.1st1K-eng1.xml
@@ -77,7 +77,7 @@ License</licence>
 </imprint>
   <biblScope unit="volume">1</biblScope>
 </monogr>
-  <ref target="https://archive.org/details/IsaiahAccordingToTheSeptuagint">The Internet Archive</ref>
+  <ref target="https://archive.org/details/IsaiahAccordingToTheSeptuagint/page/n71/mode/2up">The Internet Archive</ref>
 </biblStruct>
 </listBibl>
 </sourceDesc>

--- a/data/tlg0527/tlg048/tlg0527.tlg048.opp-eng2.xml
+++ b/data/tlg0527/tlg048/tlg0527.tlg048.opp-eng2.xml
@@ -78,7 +78,7 @@ License</licence>
 </imprint>
 <biblScope unit="volume">1</biblScope>
 </monogr>
-  <ref target="https://archive.org/details/IsaiahAccordingToTheSeptuagint">The Internet Archive</ref>
+  <ref target="https://archive.org/details/IsaiahAccordingToTheSeptuagint/page/n71/mode/2up">The Internet Archive</ref>
 </biblStruct>
 </listBibl>
 </sourceDesc>


### PR DESCRIPTION
Updated the CTS_XML file for this translation of Isaias to agree with other works taken from the same printed edition.

I am also contemplating why this record was created with the ID heb0001.heb010 when the English translation of this work from the Greek (in the same book) was given the ID tlg0527.tlg048.opp-eng2. There is some discussion here (https://github.com/OpenGreekAndLatin/First1KGreek/pull/1409).  I'm wondering if they wanted to specify this work had been translated from the Hebrew rather than the Greek, but then of course, this URN means it doesn't align with any of the other versions or translations of Isaias. Thoughts @lcerrato? @gregorycrane ?

