### PR TITLE
Mark Hultsch excursus chapter as xml:lang="deu"

### DIFF
--- a/data/tlg4036/tlg001/tlg4036.tlg001.opp-grc1.xml
+++ b/data/tlg4036/tlg001/tlg4036.tlg001.opp-grc1.xml
@@ -23737,7 +23737,7 @@ vel μεταξύ sententiae apta 18 add. Sch. 19 φιλόσοφον</note>
 <note type="footnote">1 ante κατ' sex septemve litterae legi nequeunt</note>
 </div>
  
-<div type="textpart" subtype="chapter" n="14">
+<div type="textpart" subtype="chapter" xml:lang="deu" n="14">
 <pb n="384"/>
 <head>Drei Exkurse von F. Hultscli.</head>
 <p>I.</p>


### PR DESCRIPTION
Chapter 14 is F. Hultsch's German editorial excursuses, not source Greek. Mark it as German rather than Greek. The prose is German throughout with occasional Greek lines quoted from the source interspersed.